### PR TITLE
SCAD syntax highlighting

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -201,7 +201,7 @@ console.log('# ace modes ---------');
 project.assumeAllFilesLoaded();
 [
     "css", "html", "javascript", "php", "python", "xml", "ruby", "java", "c_cpp",
-    "coffee", "perl", "csharp", "svg", "clojure", "scss"
+    "coffee", "perl", "csharp", "svg", "clojure", "scss", "scad"
 ].forEach(function(mode) {
     console.log("mode " + mode);
     copy({

--- a/lib/ace/mode/scad.js
+++ b/lib/ace/mode/scad.js
@@ -1,0 +1,130 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Ajax.org Code Editor (ACE).
+ *
+ * The Initial Developer of the Original Code is
+ * Ajax.org B.V.
+ * Portions created by the Initial Developer are Copyright (C) 2010
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *      Fabian Jakobs <fabian AT ajax DOT org>
+ *      Gastón Kleiman <gaston.kleiman AT gmail DOT com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+define(function(require, exports, module) {
+
+var oop = require("pilot/oop");
+var TextMode = require("ace/mode/text").Mode;
+var Tokenizer = require("ace/tokenizer").Tokenizer;
+var scadHighlightRules = require("ace/mode/scad_highlight_rules").scadHighlightRules;
+var MatchingBraceOutdent = require("ace/mode/matching_brace_outdent").MatchingBraceOutdent;
+var Range = require("ace/range").Range;
+var CstyleBehaviour = require("ace/mode/behaviour/cstyle").CstyleBehaviour;
+
+var Mode = function() {
+    this.$tokenizer = new Tokenizer(new scadHighlightRules().getRules());
+    this.$outdent = new MatchingBraceOutdent();
+    this.$behaviour = new CstyleBehaviour();
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+
+    this.toggleCommentLines = function(state, doc, startRow, endRow) {
+        var outdent = true;
+        var outentedRows = [];
+        var re = /^(\s*)\/\//;
+
+        for (var i=startRow; i<= endRow; i++) {
+            if (!re.test(doc.getLine(i))) {
+                outdent = false;
+                break;
+            }
+        }
+
+        if (outdent) {
+            var deleteRange = new Range(0, 0, 0, 0);
+            for (var i=startRow; i<= endRow; i++)
+            {
+                var line = doc.getLine(i);
+                var m = line.match(re);
+                deleteRange.start.row = i;
+                deleteRange.end.row = i;
+                deleteRange.end.column = m[0].length;
+                doc.replace(deleteRange, m[1]);
+            }
+        }
+        else {
+            doc.indentRows(startRow, endRow, "//");
+        }
+    };
+
+    this.getNextLineIndent = function(state, line, tab) {
+        var indent = this.$getIndent(line);
+
+        var tokenizedLine = this.$tokenizer.getLineTokens(line, state);
+        var tokens = tokenizedLine.tokens;
+        var endState = tokenizedLine.state;
+
+        if (tokens.length && tokens[tokens.length-1].type == "comment") {
+            return indent;
+        }
+
+        if (state == "start") {
+            var match = line.match(/^.*[\{\(\[]\s*$/);
+            if (match) {
+                indent += tab;
+            }
+        } else if (state == "doc-start") {
+            if (endState == "start") {
+                return "";
+            }
+            var match = line.match(/^\s*(\/?)\*/);
+            if (match) {
+                if (match[1]) {
+                    indent += " ";
+                }
+                indent += "* ";
+            }
+        }
+
+        return indent;
+    };
+
+    this.checkOutdent = function(state, line, input) {
+        return this.$outdent.checkOutdent(line, input);
+    };
+
+    this.autoOutdent = function(state, doc, row) {
+        this.$outdent.autoOutdent(doc, row);
+    };
+
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+});

--- a/lib/ace/mode/scad_highlight_rules.js
+++ b/lib/ace/mode/scad_highlight_rules.js
@@ -1,0 +1,163 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Ajax.org Code Editor (ACE).
+ *
+ * The Initial Developer of the Original Code is
+ * Ajax.org B.V.
+ * Portions created by the Initial Developer are Copyright (C) 2010
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *      Fabian Jakobs <fabian AT ajax DOT org>
+ *      Gastón Kleiman <gaston.kleiman AT gmail DOT com>
+ *
+ * Based on Bespin's C/C++ Syntax Plugin by Marc McIntyre.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+define(function(require, exports, module) {
+
+var oop = require("pilot/oop");
+var lang = require("pilot/lang");
+var DocCommentHighlightRules = require("ace/mode/doc_comment_highlight_rules").DocCommentHighlightRules;
+var TextHighlightRules = require("ace/mode/text_highlight_rules").TextHighlightRules;
+
+var scadHighlightRules = function() {
+
+    var keywords = lang.arrayToMap(
+        ("module|if|else|for").split("|")
+    );
+
+    var buildinConstants = lang.arrayToMap(
+        ("NULL").split("|")
+    );
+
+    // regexp must not have capturing parentheses. Use (?:) instead.
+    // regexps are ordered -> the first match is used
+
+    this.$rules = {
+        "start" : [
+	        {
+	            token : "comment",
+	            regex : "\\/\\/.*$"
+	        },
+	        new DocCommentHighlightRules().getStartRule("start"),
+	        {
+	            token : "comment", // multi line comment
+	            regex : "\\/\\*",
+	            next : "comment"
+	        }, {
+	            token : "string", // single line
+	            regex : '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
+	        }, {
+	            token : "string", // multi line string start
+	            regex : '["].*\\\\$',
+	            next : "qqstring"
+	        }, {
+	            token : "string", // single line
+	            regex : "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"
+	        }, {
+	            token : "string", // multi line string start
+	            regex : "['].*\\\\$",
+	            next : "qstring"
+	        }, {
+	            token : "constant.numeric", // hex
+	            regex : "0[xX][0-9a-fA-F]+\\b"
+	        }, {
+	            token : "constant.numeric", // float
+	            regex : "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b"
+	        }, {
+              token : "constant", // <CONSTANT>
+              regex : "<[a-zA-Z0-9.]+>"
+	        }, {
+              token : "keyword", // pre-compiler directivs
+              regex : "(?:use|include)"
+          }, {
+	            token : function(value) {
+	                if (value == "this")
+	                    return "variable.language";
+	                else if (keywords.hasOwnProperty(value))
+	                    return "keyword";
+	                else if (buildinConstants.hasOwnProperty(value))
+	                    return "constant.language";
+	                else
+	                    return "identifier";
+	            },
+	            regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
+	        }, {
+	            token : "keyword.operator",
+	            regex : "!|\\$|%|&|\\*|\\-\\-|\\-|\\+\\+|\\+|~|==|=|!=|<=|>=|<<=|>>=|>>>=|<>|<|>|!|&&|\\|\\||\\?\\:|\\*=|%=|\\+=|\\-=|&=|\\^=|\\b(?:in|new|delete|typeof|void)"
+	        }, {
+	            token : "lparen",
+	            regex : "[[({]"
+	        }, {
+	            token : "rparen",
+	            regex : "[\\])}]"
+	        }, {
+	            token : "text",
+	            regex : "\\s+"
+	        }
+        ],
+        "comment" : [
+	        {
+	            token : "comment", // closing comment
+	            regex : ".*?\\*\\/",
+	            next : "start"
+	        }, {
+	            token : "comment", // comment spanning whole line
+	            regex : ".+"
+	        }
+        ],
+        "qqstring" : [
+            {
+	            token : "string",
+	            regex : '(?:(?:\\\\.)|(?:[^"\\\\]))*?"',
+	            next : "start"
+	        }, {
+	            token : "string",
+	            regex : '.+'
+	        }
+        ],
+        "qstring" : [
+	        {
+	            token : "string",
+	            regex : "(?:(?:\\\\.)|(?:[^'\\\\]))*?'",
+	            next : "start"
+	        }, {
+	            token : "string",
+	            regex : '.+'
+	        }
+        ]
+    };
+    
+    this.embedRules(DocCommentHighlightRules, "doc-",
+        [ new DocCommentHighlightRules().getEndRule("start") ]);
+};
+
+oop.inherits(scadHighlightRules, TextHighlightRules);
+
+exports.scadHighlightRules = scadHighlightRules;
+});


### PR DESCRIPTION
Added syntax highlighting for the SCAD 3D modelling language used by the RepRap community and others. Basically a slightly modified version of the already existing c/c++ syntax highlighting.

Also did a make clean && make build to get the built files up to date with the changes made.
@gissues:{"order":70.18633540372684,"status":"backlog"}
