### PR TITLE
fix for binding ctrl-;

### DIFF
--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -277,7 +277,7 @@ function normalizeCommandKeys(callback, e, keyCode) {
     // If there is no hashID and the keyCode is not a function key, then
     // we don't call the callback as we don't handle a command key here
     // (it's a normal key/character input).
-    if (!(keyCode in keys.FUNCTION_KEYS) && !(keyCode in keys.PRINTABLE_KEYS)) {
+    if (!hashId && !(keyCode in keys.FUNCTION_KEYS) && !(keyCode in keys.PRINTABLE_KEYS)) {
         return false;
     }
     return callback(e, hashId, keyCode);


### PR DESCRIPTION
It is no longer possible to achieve some bindings like ctrl-;. This fixes it.

To get the binding you actually have to use "Ctrl-º" (as returned by keyCodeToString).
