### PR TITLE
HTML/CSS Syntax Highlighting for PHP

### DIFF
--- a/lib/ace/mode/php_highlight_rules.js
+++ b/lib/ace/mode/php_highlight_rules.js
@@ -461,12 +461,31 @@ var PhpHighlightRules = function() {
     this.$rules = {
         "start" : [
             {
-                token : "support", // php open tag
+                token : "support.php_tag", // php open tag
                 regex : "<\\?(?:php|\\=)"
             },
             {
-                token : "support", // php close tag
+                token : "support.php_tag", // php close tag
                 regex : "\\?>"
+            },
+            {
+            	token : "comment",
+        		regex : "<\\!--",
+        		next : "htmlcomment"
+            }, 
+		    {
+		        token : "html_tag",
+		        regex : "<style",
+		        next : "css"
+		    },
+		    {
+		        token : "html_tag", // opening tag
+		        regex : "<\\/?[-_a-zA-Z0-9:]+",
+		        next : "htmltag"
+		    },
+            {
+            	token : 'html_tag.html_doctype',
+            	regex : '<\!DOCTYPE.*?>'
             },
             {
                 token : "comment",
@@ -594,7 +613,96 @@ var PhpHighlightRules = function() {
                 token : "string",
                 regex : '.+'
             }
-        ]
+        ],
+        "htmlcomment" : [
+             {
+             	token : "comment",
+             	regex : ".*?-->",
+             	next : "start"
+         	}, {
+         		token : "comment",
+         		regex : ".+"
+         	} 
+         ],
+         "htmltag" : [ 
+             {
+ 	            token : "html_tag_closing",
+ 	            regex : ">",
+ 	            next : "start"
+ 	        }, {
+ 	            token : "html_attribute",
+ 	            regex : "[-_a-zA-Z0-9:]+"
+ 	        }, {
+ 	            token : "text",
+ 	            regex : "\\s+"
+ 	        }, {
+ 	            token : "html_attribute_value",
+ 	            regex : '".*?"'
+ 	        }, {
+ 	            token : "html_attribute_value",
+ 	            regex : "'.*?'"
+ 	        } 
+ 	    ],
+        "css" : [ 
+             {
+ 	            token : "html_tag",
+ 	            regex : "<\/style>",
+ 	            next : "htmltag"
+ 	        }, {
+ 	            token : "html_tag_closing",
+ 	            regex : ">",
+ 		    }, {
+ 	        	token : 'html_attribute',
+ 	        	regex : "(?:media|type|href)"
+ 	        }, {
+ 	        	token : 'html_attribute_value',
+ 	        	regex : '=".*?"'
+ 	        }, {
+ 	            token : "css_declaration",
+ 	            regex : "\{",
+ 	            next : "cssdeclaration",
+ 	        }, {
+ 	        	token : "css_declaration_id",
+ 	        	regex : "#[A-Za-z0-9\-\_\.]+"
+ 	        }, {
+ 	        	token : "css_declaration_class",
+ 	        	regex : "\\.[A-Za-z0-9\-\_\.]+"
+ 	        }, {
+ 	        	token : "css_declaration_tag",
+ 	        	regex : "[A-Za-z0-9]+"
+ 	        }
+ 	    ],
+ 	    "cssdeclaration" : [
+ 	        {
+ 	        	token : "css_property",
+ 	        	regex : "[\-a-zA-Z]+",
+ 	        	next  : "cssvalue"
+ 	        }, 
+ 	        {
+ 	        	token : "css_declaration",
+ 	        	regex : '\}',
+ 	        	next : "css"
+ 	        }
+ 	    ],
+ 	    "cssvalue" : [
+   	        {
+   	        	token : "css_colon.css_text",
+   	        	regex : "\:"
+   	        }, 
+   	        {
+   	        	token : "css_value.css_color",
+   	        	regex : "#[0-9a-zA-Z]+"
+   	        },
+   	        {
+   	        	token : "css_value",
+   	        	regex : "[\-\_0-9a-zA-Z\"' ,%]+"
+   	        },
+   	        {
+   	        	token : "css_semicolon.css_text",
+   	        	regex : ";",
+   	        	next : "cssdeclaration"
+   	        }
+ 	    ],
     };
 
     this.addRules(docComment.getRules(), "doc-");


### PR DESCRIPTION
I know it doesn't conform to your standards, I wanted more control over my syntax coloring rules, but it's easy enough to adjust the class names. I saw some people asking for this, so I figured I should commit it :)
@gissues:{"order":88.19875776397521,"status":"backlog"}
