### PR TITLE
Fixes inability to stop keyevents when a non command key is binded

### DIFF
--- a/lib/ace/commands/command_manager.js
+++ b/lib/ace/commands/command_manager.js
@@ -77,7 +77,7 @@ var CommandManager = function(commands) {
         if (typeof command === 'string')
             command = this.commands[command];
         
-        command.exec(env, args || {});
+        return command.exec(env, args || {});
     };
 
 }).call(CommandManager.prototype);


### PR DESCRIPTION
allows exec to return something other than undefined - this is needed to stop keyevents
