### PR TITLE
Fix typing (or pasting) at the end of the longest line

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -84,6 +84,7 @@ var VirtualRenderer = function(container, theme) {
     this.lineHeight = textLayer.getLineHeight();
 
     this.$cursorLayer = new CursorLayer(this.content);
+    this.$cursorPadding = 8;
 
     this.layers = [ this.$markerLayer, textLayer, this.$cursorLayer ];
 
@@ -424,7 +425,8 @@ var VirtualRenderer = function(container, theme) {
         var offset = this.scrollTop % this.lineHeight;
         var minHeight = this.$size.scrollerHeight + this.lineHeight;
 
-        var longestLine = this.$getLongestLine();
+        // Add some space for the cursor itself plus some cursor padding
+        var longestLine = this.$getLongestLine() + this.$cursorPadding + 3;
         var widthChanged = !this.layerConfig ? true : (this.layerConfig.width != longestLine);
 
         var lineCount = Math.ceil(minHeight / this.lineHeight) - 1;
@@ -560,8 +562,12 @@ var VirtualRenderer = function(container, theme) {
         }
 
         if (this.scroller.scrollLeft + this.$size.scrollerWidth < left
-                + this.characterWidth) {
-            this.scrollToX(Math.round(left + this.characterWidth
+                + this.characterWidth + this.$cursorPadding) {
+
+            if (left + this.characterWidth + this.$cursorPadding > this.scroller.scrollWidth)
+                this.$renderChanges(this.CHANGE_SIZE);
+
+            this.scrollToX(Math.round(left + this.characterWidth + this.$cursorPadding
                     - this.$size.scrollerWidth));
         }
     },


### PR DESCRIPTION
To repro the bug: With word wrap turned off, start typing a very long line. When the line's width starts exceeding the width of the content area, you'll notice that you can't see the last character or the cursor anymore.

This seems to be because the editor tries to scroll to the cursor before the renderLoop has had a chance to make the line wide enough to contain the new cursor.

To fix the problem I added detection for this situation and synchronously call $renderChanges(CHANGE_SCROLL) to force the update, then scroll to the cursor.
