### PR TITLE
Avoids multiple duplicate messages in the gutter title

### DIFF
--- a/lib/ace/layer/gutter.js
+++ b/lib/ace/layer/gutter.js
@@ -84,7 +84,9 @@ var Gutter = function(parentEl) {
             };
             for (var i=0; i<rowAnnotations.length; i++) {
                 var annotation = rowAnnotations[i];
-                rowInfo.text.push(annotation.text.replace(/"/g, "&quot;").replace(/'/g, "&#8217;").replace(/</, "&lt;"));
+                var annoText = annotation.text.replace(/"/g, "&quot;").replace(/'/g, "&#8217;").replace(/</, "&lt;");
+                if (rowInfo.text.indexOf(annoText) === -1)
+                    rowInfo.text.push(annoText);
                 var type = annotation.type;
                 if (type == "error")
                     rowInfo.className = "ace_error";


### PR DESCRIPTION
If multiple annotations have the same message, only one will be shown when hovering over the gutter annotation.

@sergi @fjakobs
