### PR TITLE
Added proper support for parsing warnings / errors display in Javascript mode

### DIFF
--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -358,6 +358,10 @@ var EditSession = function(text, mode) {
         for (var i=0; i<annotations.length; i++) {
             var annotation = annotations[i];
             var row = annotation.row;
+
+			if(isNaN(row))
+				row=0;
+				
             if (this.$annotations[row])
                 this.$annotations[row].push(annotation);
             else

--- a/lib/ace/mode/javascript.js
+++ b/lib/ace/mode/javascript.js
@@ -146,7 +146,7 @@ oop.inherits(Mode, TextMode);
                         row: error.line-1,
                         column: error.character-1,
                         text: error.reason,
-                        type: "warning",
+                        type: (error.type!=undefined && (error.type=='warning' || error.type=='error' || error.type=='info')) ? error.type : "warning",
                         lint: error
                     });
             }

--- a/lib/ace/mode/javascript_worker.js
+++ b/lib/ace/mode/javascript_worker.js
@@ -23,10 +23,10 @@ oop.inherits(JavaScriptWorker, Mirror);
         try {
             parser.parse(value);
         } catch(e) {
-//            console.log("narcissus")
-//            console.log(e);
+           // console.log("narcissus")
+            //console.log(e);
             this.sender.emit("narcissus", {
-                row: e.lineno-1,
+                row: e.lineno,
                 column: null, // TODO convert e.cursor
                 text: e.message,
                 type: "error"

--- a/lib/ace/narcissus/jslex.js
+++ b/lib/ace/narcissus/jslex.js
@@ -486,12 +486,13 @@
         },
 
         newSyntaxError: function (m) {
-            m = (this.filename ? this.filename + ":" : "") + this.lineno + ": " + m;
+            m = (this.filename ? this.filename + ":" : "") + m;
             var e = new SyntaxError(m, this.filename, this.lineno);
             e.source = this.source;
             e.cursor = this.lookahead
                        ? this.tokens[(this.tokenIndex + this.lookahead) & 3].start
                        : this.cursor;
+			e.lineno = this.lineno;
             return e;
         },
 

--- a/lib/ace/worker/jshint.js
+++ b/lib/ace/worker/jshint.js
@@ -820,7 +820,7 @@ var JSHINT = (function () {
         };
     }
 
-    function warning(m, t, a, b, c, d) {
+    function warning(m, t, a, b, c, d,wType) {
         var ch, l, w;
         t = t || nexttoken;
         if (t.id === '(end)') {  // `~
@@ -828,9 +828,14 @@ var JSHINT = (function () {
         }
         l = t.line || 0;
         ch = t.from || 0;
+
+		if(wType==undefined || wType==null || wType=='')
+			wType='warning';
+
         w = {
             id: '(error)',
             raw: m,
+			type: wType,
             evidence: lines[l - 1] || '',
             line: l,
             character: ch,
@@ -859,7 +864,7 @@ var JSHINT = (function () {
     }
 
     function error(m, t, a, b, c, d) {
-        var w = warning(m, t, a, b, c, d);
+        var w = warning(m, t, a, b, c, d,'error');
         quit("Stopping, unable to continue.", w.line, w.character);
     }
 
@@ -1291,7 +1296,7 @@ var JSHINT = (function () {
                                                 l += 1;
                                                 break;
                                             default:
-                                                warningAt(
+                                                errorAt(
 "Expected '{a}' and instead saw '{b}'.", line, from + l, ':', s.charAt(l));
                                             }
                                         } else {
@@ -1417,7 +1422,7 @@ klass:                                  do {
                                             l += 1;
                                             c = s.charAt(l);
                                             if (c < '0' || c > '9') {
-                                                warningAt(
+                                                errorAt(
 "Expected a number and instead saw '{a}'.", line, from + l, c);
                                             }
                                             l += 1;
@@ -1449,7 +1454,7 @@ klass:                                  do {
                                                 }
                                             }
                                             if (s.charAt(l) !== '}') {
-                                                warningAt(
+                                                errorAt(
 "Expected '{a}' and instead saw '{b}'.", line, from + l, '}', c);
                                             } else {
                                                 l += 1;
@@ -1661,12 +1666,12 @@ loop:   for (;;) {
                 if (nexttoken.id === '(end)') {
                     warning("Unmatched '{a}'.", t, t.id);
                 } else {
-                    warning("Expected '{a}' to match '{b}' from line {c} and instead saw '{d}'.",
+                    error("Expected '{a}' to match '{b}' from line {c} and instead saw '{d}'.",
                             nexttoken, id, t.id, t.line, nexttoken.value);
                 }
             } else if (nexttoken.type !== '(identifier)' ||
                             nexttoken.value !== id) {
-                warning("Expected '{a}' and instead saw '{b}'.",
+                error("Expected '{a}' and instead saw '{b}'.",
                         nexttoken, id, nexttoken.value);
             }
         }
@@ -2007,7 +2012,7 @@ loop:   for (;;) {
                     return that;
                 }
                 if (left === syntax['function']) {
-                    warning(
+                    error(
 "Expected an identifier in an assignment and instead saw a function invocation.",
                                 token);
                 }
@@ -2047,7 +2052,7 @@ loop:   for (;;) {
                     return that;
                 }
                 if (left === syntax['function']) {
-                    warning(
+                    error(
 "Expected an identifier in an assignment, and instead saw a function invocation.",
                                 token);
                 }
@@ -2084,7 +2089,7 @@ loop:   for (;;) {
                 // against the case when somebody does `undefined = true` and
                 // help with minification. More info: https://gist.github.com/315916
                 if (!fnparam || token.value != 'undefined') {
-                    warning("Expected an identifier and instead saw '{a}' (a reserved word).",
+                    error("Expected an identifier and instead saw '{a}' (a reserved word).",
                             token, token.id);
                 }
             }
@@ -2173,7 +2178,7 @@ loop:   for (;;) {
 
         if (!t.block) {
             if (!option.expr && (!r || !r.exps)) {
-                warning("Expected an assignment or function call and instead saw an expression.",
+                error("Expected an assignment or function call and instead saw an expression.",
                     token);
             } else if (option.nonew && r.id === '(' && r.left.id === 'new') {
                 warning("Do not use 'new' for side effects.");
@@ -2273,7 +2278,7 @@ loop:   for (;;) {
                   nexttoken, '{', nexttoken.value);
         } else {
             if (!stmt || option.curly)
-                warning("Expected '{a}' and instead saw '{b}'.",
+                error("Expected '{a}' and instead saw '{b}'.",
                         nexttoken, '{', nexttoken.value);
 
             noreach = true;
@@ -2530,7 +2535,7 @@ loop:   for (;;) {
                 (left.value == 'null' || right.value == 'null');
 
         if (!eqnull && option.eqeqeq) {
-            warning("Expected '{a}' and instead saw '{b}'.",
+            error("Expected '{a}' and instead saw '{b}'.",
                     this, '===', '==');
         } else if (isPoorRelation(left)) {
             warning("Use '{a}' to compare with '{b}'.",
@@ -2547,7 +2552,7 @@ loop:   for (;;) {
                 (left.value == 'null' || right.value == 'null');
 
         if (!eqnull && option.eqeqeq) {
-            warning("Expected '{a}' and instead saw '{b}'.",
+            error("Expected '{a}' and instead saw '{b}'.",
                     this, '!==', '!=');
         } else if (isPoorRelation(left)) {
             warning("Use '{a}' to compare with '{b}'.",
@@ -2994,7 +2999,7 @@ loop:   for (;;) {
                     f = doFunction();
                     p = f['(params)'];
                     if (!p || p.length !== 1 || p[0] !== 'value') {
-                        warning("Expected (value) in set {a} function.", t, i);
+                        error("Expected (value) in set {a} function.", t, i);
                     }
                 } else {
                     i = property_name();
@@ -3119,7 +3124,7 @@ loop:   for (;;) {
         expression(20);
         if (nexttoken.id === '=') {
             if (!option.boss)
-                warning("Expected a conditional expression and instead saw an assignment.");
+                error("Expected a conditional expression and instead saw an assignment.");
             advance('=');
             expression(20);
         }
@@ -3150,7 +3155,7 @@ loop:   for (;;) {
             scope = Object.create(s);
             e = nexttoken.value;
             if (nexttoken.type !== '(identifier)') {
-                warning("Expected an identifier and instead saw '{a}'.",
+                error("Expected an identifier and instead saw '{a}'.",
                     nexttoken, e);
             } else {
                 addlabel(e, 'exception');
@@ -3182,7 +3187,7 @@ loop:   for (;;) {
         expression(20);
         if (nexttoken.id === '=') {
             if (!option.boss)
-                warning("Expected a conditional expression and instead saw an assignment.");
+                error("Expected a conditional expression and instead saw an assignment.");
             advance('=');
             expression(20);
         }
@@ -3313,7 +3318,7 @@ loop:   for (;;) {
             expression(20);
             if (nexttoken.id === '=') {
                 if (!option.boss)
-                    warning("Expected a conditional expression and instead saw an assignment.");
+                    error("Expected a conditional expression and instead saw an assignment.");
                 advance('=');
                 expression(20);
             }
@@ -3384,7 +3389,7 @@ loop:   for (;;) {
                 expression(20);
                 if (nexttoken.id === '=') {
                     if (!option.boss)
-                        warning("Expected a conditional expression and instead saw an assignment.");
+                        error("Expected a conditional expression and instead saw an assignment.");
                     advance('=');
                     expression(20);
                 }
@@ -3521,7 +3526,7 @@ loop:   for (;;) {
                     } else if (nexttoken.id === ',') {
                         error("Unexpected comma.", nexttoken);
                     } else if (nexttoken.id !== '(string)') {
-                        warning("Expected a string and instead saw {a}.",
+                        error("Expected a string and instead saw {a}.",
                                 nexttoken, nexttoken.value);
                     }
                     if (o[nexttoken.value] === true) {


### PR DESCRIPTION
Currently, if a Javascript error is detected by narcissus, the error is not displayed on the left margin of the editor. Moreover, too many times the warning generated by JSHint should be errors instead of warning. Last but not least, there is currently no support for JSHint to differentiate between an error or a warning and therefore only warnings are displayed in the editor UI.

This pull request aims to correct the above problems.
