### PR TITLE
Fix offset problems with hard tabs

### DIFF
--- a/lib/ace/layer/text.js
+++ b/lib/ace/layer/text.js
@@ -370,7 +370,7 @@ var Text = function(parentEl) {
         else {
             stringBuilder.push(output);
         }
-        return value.length;
+        return screenColumn + value.length;
     }
 
     this.$renderLineCore = function(stringBuilder, lastRow, tokens, splits) {
@@ -382,7 +382,7 @@ var Text = function(parentEl) {
             self = this;
 
         function addToken(token, value) {
-            screenColumn += self.$renderToken(
+            screenColumn = self.$renderToken(
                 stringBuilder, screenColumn, token, value);
         }
 


### PR DESCRIPTION
The cursor offset becomes incorrect if you type e.g. the following with soft tabs disabled:

```
a<Tab>a<Tab>a<Tab>
```

The problem is the screenColumn value does not get incremented correctly in the presence of hard tabs. This patch corrects that.
