### PR TITLE
Set DEBUG to false in state_handler.js again

### DIFF
--- a/lib/ace/keyboard/state_handler.js
+++ b/lib/ace/keyboard/state_handler.js
@@ -39,7 +39,7 @@ define(function(require, exports, module) {
 
 // If you're developing a new keymapping and want to get an idea what's going
 // on, then enable debugging.
-var DEBUG = true;
+var DEBUG = false;
 
 function StateHandler(keymapping) {
     this.keymapping = this.$buildKeymappingRegex(keymapping);


### PR DESCRIPTION
Really sorry to have included this in the former patch :( This patch turns the debugging off again. It doesn't hurt to keep it on, but it spams your console which shouldn't be by default.
