### PR TITLE
Update selection and active_line on resize event

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -280,6 +280,7 @@ var Editor = function(renderer, session) {
      **/
     this.resize = function(force) {
         this.renderer.onResize(force);
+    	this.onSelectionChange();
     };
 
     /**


### PR DESCRIPTION
This patch forces editor to refresh text selection or active line highlighting width when resizing editor.
