### PR TITLE
Improve VIM key bindings a bit

### DIFF
--- a/lib/ace/keyboard/keybinding/vim.js
+++ b/lib/ace/keyboard/keybinding/vim.js
@@ -40,6 +40,22 @@ define(function(require, exports, module) {
 var StateHandler = require("ace/keyboard/state_handler").StateHandler;
 var matchCharacterOnly =  require("ace/keyboard/state_handler").matchCharacterOnly;
 
+var vimcommand = function(key, exec, then) {
+    return {
+        regex:  [ "([0-9]*)", key ],
+        exec:   exec,
+        params: [
+            {
+                name:     "times",
+                match:    1,
+                type:     "number",
+                defaultValue:     1
+            }
+        ],
+        then:   then
+    }
+}
+
 var vimStates = {
     start: [
         {
@@ -75,78 +91,20 @@ var vimStates = {
             exec:   "overwrite",
             then:   "replaceMode"
         },
-        {
-            regex:  [ "([0-9]*)", "(k|up)" ],
-            exec:   "golineup",
-            params: [
-                {
-                    name:     "times",
-                    match:    1,
-                    type:     "number",
-                    defaultValue:     1
-                }
-            ]
-        },
-        {
-            regex:  [ "([0-9]*)", "(j|down|enter)" ],
-            exec:   "golinedown",
-            params: [
-                {
-                    name:    "times",
-                    match:   1,
-                    type:    "number",
-                    defaultValue:    1
-                }
-            ]
-        },
-        {
-            regex:  [ "([0-9]*)", "(l|right)" ],
-            exec:   "gotoright",
-            params: [
-                {
-                    name:   "times",
-                    match:  1,
-                    type:   "number",
-                    defaultValue:     1
-                }
-            ]
-        },
-        {
-            regex:  [ "([0-9]*)", "(h|left)" ],
-            exec:   "gotoleft",
-            params: [
-                {
-                    name:     "times",
-                    match:    1,
-                    type:     "number",
-                    defaultValue:     1
-                }
-            ]
-        },
+        vimcommand("(k|up)", "golineup"),
+        vimcommand("(j|down)", "golinedown"),
+        vimcommand("(l|right)", "golineright"),
+        vimcommand("(h|left)", "golineleft"),
         {
             key:    "shift-g",
             exec:   "gotoend"
         },
-        {
-            key:    "b",
-            exec:   "gotowordleft"
-        },
-        {
-            key:    "e",
-            exec:   "gotowordright"
-        },
-        {
-            key:    "x",
-            exec:   "del"
-        },
-        {
-            key:    "shift-x",
-            exec:   "backspace"
-        },
-        {
-            key:    "shift-d",
-            exec:   "removetolineend"
-        },
+        vimcommand("b", "gotowordleft"),
+        vimcommand("e", "gotowordright"),
+        vimcommand("x", "del"),
+        vimcommand("shift-x", "backspace"),
+        vimcommand("shift-d", "removetolineend"),
+        vimcommand("u", "undo"), // [count] on this may/may not work, depending on browser implementation...
         {
             comment:    "Catch some keyboard input to stop it here",
             match:      matchCharacterOnly


### PR DESCRIPTION
Make it easy to have vim bindings which work with optional [count]s. (One or two commands already did this, but not enough.)

Add undo as a binding while I'm at it.
