### PR TITLE
Make sure that Ace looks good on Windows & Linux too

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -4,7 +4,7 @@
 .ace_editor {
     position: absolute;
     overflow: hidden;
-    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Droid Sans Mono', 'Courier New', monospace;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Droid Sans Mono', 'Consolas', monospace;
     font-size: 12px;
 }
 


### PR DESCRIPTION
Default monospace font on Windows is now Consolas, which is a great one, then remove Courier New, because monospace is better on Linux systems; and if there is no nice monospace font it'll fall back to Courier anyway.

@fjakobs
