### PR TITLE
Exception when setting value with leading blank line (i.e. setValue("\nfoo") )

### DIFF
--- a/lib/ace/document.js
+++ b/lib/ace/document.js
@@ -187,6 +187,13 @@ var Document = function(text) {
                 var end = this.insertInLine(position, newLines[0]);
                 this.insertNewLine(end);
             }
+            else if (position.row >= this.getLength()) {
+                // Edge case: inserting text that starts with a blank line
+                // into an empty document. If we don't do this, this.$lines[0]
+                // will be undefined and give us problems later.
+                this.insertNewLine(position);
+            }
+
             // If we are inserting at the end of the document, we don't need to
             // use insertInLine (concorde depends on this optimization!)
             if (position.row + 1 == this.getLength()) {


### PR DESCRIPTION
We pushed ace to production for the first time today and this bug immediately took down a bunch of our users :(
