### PR TITLE
Fix for IE8 and jQuery 1.7.1 compatibility.

### DIFF
--- a/lib/ace/lib/regexp.js
+++ b/lib/ace/lib/regexp.js
@@ -42,7 +42,7 @@ define(function(require, exports, module) {
     RegExp.prototype.exec = function (str) {
         var match = real.exec.apply(this, arguments),
             name, r2;
-        if (match) {
+        if ( typeof(str) == 'string' && match) {
             // Fix browsers whose `exec` methods don't consistently return `undefined` for
             // nonparticipating capturing groups
             if (!compliantExecNpcg && match.length > 1 && indexOf(match, "") > -1) {


### PR DESCRIPTION
Hi everyone:

This fixes issue #628, the "undefined" error that occurs in IE8 when using Ace and jQuery 1.7.1 on the same page. Didn't write a test for it since this is an edge case of all edge cases, but hope that's okay.

Cheers,
Bernie
