### PR TITLE
OldGecko Ampersand Fix

### DIFF
--- a/lib/ace/layer/text.js
+++ b/lib/ace/layer/text.js
@@ -43,6 +43,7 @@ define(function(require, exports, module) {
 var oop = require("pilot/oop");
 var dom = require("pilot/dom");
 var lang = require("pilot/lang");
+var useragent = require("pilot/useragent");
 var EventEmitter = require("pilot/event_emitter").EventEmitter;
 
 var Text = function(parentEl) {
@@ -311,6 +312,9 @@ var Text = function(parentEl) {
                 screenColumn += tabSize - 1;
                 return self.$tabStrings[tabSize];
             } else if (c == "&") {
+              if (useragent.isOldGecko)
+                return "&";
+              else
                 return "&amp";
             } else if (c == "<") {
                 return "&lt;";


### PR DESCRIPTION
On Firefox < 4 there is an issue in all of the syntax modes I have tested where typing "&" followed by any other character causes the "&" to expand out to "&amp". In some modes it only happens when finishing a quoted string, but it happens in any context of an html mode document.

The only solution I have found it to disable the & replacement that happens in lib/ace/layer/text.js, which is the only change in this pull request.
