### PR TITLE
Fix for screenToTextCoordinates

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -609,7 +609,7 @@ var VirtualRenderer = function(container, theme) {
 
         var col = Math.round((pageX + this.scroller.scrollLeft - canvasPos.left - this.$padding)
                 / this.characterWidth);
-        var row = Math.floor((pageY + this.scrollTop - canvasPos.top)
+        var row = Math.floor((pageY + this.scrollTop - canvasPos.top - window.pageYOffset)
                 / this.lineHeight);
 
         return this.session.screenToDocumentPosition(row, Math.max(col, 0));


### PR DESCRIPTION
Should fix this ticket:

https://github.com/ajaxorg/ace/issues/issue/102

Tested in Chrome 10.0.648.45, Safari 5.0.3, Firefox 3.6.12.  

I wasn't able to get the unit tests running. :/
