### PR TITLE
improve default keybindings

### DIFF
--- a/lib/ace/commands/default_commands.js
+++ b/lib/ace/commands/default_commands.js
@@ -72,22 +72,22 @@ exports.commands = [{
     readOnly: true
 }, {
     name: "fold",
-    bindKey: bindKey("Alt-L", "Alt-L"),
+    bindKey: bindKey("Alt-L|Ctrl-F1", "Command-Alt-L|Command-F1"),
     exec: function(editor) { editor.session.toggleFold(false); },
     readOnly: true
 }, {
     name: "unfold",
-    bindKey: bindKey("Alt-Shift-L", "Alt-Shift-L"),
+    bindKey: bindKey("Alt-Shift-L|Ctrl-Shift-F1", "Command-Alt-Shift-L|Command-Shift-F1"),
     exec: function(editor) { editor.session.toggleFold(true); },
     readOnly: true
 }, {
     name: "foldall",
-    bindKey: bindKey("Alt-0", "Alt-0"),
+    bindKey: bindKey("Alt-0", "Command-Option-0"),
     exec: function(editor) { editor.session.foldAll(); },
     readOnly: true
 }, {
     name: "unfoldall",
-    bindKey: bindKey("Alt-Shift-0", "Alt-Shift-0"),
+    bindKey: bindKey("Alt-Shift-0", "Command-Option-Shift-0"),
     exec: function(editor) { editor.session.unfold(); },
     readOnly: true
 }, {
@@ -110,17 +110,17 @@ exports.commands = [{
     readOnly: true
 }, {
     name: "overwrite",
-    bindKey: bindKey("Insert", "Insert"),
+    bindKey: "Insert",
     exec: function(editor) { editor.toggleOverwrite(); },
     readOnly: true
 }, {
     name: "selecttostart",
-    bindKey: bindKey("Ctrl-Shift-Home|Alt-Shift-Up", "Command-Shift-Up"),
+    bindKey: bindKey("Ctrl-Shift-Home", "Command-Shift-Up"),
     exec: function(editor) { editor.getSelection().selectFileStart(); },
     readOnly: true
 }, {
     name: "gotostart",
-    bindKey: bindKey("Ctrl-Home|Ctrl-Up", "Command-Home|Command-Up"),
+    bindKey: bindKey("Ctrl-Home", "Command-Home|Command-Up"),
     exec: function(editor) { editor.navigateFileStart(); },
     readOnly: true
 }, {
@@ -137,13 +137,13 @@ exports.commands = [{
     readOnly: true
 }, {
     name: "selecttoend",
-    bindKey: bindKey("Ctrl-Shift-End|Alt-Shift-Down", "Command-Shift-Down"),
+    bindKey: bindKey("Ctrl-Shift-End", "Command-Shift-Down"),
     exec: function(editor) { editor.getSelection().selectFileEnd(); },
     multiSelectAction: "forEach",
     readOnly: true
 }, {
     name: "gotoend",
-    bindKey: bindKey("Ctrl-End|Ctrl-Down", "Command-End|Command-Down"),
+    bindKey: bindKey("Ctrl-End", "Command-End|Command-Down"),
     exec: function(editor) { editor.navigateFileEnd(); },
     multiSelectAction: "forEach",
     readOnly: true
@@ -233,43 +233,53 @@ exports.commands = [{
     readOnly: true
 }, {
     name: "selectpagedown",
-    bindKey: bindKey("Shift-PageDown", "Shift-PageDown"),
+    bindKey: "Shift-PageDown",
     exec: function(editor) { editor.selectPageDown(); },
     readOnly: true
 }, {
     name: "pagedown",
-    bindKey: bindKey(null, "PageDown"),
+    bindKey: bindKey(null, "Option-PageDown"),
     exec: function(editor) { editor.scrollPageDown(); },
     readOnly: true
 }, {
     name: "gotopagedown",
-    bindKey: bindKey("PageDown", "Option-PageDown|Ctrl-V"),
+    bindKey: bindKey("PageDown", "PageDown|Ctrl-V"),
     exec: function(editor) { editor.gotoPageDown(); },
     readOnly: true
 }, {
     name: "selectpageup",
-    bindKey: bindKey("Shift-PageUp", "Shift-PageUp"),
+    bindKey: "Shift-PageUp",
     exec: function(editor) { editor.selectPageUp(); },
     readOnly: true
 }, {
     name: "pageup",
-    bindKey: bindKey(null, "PageUp"),
+    bindKey: bindKey(null, "Option-PageUp"),
     exec: function(editor) { editor.scrollPageUp(); },
     readOnly: true
 }, {
     name: "gotopageup",
-    bindKey: bindKey("PageUp", "Option-PageUp"),
+    bindKey: "PageUp",
     exec: function(editor) { editor.gotoPageUp(); },
     readOnly: true
 }, {
+    name: "scrollup",
+    bindKey: bindKey("Ctrl-Up", null),
+    exec: function(e) { e.renderer.scrollBy(0, -2 * e.renderer.layerConfig.lineHeight); },
+    readOnly: true
+}, {
+    name: "scrolldown",
+    bindKey: bindKey("Ctrl-Down", null),
+    exec: function(e) { e.renderer.scrollBy(0, 2 * e.renderer.layerConfig.lineHeight); },
+    readOnly: true
+}, {
     name: "selectlinestart",
-    bindKey: bindKey("Shift-Home", "Shift-Home"),
+    bindKey: "Shift-Home",
     exec: function(editor) { editor.getSelection().selectLineStart(); },
     multiSelectAction: "forEach",
     readOnly: true
 }, {
     name: "selectlineend",
-    bindKey: bindKey("Shift-End", "Shift-End"),
+    bindKey: "Shift-End",
     exec: function(editor) { editor.getSelection().selectLineEnd(); },
     multiSelectAction: "forEach",
     readOnly: true
@@ -348,7 +358,7 @@ exports.commands = [{
     exec: function(editor) { editor.redo(); }
 }, {
     name: "copylinesup",
-    bindKey: bindKey("Ctrl-Alt-Up", "Command-Option-Up"),
+    bindKey: bindKey("Alt-Shift-Up", "Command-Option-Up"),
     exec: function(editor) { editor.copyLinesUp(); }
 }, {
     name: "movelinesup",
@@ -356,7 +366,7 @@ exports.commands = [{
     exec: function(editor) { editor.moveLinesUp(); }
 }, {
     name: "copylinesdown",
-    bindKey: bindKey("Ctrl-Alt-Down", "Command-Option-Down"),
+    bindKey: bindKey("Alt-Shift-Down", "Command-Option-Down"),
     exec: function(editor) { editor.copyLinesDown(); }
 }, {
     name: "movelinesdown",


### PR DESCRIPTION
on windows
   ctrl+up/down must scroll the page
   #750

on mac
   swap pageup and alt+pageup
   change folding keys to match textmate (#649, #643)
