### PR TITLE
Fix performance regression on large documents

### DIFF
--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -1275,7 +1275,11 @@ var EditSession = function(text, mode) {
         return screenRows;
     }
     
+    // For every keystroke this gets called once per char in the whole doc!!
+    // Wouldn't hurt to make it a bit faster for c >= 0x1100
     function isFullWidth(c) {
+        if (c < 0x1100)
+            return false;
         return c >= 0x1100 && c <= 0x115F ||
                c >= 0x11A3 && c <= 0x11A7 ||
                c >= 0x11FA && c <= 0x11FF ||


### PR DESCRIPTION
My commit 21a79f on 3/23/2011 resulted in a significant increase in keystroke latency on large documents. This patch should speed things back up for docs that mainly do not contain full-width (Asian) characters.
