### PR TITLE
a document change now doesn't scroll the cursor into view

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -282,6 +282,14 @@ var Editor = function(renderer, session) {
         this._emit("blur");
     };
 
+    function cursorChange() {
+        this.renderer.updateCursor();
+
+        // move text input over the cursor
+        // this is required for iOS and IME
+        this.renderer.moveTextAreaToCursor(this.textInput.getElement());
+    }
+
     this.onDocumentChange = function(e) {
         var delta = e.data;
         var range = delta.range;
@@ -296,7 +304,7 @@ var Editor = function(renderer, session) {
         this._emit("change", e);
 
         // update cursor because tab characters can influence the cursor position
-        this.onCursorChange();
+        cursorChange.call(this);
     };
 
     this.onTokenizerUpdate = function(e) {
@@ -313,15 +321,11 @@ var Editor = function(renderer, session) {
     };
 
     this.onCursorChange = function() {
-        this.renderer.updateCursor();
+        cursorChange.call(this);
 
         if (!this.$blockScrolling) {
             this.renderer.scrollCursorIntoView();
         }
-
-        // move text input over the cursor
-        // this is required for iOS and IME
-        this.renderer.moveTextAreaToCursor(this.textInput.getElement());
 
         this.$highlightBrackets();
         this.$updateHighlightActiveLine();
@@ -1239,7 +1243,7 @@ var Editor = function(renderer, session) {
                 var cursor = this.getCursorPosition();
                 if (!this.isRowFullyVisible(cursor.row))
                     this.scrollToLine(cursor.row, true);
-    
+
                 //@todo scroll X
                 //if (!this.isColumnFullyVisible(cursor.column))
                     //this.scrollToRow(cursor.column);


### PR DESCRIPTION
@fjakobs like we discussed before, this change prevents incoming change messages from, for example, concorde to make the viewport scroll to the change. This is not the desired behavior when collaborating on a document with multiple people.
