### PR TITLE
Fix for empty document issue

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -399,7 +399,7 @@ var VirtualRenderer = function(container, theme) {
 
         var lineCount = Math.ceil(minHeight / this.lineHeight);
         var firstRow = Math.max(0, Math.round((this.scrollTop - offset) / this.lineHeight));
-        var lastRow = Math.min(this.lines.length, firstRow + lineCount) - 1;
+        var lastRow = Math.max(0, Math.min(this.lines.length, firstRow + lineCount) - 1);
 
         var layerConfig = this.layerConfig = {
             width : longestLine,


### PR DESCRIPTION
As per my bug report, empty documents cause a rendering bug. This turns out to be because config.lastRow is -1, whereas it should be 0 for an empty document. The negative value causes the line to not be created inside of text.js until another line is added to the document.
Another possible fix would be for lines.length to be 1 for an empty document, i.e for the constructor of Document to start with lines = [""] instead of an empty array. That could have effects elsewhere in the program though.
