### PR TITLE
Add auto-outdent to Python after pass/return/raise statements

### DIFF
--- a/lib/ace/mode/python.js
+++ b/lib/ace/mode/python.js
@@ -108,7 +108,15 @@ oop.inherits(Mode, TextMode);
     };
 
     this.autoOutdent = function(state, doc, row) {
-        this.$outdent.autoOutdent(doc, row);
+        var line = doc.getLine(row - 1);
+        var indent = this.$getIndent(line);
+        var match = line.match(/^\s+(pass|return|raise)\b/);
+        
+        if (match) {
+            indent -= tab;
+        }
+        
+        return indent;
     };
 
 }).call(Mode.prototype);


### PR DESCRIPTION
I'm not sure I did this in right way, but this is quite useful when you're writing python code
