### PR TITLE
fix event.capture

### DIFF
--- a/plugins/pilot/event.js
+++ b/plugins/pilot/event.js
@@ -151,14 +151,14 @@ else {
             eventHandler && eventHandler(e);
             releaseCaptureHandler && releaseCaptureHandler();
 
-            el.removeEventListener("mousemove", onMouseMove, true);
-            el.removeEventListener("mouseup", onMouseUp, true);
+            document.removeEventListener("mousemove", onMouseMove, true);
+            document.removeEventListener("mouseup", onMouseUp, true);
 
             e.stopPropagation();
         }
 
-        el.addEventListener("mousemove", onMouseMove, true);
-        el.addEventListener("mouseup", onMouseUp, true);
+        document.addEventListener("mousemove", onMouseMove, true);
+        document.addEventListener("mouseup", onMouseUp, true);
     };
 }
 


### PR DESCRIPTION
event.capture for old browsers is broken
it should add listener to document instead of element
