### PR TITLE
Implementation of textmate like margin

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -32,13 +32,23 @@
   left: 0px;
 }
 
+.ace_editor .ace_print_margin_layer {
+  z-index: 0;
+  position: absolute;
+  overflow: hidden;
+  margin: 0px;
+  left: 0px;
+  height: 100%;
+  width: 100%;
+}
+
 .ace_editor .ace_print_margin {
   position: absolute;
   height: 100%;
 }
 
 .ace_layer {
-  z-index: 0;
+  z-index: 1;
   position: absolute;
   overflow: hidden;  
   white-space: nowrap;
@@ -56,7 +66,7 @@
 }
 
 .ace_cursor {
-  z-index: 3;
+  z-index: 4;
   position: absolute;
 }
 
@@ -69,20 +79,20 @@
 
 .ace_marker-layer .ace_step {
   position: absolute;
-  z-index: 2;
+  z-index: 3;
 }
 
 .ace_marker-layer .ace_selection {
   position: absolute;
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_marker-layer .ace_bracket {
   position: absolute;
-  z-index: 4;
+  z-index: 5;
 }
 
 .ace_marker-layer .ace_active_line {
   position: absolute;
-  z-index: 1;
+  z-index: 2;
 }

--- a/lib/ace/theme/twilight.js
+++ b/lib/ace/theme/twilight.js
@@ -64,8 +64,9 @@ define(function(require, exports, module) {
 }\
 \
 .ace-twilight .ace_print_margin {\
-  width: 1px;\
-  background: #e8e8e8;\
+  border-left: 1px solid #3C3C3C;\
+  width: 100%;\
+  background: #242424;\
 }\
 \
 .ace-twilight .ace_scroller {\

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -20,6 +20,7 @@
  *
  * Contributor(s):
  *      Fabian Jakobs <fabian AT ajax DOT org>
+ *      Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
  *
  * Alternatively, the contents of this file may be used under the terms of
  * either the GNU General Public License Version 2 or later (the "GPL"), or
@@ -265,13 +266,17 @@ var VirtualRenderer = function(container, theme) {
     }
 
     this.$updatePrintMargin = function() {
+        var containerEl
+
         if (!this.$showPrintMargin && !this.$printMarginEl)
             return;
-
         if (!this.$printMarginEl) {
-            this.$printMarginEl = document.createElement("div");
-            this.content.insertBefore(this.$printMarginEl, this.$textLayer.element);
+            containerEl = document.createElement("div");
+            containerEl.className = "ace_print_margin_layer";
+            this.$printMarginEl = document.createElement("div")
             this.$printMarginEl.className = "ace_print_margin";
+            containerEl.appendChild(this.$printMarginEl);
+            this.content.insertBefore(containerEl, this.$textLayer.element);
         }
 
         var style = this.$printMarginEl.style;


### PR DESCRIPTION
In textmate you can have two options for print margin:
- Show right margin indicator (print margin line)
- Highlight right margin (darker background no the right side of the margin)

This change adds ability to have such a styling, also twilight theme is extended to show that feature.
