### PR TITLE
static_highlight should enable control over gutter rendering

### DIFF
--- a/lib/ace/ext/static_highlight.js
+++ b/lib/ace/ext/static_highlight.js
@@ -52,7 +52,7 @@ var baseStyles = require("../requirejs/text!./static.css");
 * @returns {object} An object containing: html, css
 */
 
-exports.render = function(input, mode, theme, lineStart) {
+exports.render = function(input, mode, theme, lineStart, disableGutter) {
     lineStart = parseInt(lineStart || 1, 10);
     
     var session = new EditSession("");
@@ -74,7 +74,8 @@ exports.render = function(input, mode, theme, lineStart) {
     for(var ix = 0; ix < length; ix++) {
         var lineTokens = session.getTokens(ix);
         stringBuilder.push("<div class='ace_line'>");
-        stringBuilder.push("<span class='ace_gutter ace_gutter-cell' unselectable='on'>" + (ix + lineStart) + "</span>");
+        if (!disableGutter)
+            stringBuilder.push("<span class='ace_gutter ace_gutter-cell' unselectable='on'>" + (ix + lineStart) + "</span>");
         textLayer.$renderLine(stringBuilder, 0, lineTokens, true);
         stringBuilder.push("</div>");
     }


### PR DESCRIPTION
There should be an option in static_highlight which controls gutter rendering. When highlighting code, sometimes the gutter is not desired.
