### PR TITLE
IE8 fixes

### DIFF
--- a/lib/ace/layer/text.js
+++ b/lib/ace/layer/text.js
@@ -227,7 +227,8 @@ var Text = function(parentEl) {
             style.width = config.width + "px";
 
             var html = [];
-            this.$renderLine(html, row, tokens[row-firstRow].tokens);
+            if (tokens.length > row-firstRow)
+            	this.$renderLine(html, row, tokens[row-firstRow].tokens);
             // don't use setInnerHtml since we are working with an empty DIV
             lineEl.innerHTML = html.join("");
             fragment.appendChild(lineEl);

--- a/lib/ace/tokenizer.js
+++ b/lib/ace/tokenizer.js
@@ -79,7 +79,7 @@ var Tokenizer = function(rules) {
             }
 
             for ( var i = 0; i < state.length; i++) {
-                if (match[i + 1] !== undefined) {
+                if (match[i + 1] !== undefined && match[i + 1].length) {
                     if (typeof state[i].token == "function") {
                         type = state[i].token(match[0]);
                     }


### PR DESCRIPTION
Noticed two issues with IE8:
- Fix error that happens on load: 'tokens' is null or not an object
- Syntax highlighting didn't actually work due to IE8 match semantics being different (empty string, not undefined, returned unmatched capturing groups)

I have no idea whether the fix to text.js is the appropriate fix but it "Worked For Me".
