### PR TITLE
Minor fix in README file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,7 @@ After the checkout Ace works out of the box. No build step is required. Open 'ed
 Or using Node.JS
 
 ```bash
+    npm install mime
     ./static.js
 ```
 


### PR DESCRIPTION
The node mini HTTP server requires node-mime, which isn't part of the default node.js package.
@gissues:{"order":7.453416149068603,"status":"backlog"}
