### PR TITLE
Fix editor.find for search selections

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -1180,7 +1180,9 @@ var Editor = function(renderer, session) {
     };
 
     this.find = function(needle, options) {
-        this.clearSelection();
+        if (options.scope != Search.SELECTION) {
+            this.clearSelection();
+        }
         options = options || {};
         options.needle = needle;
         this.$search.set(options);
@@ -1204,9 +1206,6 @@ var Editor = function(renderer, session) {
     };
 
     this.$find = function(backwards) {
-        if (!this.selection.isEmpty())
-            this.$search.set({needle: this.session.getTextRange(this.getSelectionRange())});
-
         if (typeof backwards != "undefined")
             this.$search.set({backwards: backwards});
 


### PR DESCRIPTION
Man oh man did this one make me mad.

I couldn't figure out why kitchen sink's search selection, or the search selection tests, were working just fine...but [the Cloud9 one wasn't](https://github.com/ajaxorg/cloud9/issues/1222). Weren't they just hooking into the same system?

Apparently, not quite. in two different places. _The selection is always cleared_, regardless of the search type. To be honest, I'm not even sure what those lines in `$find` are doing: "if something is selected, set that to the needle." 

Huh? Why would you want to do that? It screws up the selection search in a second way.
