### PR TITLE
Make Ruby symbols less greedy - don't match Namespaced::Constants

### DIFF
--- a/lib/ace/mode/ruby_highlight_rules.js
+++ b/lib/ace/mode/ruby_highlight_rules.js
@@ -125,7 +125,7 @@ var RubyHighlightRules = function() {
                 regex : "[A-Z](?:[a-zA-Z_]|\d)+"
 	        }, {
                 token : "string", // symbol
-                regex : "[:](?:[A-Za-z_]|[@$](?=[a-zA-Z0-9_]))[a-zA-Z0-9_]*[!=?]?"
+                regex : "(?:[^:]|^)[:](?:[A-Za-z_]|[@$](?=[a-zA-Z0-9_]))[a-zA-Z0-9_]*[!=?]?"
 	       }, {
 	            token : "constant.numeric", // hex
 	            regex : "0[xX][0-9a-fA-F](?:[0-9a-fA-F]|_(?=[0-9a-fA-F]))*\\b"


### PR DESCRIPTION
Before:

![](https://img.skitch.com/20110726-8dfhh28tyamf786x576fug1akb.png)

After:

![](https://img.skitch.com/20110726-dtdc2urtdut966m4ir3pw9m997.png)

I would very much like to include a test but I'm having trouble running the suite. Any tips? https://gist.github.com/d20a2f804dd1d4c18f7d
