### PR TITLE
moved `devDependencies` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
          "url" : "http://github.com/ajaxorg/ace.git"
     },
     "dependencies": {
-        "mime": "1.2.x"
-    },
-    "devDependencies": {
+        "mime": "1.2.x",
         "asyncjs": "0.0.x",
         "jsdom": "0.2.x",
         "amd-loader": "~0.0.4",


### PR DESCRIPTION
Since all dependencies are needed in `postinstall` script they should be listed in `dependencies` rather than `devDependencies`.
