### PR TITLE
bindings should not be over-normalized  if (key is set to null it should stay

### DIFF
--- a/lib/ace/keyboard/state_handler.js
+++ b/lib/ace/keyboard/state_handler.js
@@ -64,7 +64,8 @@ StateHandler.prototype = {
             if (binding.key) {
                 binding.key = new RegExp('^' + binding.key + '$');
             } else if (Array.isArray(binding.regex)) {
-                binding.key = new RegExp('^' + binding.regex[1] + '$');
+                if (!('key' in binding))
+                  binding.key = new RegExp('^' + binding.regex[1] + '$');
                 binding.regex = new RegExp(binding.regex.join('') + '$');
             } else if (binding.regex) {
                 binding.regex = new RegExp(binding.regex + '$');


### PR DESCRIPTION
Currently bindings normalization makes it impossible to implement some of keybindings in vim. For example:

'i' - means switch to insert mode
'ti' - means means move cursor to the following 'i' char on the line

binding.key is generated form regex so that i will be executed instead of ti. To avoid that I set `binding.key` to `null` and would expect ace to don't override this (this change does exactly that). 
