### PR TITLE
Modify where keyboard cut/copy can come from

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -129,9 +129,12 @@ var TextInput = function(parentNode, host) {
 
     var onCopy = function(e) {
         copied = true;
+        outsideCopyText = "";
         var copyText = host.getCopyText();
-        if(copyText)
+        if(copyText) {
             text.value = copyText;
+            host.onCopy();
+        }
         else
             e.preventDefault();
         select();
@@ -142,6 +145,7 @@ var TextInput = function(parentNode, host) {
     
     var onCut = function(e) {
         copied = true;
+        outsideCopyText = "";
         var copyText = host.getCopyText();
         if(copyText) {
             text.value = copyText;
@@ -153,6 +157,17 @@ var TextInput = function(parentNode, host) {
             sendText();
         }, 0);
     };
+
+    // these emit methods can be used for outside of the keyboard command context
+    this.emitCut = function() {
+        onCut();
+        outsideCopyText = text.value;
+    }
+
+    this.emitCopy = function() {
+        onCopy();
+        outsideCopyText = text.value;
+    }
 
     event.addCommandKeyListener(text, host.onCommandKey.bind(host));
     if (useragent.isOldIE) {
@@ -178,7 +193,10 @@ var TextInput = function(parentNode, host) {
         // Some browsers support the event.clipboardData API. Use this to get
         // the pasted content which increases speed if pasting a lot of lines.
         if (e.clipboardData && e.clipboardData.getData) {
-            sendText(e.clipboardData.getData("text/plain"));
+            if (outsideCopyText.length > 0)
+                sendText(outsideCopyText);
+            else
+                sendText(e.clipboardData.getData("text/plain"));
             e.preventDefault();
         } 
         else {


### PR DESCRIPTION
We want the cut/copy to also potentially come from a non-keyboard command. This was the only way I could see getting that to work.

To use, do, for example, `editor.textInput.emitCut(ace);`
