### PR TITLE
Cursor should be I-beam, not pointer

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -122,6 +122,7 @@
 }
 
 .ace_marker-layer {
+    cursor: text;
 }
 
 .ace_marker-layer .ace_step {


### PR DESCRIPTION
Recently the cursor started being the pointer, not I-beam, I believe due to the addition of the marker layer in front of the text.
