### PR TITLE
Fixing `editor.setOverwrite` 

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -487,7 +487,7 @@ var Editor =function(renderer, session) {
     };
 
     this.setOverwrite = function(overwrite) {
-        this.session.setOverwrite();        
+        this.session.setOverwrite(overwrite);
     };
 
     this.getOverwrite = function() {


### PR DESCRIPTION
Fix for https://github.com/ajaxorg/ace/issues#issue/204
