### PR TITLE
fix comment typos

### DIFF
--- a/lib/ace/keyboard/state_handler.js
+++ b/lib/ace/keyboard/state_handler.js
@@ -140,11 +140,11 @@ StateHandler.prototype = {
             }
 
             // If there is a command to execute, then figure out the
-            // comand and the arguments.
+            // command and the arguments.
             if (binding.exec) {
                 result.command = binding.exec;
 
-                // Bulid the arguments.
+                // Build the arguments.
                 if (binding.params) {
                     var value;
                     result.args = {};


### PR DESCRIPTION
Fixed a couple of typos I found in comments as I was meandering through the source
