### PR TITLE
Fix failing unit test by implementing MockRenderer#scrollToLine

### DIFF
--- a/lib/ace/test/mockrenderer.js
+++ b/lib/ace/test/mockrenderer.js
@@ -94,7 +94,17 @@ MockRenderer.prototype.updateCursor = function(position) {
     this.cursor.column = position.column;
 };
 
-MockRenderer.prototype.scrollToLine = function(row) {
+MockRenderer.prototype.scrollToLine = function(line, center) {
+    var lineHeight = { lineHeight: 16 };
+    var row = 0;
+    for (var l = 1; l < line; l++) {
+        row += this.session.getRowHeight(lineHeight, l-1) / lineHeight.lineHeight;
+    }
+
+    if (center) {
+        row -= this.visibleRowCount / 2;
+    }
+    this.scrollToRow(row);
 };
 
 MockRenderer.prototype.scrollCursorIntoView = function() {


### PR DESCRIPTION
This fixes the broken test from my previous patch. I tried to append this to the previous pull request but couldn't figure out how to, sorry.

The doesn't test the actual scrollToLine method at all, but works to mock the code calling it. Would you like some tests of the actual scrollToLine method as well?
