### PR TITLE
Numer of items replaced

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -1093,8 +1093,8 @@ var Editor = function(renderer, session) {
         if (options)
             this.$search.set(options);
 
-        var range = this.$search.find(this.session),
-            replaced = 0;
+        var range = this.$search.find(this.session);
+        var replaced = 0;
         if (!range)
             return replaced;
 
@@ -1112,8 +1112,8 @@ var Editor = function(renderer, session) {
             this.$search.set(options);
         }
 
-        var ranges = this.$search.findAll(this.session),
-            replaced = 0;
+        var ranges = this.$search.findAll(this.session);
+        var replaced = 0;
         if (!ranges.length)
             return replaced;
 


### PR DESCRIPTION
For giving useful feedback to the user, replace and replaceAll should return the number of items replaced. Of course, for 'replace' that number will be 0 or 1. 
@gissues:{"order":19.25465838509346,"status":"backlog"}
