### PR TITLE
build_support versions of define are broken

### DIFF
--- a/build_support/mini_require.js
+++ b/build_support/mini_require.js
@@ -59,6 +59,9 @@ var _define = function(module, deps, payload) {
         return;
     }
 
+    if (arguments.length == 2)
+        payload = deps;
+
     if (!define.modules)
         define.modules = {};
         

--- a/build_support/mini_require_textarea.js
+++ b/build_support/mini_require_textarea.js
@@ -55,6 +55,9 @@ var _define = function(module, deps, payload) {
         return;
     }
 
+    if (arguments.length == 2)
+        payload = deps;
+
     if (!_define.modules)
         _define.modules = {};
 


### PR DESCRIPTION
Looks like the versions of define in build_support were recently changed to take a "deps" argument but the logic was left off to make deps optional. This causes the built versions of ace.js and ace-uncompressed.js to break.
