### PR TITLE
remove trailing commas

### DIFF
--- a/lib/ace/mode/php_highlight_rules.js
+++ b/lib/ace/mode/php_highlight_rules.js
@@ -1046,7 +1046,7 @@ var PhpHighlightRules = function() {
             }, {
                 token : "string",
                 regex : '[^"]+'
-            }, 
+            }
         ],
         "qstring" : [
             {
@@ -1094,7 +1094,7 @@ var PhpHighlightRules = function() {
                  next : "htmltag"
              }, {
                  token : "meta.tag",
-                 regex : ">",
+                 regex : ">"
              }, {
                  token : 'text',
                  regex : "(?:media|type|href)"
@@ -1104,7 +1104,7 @@ var PhpHighlightRules = function() {
              }, {
                  token : "paren.lparen",
                  regex : "\{",
-                 next : "cssdeclaration",
+                 next : "cssdeclaration"
              }, {
                  token : "keyword",
                  regex : "#[A-Za-z0-9\-\_\.]+"
@@ -1146,7 +1146,7 @@ var PhpHighlightRules = function() {
                    regex : ";",
                    next : "cssdeclaration"
                }
-         ],
+         ]
     };
 
     this.embedRules(DocCommentHighlightRules, "doc-",


### PR DESCRIPTION
I have removed trailing commas, wich cause google closure compiler error:
"Parse error. Internet Explorer has a non-standart intepretation of trailing commas."
I know, this is not really error, standarts allow using trailing commas, but no need to use it here.
