### PR TITLE
Safari 4 vertical scrollbar does not appear

### DIFF
--- a/lib/ace/scrollbar.js
+++ b/lib/ace/scrollbar.js
@@ -52,7 +52,7 @@ var ScrollBar = function(parent) {
     parent.appendChild(this.element);
 
     this.width = dom.scrollbarWidth();
-    this.element.style.width = this.width;
+    this.element.style.width = this.width + "px";
 
     event.addListener(this.element, "scroll", this.onScroll.bind(this));
 };


### PR DESCRIPTION
Safari 4 seems to ignore the width if it doesn't have units.
