### PR TITLE
Bugfix/no paste event on indent

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -792,7 +792,7 @@ var Editor =function(renderer, session) {
                 indentString = lang.stringRepeat(" ", count);
             } else
                 indentString = "\t";
-            return this.onTextInput(indentString);
+            return this.onTextInput(indentString, true);
         }
     };
 


### PR DESCRIPTION
Hitting Tab key to indent causes a paste event to be erroneously fired
