### PR TITLE
Text inserted even though there is a keyhandler

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -541,7 +541,7 @@ var Editor = function(renderer, session) {
             // make the `text` get sent to the keyboardHandler twice, which might
             // turn out to be a bad thing in case there is a custome keyboard
             // handler like the StateHandler.
-            if (!handled) {
+            if (handled===false) {
                 this.insert(text);
             }
         } else {


### PR DESCRIPTION
Fixes an issue where !handled cannot be avoided as it is either false or undefined.
It is undefined because the exec doesn't return anything.
