### PR TITLE
Small change to let Ace work with useWrapMode = true in Cloud9

### DIFF
--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -1088,8 +1088,8 @@ var EditSession = function(text, mode) {
             }
         }
 
-        if (useWrapMode && this.$wrapData.length != this.doc.$lines.length) {
-            console.error("The length of doc.$lines and $wrapData have to be the same!");
+        if (useWrapMode && this.$wrapData.length != this.doc.getLength()) {
+            console.error("doc.getLength() and $wrapData.length have to be the same!");
         }
 
         useWrapMode && this.$updateWrapData(firstRow, lastRow);


### PR DESCRIPTION
I was playing around trying to get line wrapping to work in Cloud9 (I see that the functionality is mostly there but commented out) and I needed to make this change to Ace for it to work. This is because the ProxyDocument wrapper used by Cloud9 doesn't have the $lenth property like a regular Document.

There also seems to be an issue with maintaining the useWrapMode setting on the EditSession since the APF codeeditor element creates a new session when the 'value' property is changed. I guess that is an issue to be brought up elsewhere though, but I'd like to get it working properly if I can.
