### PR TITLE
Patch/consistent gutter width

### DIFF
--- a/lib/ace/layer/gutter.js
+++ b/lib/ace/layer/gutter.js
@@ -106,6 +106,15 @@ var Gutter = function(parentEl) {
         }
     };
 
+    // Pad this number to the width of the last line number in the session
+    this.pad = function(n) {
+        function countDigits(num) {
+            return (num + "").length;
+        }
+        var delta = countDigits(this.session.getLength()) - countDigits(n);
+        return Array(delta+1).join("\u00A0") + n;
+    };
+
     this.update = function(config) {
         this.$config = config;
 
@@ -132,7 +141,7 @@ var Gutter = function(parentEl) {
                 this.$breakpoints[i] ? " ace_breakpoint " : " ",
                 annotation.className,
                 "' title='", annotation.text.join("\n"),
-                "' style='height:", config.lineHeight, "px;'>", (i+1));
+                "' style='height:", config.lineHeight, "px;'>", this.pad(i+1));
 
             if (foldWidgets) {
                 var c = foldWidgets[i];


### PR DESCRIPTION
This patch changes the gutter auto-sizing behavior so that the gutter is always wide enough to display the largest line number. This eliminates the gutter resizing that currently happens as you merely scroll up and down in the document.

It also fixes a bug that causes Ace to freeze hard in certain conditions--essentially when lots of text is free-wrapping, and the gutter decides to resize, it's very easy to get into a situation where the renderloop's update call never returns. I can write up repro steps and additional analysis about that one if you decide not to accept this pull request.
