### PR TITLE
Ace bookmarklet settings table is obstructed by gutter

### DIFF
--- a/build/textarea/src/ace-bookmarklet.js
+++ b/build/textarea/src/ace-bookmarklet.js
@@ -413,7 +413,7 @@ exports.transformTextarea = function(element, loader) {
         right: "0px",
         bottom: "0px",
         position: "absolute",
-        padding: "5px 5px 5px 50px",
+        padding: "5px 5px 5px 65px",
         zIndex: 100,
         color: "white",
         display: "none",


### PR DESCRIPTION
In the Ace bookmarklet (http://ajaxorg.github.com/ace/build/textarea/editor.html) if the gutter is enabled, the settings table is obstructed and the 'hide' button cannot be seen or pressed.

This fix just adds some left padding, so that the table is across from the edge so it can be seen regardless of the gutter being present.
