### PR TITLE
Node static server

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "asyncjs": ">=0.0.2",
         "jsdom": ">=0.1.23",
         "htmlparser": ">=1.7.2",
-        "dryice": ">=0.2.2"
+        "dryice": ">=0.2.2",
+        "mime": ">=1.2.1"
     },
     "licenses": [{
         "type": "MPL",

--- a/static.js
+++ b/static.js
@@ -3,23 +3,9 @@
 var http = require("http"),
     url = require("url"),
     path = require("path"),
-    fs = require("fs")
+    fs = require("fs"),
+    mime = require("mime"),
     port = process.env.C9_PORT || 8888;
-
-function guessFileType(name) {
-  var types = {
-    '.html': 'text/html',
-    '.xhtml': 'application/xhtml+xml',
-    '.js': 'text/javascript',
-    '.css': 'text/css',
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-  };
-
-  var ext = path.extname(name);
-
-  return ext in types ? types[ext] : 'text/plain';
-}
 
 http.createServer(function(request, response) {
 
@@ -44,7 +30,8 @@ http.createServer(function(request, response) {
         return;
       }
 
-      response.writeHead(200, {"Content-Type": guessFileType(filename)});
+      var contentType = mime.lookup(filename) || "text/plain";
+      response.writeHead(200, {"Content-Type": contentType});
       response.write(file, "binary");
       response.end();
     });


### PR DESCRIPTION
I don't want to depend on Python to run Ace. Since we already use NodeJS, we should have static.js. The initial implementation is almost fine - it only lacked proper Content-Type headers. With this patch I can use static.js instead of static.py.
