### PR TITLE
Increase z-index of textarea so it works with jQuery dialogs with modal=...

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -84,7 +84,7 @@
 
 .ace_editor textarea {
     position: fixed;
-    z-index: -1;
+    z-index: 2000;
     width: 10px;
     height: 30px;
     opacity: 0;


### PR DESCRIPTION
So, when you use the modal=true dialog in jQueryUI, the editor stops working altogether. This tiny CSS change fixes the whole issue.
