### PR TITLE
Search's FindAll has issues when cursor is in the middle of the line.

### DIFF
--- a/lib/ace/search.js
+++ b/lib/ace/search.js
@@ -98,10 +98,20 @@ Search.SELECTION = 2;
             iterator = this.$forwardMatchIterator(session);
         }
 
+        var ignoreCursorColumn = this.$options.wrap && this.$options.scope == Search.ALL;
+        var start = session.getSelection().getCursor();
+        if (ignoreCursorColumn) {
+            session.getSelection().moveCursorTo(0, 0);
+        }
+
         var ranges = [];
         iterator.forEach(function(range) {
             ranges.push(range);
         });
+
+        if (ignoreCursorColumn) {
+            session.getSelection().moveCursorTo(start.row, start.column)
+        }
 
         return ranges;
     };

--- a/lib/ace/search_test.js
+++ b/lib/ace/search_test.js
@@ -348,6 +348,24 @@ module.exports = {
         assert.equal(search.replace("ab12", "$$"), "$");
     },
 
+    "test: find all using regular expresion containing $" : function() {
+        var session = new EditSession(["a", "     b", "c ", "d"]);
+
+        var search = new Search().set({
+            needle: "[ ]+$",
+            regExp: true,
+            wrap: true,
+            scope: Search.ALL
+        });
+
+        session.getSelection().moveCursorTo(1, 2);
+        var ranges = search.findAll(session);
+
+        assert.equal(ranges.length, 1);
+        assert.position(ranges[0].start, 2, 1);
+        assert.position(ranges[0].end, 2, 2);
+    },
+
     "test: find all matches in a line" : function() {
         var session = new EditSession("foo bar foo baz foobar foo");
 
@@ -362,12 +380,12 @@ module.exports = {
         var ranges = search.findAll(session);
 
         assert.equal(ranges.length, 3);
-        assert.position(ranges[0].start, 0, 8);
-        assert.position(ranges[0].end, 0, 11);
-        assert.position(ranges[1].start, 0, 23);
-        assert.position(ranges[1].end, 0, 26);
-        assert.position(ranges[2].start, 0, 0);
-        assert.position(ranges[2].end, 0, 3);
+        assert.position(ranges[0].start, 0, 0);
+        assert.position(ranges[0].end, 0, 3);
+        assert.position(ranges[1].start, 0, 8);
+        assert.position(ranges[1].end, 0, 11);
+        assert.position(ranges[2].start, 0, 23);
+        assert.position(ranges[2].end, 0, 26);
     },
 
     "test: find all matches in a line backwards" : function() {
@@ -385,12 +403,12 @@ module.exports = {
         var ranges = search.findAll(session);
 
         assert.equal(ranges.length, 3);
-        assert.position(ranges[0].start, 0, 8);
-        assert.position(ranges[0].end, 0, 11);
-        assert.position(ranges[1].start, 0, 0);
-        assert.position(ranges[1].end, 0, 3);
-        assert.position(ranges[2].start, 0, 23);
-        assert.position(ranges[2].end, 0, 26);
+        assert.position(ranges[0].start, 0, 23);
+        assert.position(ranges[0].end, 0, 26);
+        assert.position(ranges[1].start, 0, 8);
+        assert.position(ranges[1].end, 0, 11);
+        assert.position(ranges[2].start, 0, 0);
+        assert.position(ranges[2].end, 0, 3);
     },
 };
 


### PR DESCRIPTION
Search's [findAll](https://github.com/ajaxorg/ace/blob/master/lib/ace/search.js#L91) currently splits the line the cursor is located on.

For example `findAll` run against the text below using the regex /x$/

**`^` is the cursor**

```
xxxxx
xx^xxy
xxxxz
```

It splits line 1 into `xx` and `xxy` because the cursor is there. This will return two matches, a correct match from line 0, and an incorrect match from line 1.

This patch fixes that problem by moving the cursor to column 0 before `findAll` is called. This is only needed when wrapping is `true` and the scope is `all`. It moves the cursor back after `findAll` is done searching.

The problem isn't limited to regular expressions, the same bug would appear if you did `findAll` using `xxxx`
