### PR TITLE
create layerConfig in constructor instead of adding guards for its every 

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -121,6 +121,20 @@ var VirtualRenderer = function(container, theme) {
         scrollerWidth: 0
     };
 
+    this.layerConfig = {
+        width : 1,
+        padding : 0,
+        firstRow : 0,
+        firstRowScreen: 0,
+        lastRow : 0,
+        lineHeight : 1,
+        characterWidth : 1,
+        minHeight : 1,
+        maxHeight : 1,
+        offset : 0,
+        height : 1
+    };
+
     this.$loop = new RenderLoop(this.$renderChanges.bind(this));
     this.$loop.schedule(this.CHANGE_FULL);
 
@@ -332,33 +346,27 @@ var VirtualRenderer = function(container, theme) {
             return;
 
         var bounds = this.content.getBoundingClientRect();
-        var offset = (this.layerConfig && this.layerConfig.offset) || 0;
+        var offset = this.layerConfig.offset;
 
         textarea.style.left = (bounds.left + pos.left + this.$padding) + "px";
         textarea.style.top = (bounds.top + pos.top - this.scrollTop + offset) + "px";
     };
 
     this.getFirstVisibleRow = function() {
-        return (this.layerConfig || {}).firstRow || 0;
+        return this.layerConfig.firstRow;
     };
 
-    this.getFirstFullyVisibleRow = function(){
-        if (!this.layerConfig)
-            return 0;
-
+    this.getFirstFullyVisibleRow = function() {
         return this.layerConfig.firstRow + (this.layerConfig.offset === 0 ? 0 : 1);
     };
 
     this.getLastFullyVisibleRow = function() {
-        if (!this.layerConfig)
-            return 0;
-
         var flint = Math.floor((this.layerConfig.height + this.layerConfig.offset) / this.layerConfig.lineHeight);
         return this.layerConfig.firstRow - 1 + flint;
     };
 
     this.getLastVisibleRow = function() {
-        return (this.layerConfig || {}).lastRow || 0;
+        return this.layerConfig.lastRow;
     };
 
     this.$padding = null;
@@ -395,8 +403,7 @@ var VirtualRenderer = function(container, theme) {
             return;
 
         // text, scrolling and resize changes can cause the view port size to change
-        if (!this.layerConfig ||
-            changes & this.CHANGE_FULL ||
+        if (changes & this.CHANGE_FULL ||
             changes & this.CHANGE_SIZE ||
             changes & this.CHANGE_TEXT ||
             changes & this.CHANGE_LINES ||
@@ -469,7 +476,7 @@ var VirtualRenderer = function(container, theme) {
         var minHeight = this.$size.scrollerHeight + this.lineHeight;
 
         var longestLine = this.$getLongestLine();
-        var widthChanged = !this.layerConfig ? true : (this.layerConfig.width != longestLine);
+        var widthChanged = this.layerConfig.width != longestLine;
 
         var horizScroll = this.$horizScrollAlwaysVisible || this.$size.scrollerWidth - longestLine < 0;
         var horizScrollChanged = this.$horizScroll !== horizScroll;


### PR DESCRIPTION
only case when VirtualRenderer.layerConfig is undefined is before first render
after that CHANGE_FULL happens and layerConfig is initialised

but for this one case we have to guard every access to layerConfig 
and there is unguarded access in scrollCursor which causes error (though this happens in very specific conditions, i've encountered in acebug)

i think it's better to create dummy layerConfig in the constructor
