### PR TITLE
Fix contextMenu when accessing editor requires scrolling

### DIFF
--- a/lib/ace/mouse/default_handlers.js
+++ b/lib/ace/mouse/default_handlers.js
@@ -96,7 +96,7 @@ function DefaultHandlers(editor) {
                 editor.moveCursorToPosition(pos);
             }
             if(button == 2) {
-                editor.textInput.onContextMenu({x: pageX, y: pageY}, selectionEmpty);
+                editor.textInput.onContextMenu({x: ev.clientX, y: ev.clientY}, selectionEmpty);
                 event.capture(editor.container, function(){}, editor.textInput.onContextMenuClose);
             }
             return;

--- a/lib/ace/mouse/mouse_event.js
+++ b/lib/ace/mouse/mouse_event.js
@@ -51,6 +51,9 @@ var MouseEvent = exports.MouseEvent = function(domEvent, editor) {
     this.pageX = event.getDocumentX(domEvent);
     this.pageY = event.getDocumentY(domEvent);
     
+    this.clientX = domEvent.clientX;
+    this.clientY = domEvent.clientY;
+
     this.$pos = null;
     this.$inSelection = null;
     


### PR DESCRIPTION
When editor is not at the top of the page (requires scrolling), textarea
right-click context menu will fail to appear.

Use clientX and clientY which returns the relative coordinates instead
of pageX and pageY.

Image attached for better illustration - notice the browser vertical scroll bar:
Without scrolling (works fine): http://i40.tinypic.com/1icsq8.png
When scrolled (breaks - shown wrong context menu): http://i42.tinypic.com/14cfyi8.png
