### PR TITLE
On a Mac, Ctrl+K at line's end removes the \n

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -696,7 +696,13 @@ var Editor =function(renderer, session) {
         if (this.selection.isEmpty())
             this.selection.selectLineEnd();
 
-        this.session.remove(this.getSelectionRange());
+        var range = this.getSelectionRange();
+        if (range.start.column == range.end.column && range.start.row == range.end.row) {
+            range.end.column = 0;
+            range.end.row++;
+        }
+
+        this.session.remove(range);
         this.clearSelection();
     };
 


### PR DESCRIPTION
This should make Ctrl+K act more like the native one.
