### PR TITLE
vim I,A,C,G,b,e,x,X,D commands

### DIFF
--- a/lib/ace/keyboard/keybinding/vim.js
+++ b/lib/ace/keyboard/keybinding/vim.js
@@ -47,8 +47,23 @@ var vimStates = {
             then:   "insertMode"
         },
         {
-            key:    "o",
+            key:    "a",
             exec:   "gotoright",
+            then:   "insertMode"
+        },
+        {
+            key:    "shift-i",
+            exec:   "gotolinestart",
+            then:   "insertMode"
+        },
+        {
+            key:    "shift-a",
+            exec:   "gotolineend",
+            then:   "insertMode"
+        },
+        {
+            key:    "shift-c",
+            exec:   "removetolineend",
             then:   "insertMode"
         },
         {
@@ -103,6 +118,30 @@ var vimStates = {
                     defaultValue:     1
                 }
             ]
+        },
+        {
+            key:    "shift-g",
+            exec:   "gotoend"
+        },
+        {
+            key:    "b",
+            exec:   "gotowordleft"
+        },
+        {
+            key:    "e",
+            exec:   "gotowordright"
+        },
+        {
+            key:    "x",
+            exec:   "del"
+        },
+        {
+            key:    "shift-x",
+            exec:   "backspace"
+        },
+        {
+            key:    "shift-d",
+            exec:   "removetolineend"
         },
         {
             comment:    "Catch some keyboard input to stop it here",


### PR DESCRIPTION
@fjakobs I took out the two commands from the previous pull that are specific to US-keyboards.  Since we'd have to bind to the characters "$" and "^" rather than to the key combinations "shift-4" and "shift-6" we'd have to get the charCode from the broswer in some reliable way, which may take some changes to the way events are passed to the keybindings.

Anyways, all these commands are keyboard-layout-agnostic.  Thanks!
