### PR TITLE
Bugfix/wrap mode rendering (bug 371)

### DIFF
--- a/lib/ace/layer/text.js
+++ b/lib/ace/layer/text.js
@@ -215,7 +215,7 @@ var Text = function(parentEl) {
 
             var html = [];
             var tokens = this.session.getTokens(i, i);
-            this.$renderLine(html, i, tokens[0].tokens, true);
+            this.$renderLine(html, i, tokens[0].tokens, !this.$useLineGroups());
             lineElement = dom.setInnerHtml(lineElement, html.join(""));
 
             i = this.session.getRowFoldEnd(i);
@@ -284,9 +284,14 @@ var Text = function(parentEl) {
 
             // don't use setInnerHtml since we are working with an empty DIV
             container.innerHTML = html.join("");
-            var lines = container.childNodes
-            while(lines.length)
-                fragment.appendChild(lines[0]);
+            if (this.$useLineGroups()) {
+                container.className = 'ace_line_group';
+                fragment.appendChild(container);
+            } else {
+                var lines = container.childNodes
+                while(lines.length)
+                    fragment.appendChild(lines[0]);
+            }
 
             row++;
         }
@@ -313,6 +318,9 @@ var Text = function(parentEl) {
             if(row > lastRow)
                 break;
 
+            if (this.$useLineGroups())
+                html.push("<div class='ace_line_group'>")
+
             // Get the tokens per line as there might be some lines in between
             // beeing folded.
             // OPTIMIZE: If there is a long block of unfolded lines, just make
@@ -320,6 +328,9 @@ var Text = function(parentEl) {
             var tokens = this.session.getTokens(row, row);
             if (tokens.length == 1)
                 this.$renderLine(html, row, tokens[0].tokens, false);
+
+            if (this.$useLineGroups())
+                html.push("</div>"); // end the line group
 
             row++;
         }
@@ -529,6 +540,15 @@ var Text = function(parentEl) {
         // TODO: Build a fake splits array!
         var splits = this.session.$useWrapMode?this.session.$wrapData[row]:null;
         this.$renderLineCore(stringBuilder, row, renderTokens, splits, onlyContents);
+    };
+    
+    this.$useLineGroups = function() {
+        // For the updateLines function to work correctly, it's important that the
+        // child nodes of this.element correspond on a 1-to-1 basis to rows in the 
+        // document (as distinct from lines on the screen). For sessions that are
+        // wrapped, this means we need to add a layer to the node hierarchy (tagged
+        // with the class name ace_line_group).
+        return this.session.getUseWrapMode();
     };
 
     this.destroy = function() {


### PR DESCRIPTION
This fixes the rendering bug that happens when you type in a wrapped line.

fjakob's rendering change at 011964c removed an "unnecessary div per line"--however the div turns out to be necessary for layer/text.js `updateLines` function to work correctly for wrapped documents. This function indexes into the child nodes of the text layer element, and replaces the contents with the new contents of that line. After 011964c, the child nodes of the text layer element no longer correspond 1-for-1 with the document's lines; instead it has a potential 1-to-many correspondence. So when updateLine goes to update e.g. the 3rd (very long) line of the document, it actually removes only a single screen row, and replaces it with the complete contents of line 3 (which no longer wraps because the `onlyContent` argument to `renderLines` is `true`).

I fixed this by, essentially, surgically undoing 011964c if the session has wrap mode turned on--iff wrap mode is on, then the immediate children of the text layer element become `div.ace_line_group` that each contain `div.ace_line`. This is more complicated than the alternative of always using `div.ace_line_group`, whether it is needed or not. I'm not sure whether it's better to have the simpler code with the penalty of the extra div for non-wrapped documents, or vice versa. Let me know if you would rather have it the other way and I can make that change.
