### PR TITLE
Call onLoad in the non-browser case.

### DIFF
--- a/lib/ace/requirejs/text.js
+++ b/lib/ace/requirejs/text.js
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
             require("ace/lib/net").get(req.toUrl(name), onLoad);
         else
             //Using special require.nodeRequire, something added by r.js.
-            globalRequire.nodeRequire('fs').readFileSync(req.toUrl(name), 'utf8');
+            onLoad(globalRequire.nodeRequire('fs').readFileSync(req.toUrl(name), 'utf8'));
     };
 });
 


### PR DESCRIPTION
This allows the r.js optimizer to work when building projects that include ace from source. It should be done anyway, to indicate the load of the resource was successful.
