### PR TITLE
Add "KeyboardEvent" in window check for old Opera.

### DIFF
--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -268,7 +268,7 @@ function normalizeCommandKeys(callback, e, keyCode) {
 
 exports.addCommandKeyListener = function(el, callback) {
     var addListener = exports.addListener;
-    if (useragent.isOldGecko || useragent.isOpera && !("KeyboardEvent" in window)) {
+    if (useragent.isOldGecko || (useragent.isOpera && !("KeyboardEvent" in window))) {
         // Old versions of Gecko aka. Firefox < 4.0 didn't repeat the keydown
         // event if the user pressed the key for a longer time. Instead, the
         // keydown event was fired once and later on only the keypress event.


### PR DESCRIPTION
We've added support for DOM3 Keyboard Events (and cleaned up things)
generally--so the Opera specific workarounds won't be needed when those changes
land in a stable version of Opera. This change allows older versions
of Opera to continue working.
