### PR TITLE
Coffee: Highlight `property:` and `@property`

### DIFF
--- a/lib/ace/mode/coffee_highlight_rules.js
+++ b/lib/ace/mode/coffee_highlight_rules.js
@@ -53,7 +53,13 @@ define(function(require, exports, module) {
             start : [
                 {
                     token : "identifier",
-                    regex : "(?:@|(?:\\.|::)\\s*)" + identifier
+                    regex : "(?:(?:\\.|::)\\s*)" + identifier
+                }, {
+                    token : "variable",
+                    regex : "@" + identifier
+                }, {
+                    token : "label",
+                    regex : identifier + ":"
                 }, {
                     token : "keyword",
                     regex : "(?:t(?:h(?:is|row|en)|ry|ypeof)|s(?:uper|witch)|return|b(?:reak|y)|c(?:ontinue|atch|lass)|i(?:n(?:stanceof)?|s(?:nt)?|f)|e(?:lse|xtends)|f(?:or (?:own)?|inally|unction)|wh(?:ile|en)|n(?:ew|ot?)|d(?:e(?:lete|bugger)|o)|loop|o(?:ff?|[rn])|un(?:less|til)|and|yes)"

--- a/lib/ace/theme/twilight.js
+++ b/lib/ace/theme/twilight.js
@@ -183,6 +183,9 @@ color:#5F5A60;\
 .ace-twilight .ace_variable {\
   color:#7587A6;\
 }\
+.ace-twilight .ace_label {\
+  color:#AC885B;\
+}\
 \
 .ace-twilight .ace_variable.ace_language {\
   \


### PR DESCRIPTION
Before and after:

![](https://img.skitch.com/20110905-r5jx722xy46fjab2j5x95fmd8k.png)

I added a "label" token type and colored it in ace/theme/twilight.js. Is there a better way to go about getting that brown color?
