### PR TITLE
changed misleading argument name: row -> column

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -1001,11 +1001,11 @@ var Editor =function(renderer, session) {
     };
 
 
-    this.gotoLine = function(lineNumber, row) {
+    this.gotoLine = function(lineNumber, column) {
         this.selection.clearSelection();
 
         this.$blockScrolling += 1;
-        this.moveCursorTo(lineNumber-1, row || 0);
+        this.moveCursorTo(lineNumber-1, column || 0);
         this.$blockScrolling -= 1;
 
         if (!this.isRowVisible(this.getCursorPosition().row)) {


### PR DESCRIPTION
This argument is being used as a column number, but it's named row...

Thanks for Ace!
