### PR TITLE
Make Ruby symbols less greedy - don't match Namespaced::Constants

### DIFF
--- a/lib/ace/mode/ruby_highlight_rules.js
+++ b/lib/ace/mode/ruby_highlight_rules.js
@@ -118,6 +118,9 @@ var RubyHighlightRules = function() {
                 token : "string", // backtick string
                 regex : "[`](?:(?:\\\\.)|(?:[^'\\\\]))*?[`]"
 	        }, {
+                token : "text", // namespaces aren't symbols
+                regex : "::"
+	        }, {
                 token : "variable.instancce", // instance variable
                 regex : "@{1,2}(?:[a-zA-Z_]|\d)+"
 	        }, {

--- a/lib/ace/mode/ruby_tokenizer_test.js
+++ b/lib/ace/mode/ruby_tokenizer_test.js
@@ -60,6 +60,16 @@ module.exports = {
             ":th!ing", ":thing#"]);
     },
 
+    "test: namespaces aren't symbols" : function() {
+        var line = "Namespaced::Class";
+        var tokens = this.tokenizer.getLineTokens(line, "start").tokens;
+
+        assert.equal(3, tokens.length);
+        assert.equal("variable.class", tokens[0].type);
+        assert.equal("text", tokens[1].type);
+        assert.equal("variable.class", tokens[2].type);
+    },
+
     "test: hex tokenizer" : function() {
         assertValidTokens(this.tokenizer, "constant.numeric",
             ["0x9a", "0XA1", "0x9_a"]);


### PR DESCRIPTION
Before:

![](https://img.skitch.com/20110726-8dfhh28tyamf786x576fug1akb.png)

After:

![](https://img.skitch.com/20110726-x2m4r99ij2uydt27ntt41x4bcj.png)
