### PR TITLE
fix for #618: Editor gets blocked when typing <style type="

### DIFF
--- a/lib/ace/mode/coldfusion_highlight_rules.js
+++ b/lib/ace/mode/coldfusion_highlight_rules.js
@@ -70,7 +70,7 @@ var ColdfusionHighlightRules = function() {
         }, {
             token : "meta.tag",
             regex : "<(?=\s*style)",
-            next : "css"
+            next : "style"
         }, {
             token : "meta.tag", // opening tag
             regex : "<\\/?",
@@ -109,7 +109,7 @@ var ColdfusionHighlightRules = function() {
     };
     
     xml_util.tag(this.$rules, "tag", "start");
-    xml_util.tag(this.$rules, "css", "css-start");
+    xml_util.tag(this.$rules, "style", "css-start");
     xml_util.tag(this.$rules, "script", "js-start");
     
     this.embedRules(JavaScriptHighlightRules, "js-", [{

--- a/lib/ace/mode/html_highlight_rules.js
+++ b/lib/ace/mode/html_highlight_rules.js
@@ -69,7 +69,7 @@ var HtmlHighlightRules = function() {
         }, {
             token : "meta.tag",
             regex : "<(?=\s*style\\b)",
-            next : "css"
+            next : "style"
         }, {
             token : "meta.tag", // opening tag
             regex : "<\\/?",
@@ -108,7 +108,7 @@ var HtmlHighlightRules = function() {
     };
     
     xmlUtil.tag(this.$rules, "tag", "start");
-    xmlUtil.tag(this.$rules, "css", "css-start");
+    xmlUtil.tag(this.$rules, "style", "css-start");
     xmlUtil.tag(this.$rules, "script", "js-start");
     
     this.embedRules(JavaScriptHighlightRules, "js-", [{

--- a/lib/ace/mode/xml_util.js
+++ b/lib/ace/mode/xml_util.js
@@ -56,7 +56,7 @@ function string(state) {
         token : "string", // multi line string start
         merge : true,
         regex : '["].*',
-        next : state + "-qqstring"
+        next : state + "_qqstring"
     }, {
         token : "string",
         regex : "'.*?'"
@@ -64,7 +64,7 @@ function string(state) {
         token : "string", // multi line string start
         merge : true,
         regex : "['].*",
-        next : state + "-qstring"
+        next : state + "_qstring"
     }];
 }
 
@@ -113,17 +113,17 @@ exports.tag = function(states, name, nextState) {
         },        
         merge : true,
         regex : "[-_a-zA-Z0-9:!]+",
-        next : name + "embed-attribute-list" 
+        next : name + "_embed_attribute_list" 
     }, {
         token: "empty",
         regex: "",
-        next : name + "embed-attribute-list"
+        next : name + "_embed_attribute_list"
     }];
 
-    states[name + "-qstring"] = multiLineString("'", name + "embed-attribute-list");
-    states[name + "-qqstring"] = multiLineString("\"", name + "embed-attribute-list");
+    states[name + "_qstring"] = multiLineString("'", name + "_embed_attribute_list");
+    states[name + "_qqstring"] = multiLineString("\"", name + "_embed_attribute_list");
     
-    states[name + "embed-attribute-list"] = [{
+    states[name + "_embed_attribute_list"] = [{
         token : "meta.tag",
         merge : true,
         regex : "\/?>",


### PR DESCRIPTION
happened when rule name had the same prefix as embedded language name
