### PR TITLE
Don't hardcode protocol to Google Fonts.

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Droid+Sans+Mono);
+@import url(//fonts.googleapis.com/css?family=Droid+Sans+Mono);
 
 
 .ace_editor {


### PR DESCRIPTION
Without this change, using Ace on an SSL page throws a
mixed content warning:

![](https://img.skitch.com/20110906-8xhu97awwbeyjf6bsgawj4y7d6.png)
