### PR TITLE
Updated .gitmodules to replace the git:// protocol to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "doc/wiki"]
 	path = doc/wiki
-	url = git://github.com/ajaxorg/ace.wiki.git
+	url = https://github.com/ajaxorg/ace.wiki.git


### PR DESCRIPTION
Updated .gitmodules to replace the git:// protocol to https:// because of possible firewall issues.
