### PR TITLE
when unfocused make cursor transparent instead of removing it

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -117,6 +117,10 @@
     position: absolute;
 }
 
+.ace_cursor.ace_hidden {
+    opacity: 0.2;
+}
+
 .ace_line {
     white-space: nowrap;
 }

--- a/lib/ace/layer/cursor.js
+++ b/lib/ace/layer/cursor.js
@@ -47,7 +47,8 @@ var Cursor = function(parentEl) {
     parentEl.appendChild(this.element);
 
     this.cursor = dom.createElement("div");
-    this.cursor.className = "ace_cursor";
+    this.cursor.className = "ace_cursor ace_hidden";
+    this.element.appendChild(this.cursor);
 
     this.isVisible = false;
 };
@@ -60,18 +61,14 @@ var Cursor = function(parentEl) {
 
     this.hideCursor = function() {
         this.isVisible = false;
-        if (this.cursor.parentNode) {
-            this.cursor.parentNode.removeChild(this.cursor);
-        }
+        dom.addCssClass(this.cursor, "ace_hidden");
         clearInterval(this.blinkId);
     };
 
     this.showCursor = function() {
-        this.isVisible = true;
-        this.element.appendChild(this.cursor);
-
-        var cursor = this.cursor;
-        cursor.style.visibility = "visible";
+        this.isVisible = true;   
+        dom.removeCssClass(this.cursor, "ace_hidden");
+        this.cursor.style.visibility = "visible";
         this.restartTimer();
     };
 


### PR DESCRIPTION
hiding cursor completely when unfocused isn't very good, since sometimes one needs to know where the cursor was
allowing to style cursor with css is better
