### PR TITLE
Can we add open and close angle brackets to the list of items highlighted as a tag?

### DIFF
--- a/lib/ace/mode/html_highlight_rules.js
+++ b/lib/ace/mode/html_highlight_rules.js
@@ -51,7 +51,7 @@ var HtmlHighlightRules = function() {
             token : "string",
             regex : '".*?"'
         }, {
-            token : "string", // multi line string start
+            token : "meta.tag", // multi line string start
             merge : true,
             regex : '["].*$',
             next : state + "-qqstring"
@@ -59,7 +59,7 @@ var HtmlHighlightRules = function() {
             token : "string",
             regex : "'.*?'"
         }, {
-            token : "string", // multi line string start
+            token : "meta.tag", // multi line string start
             merge : true,
             regex : "['].*$",
             next : state + "-qstring"
@@ -68,7 +68,7 @@ var HtmlHighlightRules = function() {
     
     function multiLineString(quote, state) {
         return [{
-            token : "string",
+            token : "meta.tag",
             merge : true,
             regex : ".*" + quote,
             next : state
@@ -97,9 +97,12 @@ var HtmlHighlightRules = function() {
         states[name + "-qqstring"] = multiLineString("\"", name);
         
         states[name + "embed-attribute-list"] = [{
-            token : "text",
+            token : "meta.tag",
             regex : ">",
             next : nextState
+        }, {
+            token : "meta.tag",
+            regex : "="
         }, {
             token : "entity.other.attribute-name",
             regex : "[-_a-zA-Z0-9:]+"
@@ -114,7 +117,7 @@ var HtmlHighlightRules = function() {
 
     this.$rules = {
         start : [ {
-            token : "text",
+            token : "meta.tag",
             merge : true,
             regex : "<\\!\\[CDATA\\[",
             next : "cdata"
@@ -127,15 +130,15 @@ var HtmlHighlightRules = function() {
             regex : "<\\!--",
             next : "comment"
         }, {
-            token : "text",
+            token : "meta.tag",
             regex : "<(?=\s*script)",
             next : "script"
         }, {
-            token : "text",
+            token : "meta.tag",
             regex : "<(?=\s*style)",
             next : "css"
         }, {
-            token : "text", // opening tag
+            token : "meta.tag", // opening tag
             regex : "<\\/?",
             next : "tag"
         }, {
@@ -176,17 +179,17 @@ var HtmlHighlightRules = function() {
     tag(this.$rules, "script", "js-start");
     
     this.embedRules(JavaScriptHighlightRules, "js-", [{
-        token: "comment",
+        token: "meta.tag",
         regex: "\\/\\/.*(?=<\\/script>)",
         next: "tag"
     }, {
-        token: "text",
+        token: "meta.tag",
         regex: "<\\/(?=script)",
         next: "tag"
     }]);
     
     this.embedRules(CssHighlightRules, "css-", [{
-        token: "text",
+        token: "meta.tag",
         regex: "<\\/(?=style)",
         next: "tag"
     }]);


### PR DESCRIPTION
Hi there,
I'll submit the contribution agreement tomorrow. In the mean time, do you think it'd be a good idea to also highlight < and >'s in the HTML editor? Seems like all the other code editors highlight them this way.
