### PR TITLE
some more vim keybindings

### DIFF
--- a/lib/ace/keyboard/keybinding/vim.js
+++ b/lib/ace/keyboard/keybinding/vim.js
@@ -47,8 +47,23 @@ var vimStates = {
             then:   "insertMode"
         },
         {
-            key:    "o",
+            key:    "a",
             exec:   "gotoright",
+            then:   "insertMode"
+        },
+        {
+            key:    "shift-i",
+            exec:   "gotolinestart",
+            then:   "insertMode"
+        },
+        {
+            key:    "shift-a",
+            exec:   "gotolineend",
+            then:   "insertMode"
+        },
+        {
+            key:    "shift-c",
+            exec:   "removetolineend",
             then:   "insertMode"
         },
         {
@@ -103,6 +118,38 @@ var vimStates = {
                     defaultValue:     1
                 }
             ]
+        },
+        {
+            key:    "shift-g",
+            exec:   "gotoend"
+        },
+        {
+            key:    "b",
+            exec:   "gotowordleft"
+        },
+        {
+            key:    "w",
+            exec:   "gotowordright"
+        },
+        {
+            key:    "shift-6", // ^
+            exec:   "gotolinestart"
+        },
+        {
+            key:    "shift-4", // $
+            exec:   "gotolineend"
+        },
+        {
+            key:    "x",
+            exec:   "del"
+        },
+        {
+            key:    "shift-x",
+            exec:   "backspace"
+        },
+        {
+            key:    "shift-d",
+            exec:   "removetolineend"
         },
         {
             comment:    "Catch some keyboard input to stop it here",


### PR DESCRIPTION
It looks like these are all the keybindings that _just work_ by executing something already defined in default_commands.js.

Next up: block cursor for vim command mode and more commands...
