### PR TITLE
Fix workers that require a module returning a value

### DIFF
--- a/lib/ace/worker/worker.js
+++ b/lib/ace/worker/worker.js
@@ -48,7 +48,7 @@ var define = function(id, deps, factory) {
             };
             var returnExports = factory(require, module.exports, module);
             if (returnExports)
-                module.exports = exports;
+                module.exports = returnExports;
             return module;
         }
     };


### PR DESCRIPTION
This change is independent of my pull request, so sending separately.
