### PR TITLE
Allow empty line to be a matching state.

### DIFF
--- a/lib/ace/tokenizer.js
+++ b/lib/ace/tokenizer.js
@@ -76,7 +76,7 @@ var Tokenizer = function(rules) {
             var value = match[0];
 
             for ( var i = 0; i < state.length; i++) {
-                if (match[i + 1]) {
+                if (match[i + 1] !== undefined) {
                     var rule = state[i];
                     
                     if (typeof rule.token == "function")


### PR DESCRIPTION
Due to type coercion, empty lines can't count as real states in the current tokeniser. This is required for some tokenisation (specifically I am working on a Markdown mode for my project, which requires some blocks to be delimited by blank lines).

I realise this may break some current tokeniser implementations if they rely on matching nothing to not really count as a match.

I have not signed a CLA (and have no access to a printer as of the moment) but can fill one out soon, though this is a trivial change.
