### PR TITLE
Roll scroller width back (from css to js)

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -8,7 +8,6 @@
 .ace_scroller {
     position: absolute;
     overflow: hidden;
-    width : 100%;
 }
 
 .ace_content {

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -321,7 +321,7 @@ var VirtualRenderer = function(container, theme) {
             var gutterWidth = this.showGutter ? this.$gutter.offsetWidth : 0;
             this.scroller.style.left = gutterWidth + "px";
             size.scrollerWidth = Math.max(0, width - gutterWidth - this.scrollBar.getWidth());
-            //this.scroller.style.width = size.scrollerWidth + "px";
+            this.scroller.style.width = size.scrollerWidth + "px";
 
             if (this.session.getUseWrapMode() && this.adjustWrapLimit() || force)
                 changes = changes | this.CHANGE_FULL;


### PR DESCRIPTION
width: 100% does not consider gutter.
So, let set width by js. Or we can set "right" property when initializing and know scrollbar width.
