### PR TITLE
with marker.type=="text" it's impossible to tell wether empty line is selected or not

### DIFF
--- a/lib/ace/layer/marker.js
+++ b/lib/ace/layer/marker.js
@@ -105,7 +105,7 @@ var Marker = function(parentEl) {
         // selection start
         var row = range.start.row;
         var lineRange = new Range(row, range.start.column, row, this.doc.getLine(row).length);
-        this.drawSingleLineMarker(stringBuilder, lineRange, clazz, layerConfig);
+        this.drawSingleLineMarker(stringBuilder, lineRange, clazz, layerConfig, 1);
 
         // selection end
         var row = range.end.row;
@@ -115,8 +115,8 @@ var Marker = function(parentEl) {
         for (var row = range.start.row + 1; row < range.end.row; row++) {
             lineRange.start.row = row;
             lineRange.end.row = row;
-            lineRange.end.column = this.doc.getLine(row).length;
-            this.drawSingleLineMarker(stringBuilder, lineRange, clazz, layerConfig);
+            lineRange.end.column = this.doc.getLine(row).length; // account for endofline characters
+            this.drawSingleLineMarker(stringBuilder, lineRange, clazz, layerConfig, 1);
         }
     };
 
@@ -162,11 +162,11 @@ var Marker = function(parentEl) {
         );
     };
 
-    this.drawSingleLineMarker = function(stringBuilder, range, clazz, layerConfig) {
+    this.drawSingleLineMarker = function(stringBuilder, range, clazz, layerConfig, extraLength) {
         var range = range.toScreenRange(this.doc);
 
         var height = layerConfig.lineHeight;
-        var width = Math.round((range.end.column - range.start.column) * layerConfig.characterWidth);
+        var width = Math.round((range.end.column + (extraLength || 0) - range.start.column) * layerConfig.characterWidth);
         var top = (range.start.row - layerConfig.firstRow) * layerConfig.lineHeight;
         var left = Math.round(range.start.column * layerConfig.characterWidth);
 


### PR DESCRIPTION
other editors are making marker to be one character longer, to account for '\n'
