### PR TITLE
Add LaTeX highlighting

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -70,6 +70,7 @@ exports.launch = function(env) {
     var TextMode = require("ace/mode/text").Mode;
     var GroovyMode = require("ace/mode/groovy").Mode;
     var ScalaMode = require("ace/mode/scala").Mode;
+    var LatexMode = require("ace/mode/latex").Mode;
 
     var UndoManager = require("ace/undomanager").UndoManager;
 
@@ -182,6 +183,9 @@ exports.launch = function(env) {
     docs.scala.setMode(new ScalaMode());
     docs.scala.setUndoManager(new UndoManager());
 
+    docs.latex = new EditSession(document.getElementById("latex").innerHTML);
+    docs.latex.setMode(new LatexMode());
+    docs.latex.setUndoManager(new UndoManager());
     
     
 
@@ -226,7 +230,8 @@ exports.launch = function(env) {
         ocaml: new OcamlMode(),
         csharp: new CSharpMode(),
         groovy: new GroovyMode(),
-        scala: new ScalaMode()
+        scala: new ScalaMode(),
+        latex: new LatexMode()
     };
 
     function getMode() {
@@ -323,6 +328,9 @@ exports.launch = function(env) {
         }
         else if (mode instanceof ScalaMode) {
             modeEl.value = "scala";
+        }
+        else if (mode instanceof LatexMode) {
+            modeEl.value = "latex";
         }
         else {
             modeEl.value = "text";

--- a/kitchen-sink.html
+++ b/kitchen-sink.html
@@ -36,6 +36,7 @@
           <option value="textile">Textile</option>
           <option value="groovy">Groovy</option>
           <option value="scala">Scala</option>
+          <option value="latex">LaTeX</option>
         </select>
       </td>
     </tr>
@@ -65,6 +66,7 @@
           <option value="textile">Textile</option>
           <option value="groovy">Groovy</option>
           <option value="scala">Scala</option>
+          <option value="latex">LaTeX</option>
         </select>
       </td>
     </tr>
@@ -683,6 +685,29 @@ object implicits extends Application {
   val x = Array(2, 3, 1, 4)
   println("x = "+ x.sort((x: Int, y: Int) => x < y))
 }</script>
+<script type="text/editor" id="latex">\usepackage{amsmath}
+\title{\LaTeX}
+\date{}
+\begin{document}
+  \maketitle
+  \LaTeX{} is a document preparation system for the \TeX{}
+  typesetting program. It offers programmable desktop publishing
+  features and extensive facilities for automating most aspects of
+  typesetting and desktop publishing, including numbering and
+  cross-referencing, tables and figures, page layout, bibliographies,
+  and much more. \LaTeX{} was originally written in 1984 by Leslie
+  Lamport and has become the dominant method for using \TeX; few
+  people write in plain \TeX{} anymore. The current version  is
+  \LaTeXe.
+ 
+  % This is a comment; it will not be shown in the final output.
+  % The following shows a little of the typesetting power of LaTeX:
+  \begin{align}
+    E &= mc^2                              \\
+    m &= \frac{m_0}{\sqrt{1-\frac{v^2}{c^2}}}
+  \end{align}
+\end{document}
+</script>
   <input id="cockpitInput" type="text"/>
 
 <!-- DEVEL-->

--- a/lib/ace/mode/latex.js
+++ b/lib/ace/mode/latex.js
@@ -1,0 +1,58 @@
+define(function(require, exports, module) {
+
+var oop = require("pilot/oop");
+var TextMode = require("ace/mode/text").Mode;
+var Tokenizer = require("ace/tokenizer").Tokenizer;
+var LatexHighlightRules = require("ace/mode/latex_highlight_rules").LatexHighlightRules;
+var Range = require("ace/range").Range;
+
+var Mode = function()
+{
+    this.$tokenizer = new Tokenizer(new LatexHighlightRules().getRules());
+};
+oop.inherits(Mode, TextMode);
+
+(function()
+{
+    this.toggleCommentLines = function(state, doc, startRow, endRow) {
+        // This code is adapted from ruby.js
+        var outdent = true;
+        var outentedRows = [];
+        
+        // LaTeX comments begin with % and go to the end of the line
+        var commentRegEx = /^(\s*)\%/;
+
+        for (var i = startRow; i <= endRow; i++) {
+            if (!commentRegEx.test(doc.getLine(i))) {
+                outdent = false;
+                break;
+            }
+        }
+
+        if (outdent) {
+            var deleteRange = new Range(0, 0, 0, 0);
+            for (var i = startRow; i <= endRow; i++) {
+                var line = doc.getLine(i);
+                var m = line.match(commentRegEx);
+                deleteRange.start.row = i;
+                deleteRange.end.row = i;
+                deleteRange.end.column = m[0].length;
+                doc.replace(deleteRange, m[1]);
+            }
+        }
+        else {
+            doc.indentRows(startRow, endRow, "%");
+        }
+    };
+    
+    // There is no universally accepted way of indenting a tex document
+    // so just maintain the indentation of the previous line
+    this.getNextLineIndent = function(state, line, tab) {
+        return this.$getIndent(line);
+    };
+    
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+
+});

--- a/lib/ace/mode/latex_highlight_rules.js
+++ b/lib/ace/mode/latex_highlight_rules.js
@@ -1,0 +1,39 @@
+define(function(require, exports, module) {
+
+var oop = require("pilot/oop");
+var TextHighlightRules = require("ace/mode/text_highlight_rules").TextHighlightRules;
+
+var LatexHighlightRules = function()
+{   
+    this.$rules = {
+        "start" : [
+            {
+                // A tex command e.g. \foo
+                token : "keyword",
+                regex : "\\\\(?:[^a-zA-Z]|[a-zA-Z]+)",
+            },
+            {
+                // Curly and square braces
+                token : "keyword",
+                regex : "[\\{\\}\\]\\[]"
+            },
+            {
+                // Inline math between two $ symbols
+                token : "string",
+                regex : "\\$(?:(?:\\\\.)|(?:[^\\$\\\\]))*?\\$"
+            },
+            {
+                // A comment. Tex comments start with % and go to 
+                // the end of the line
+                token : "comment",
+                regex : "%.*$"
+            }
+        ]
+    };
+};
+
+oop.inherits(LatexHighlightRules, TextHighlightRules);
+
+exports.LatexHighlightRules = LatexHighlightRules;
+
+});


### PR DESCRIPTION
I've added a very simple LaTeX highlighting mode. It only picks up on simple commands, braces, inline math and comments, but this should be enough to highlight TeX documents nicely.
