### PR TITLE
Restore Emacs up key binding

### DIFF
--- a/lib/ace/commands/default_commands.js
+++ b/lib/ace/commands/default_commands.js
@@ -295,7 +295,7 @@ exports.commands = [{
     readOnly: true
 }, {
     name: "jumptomatching",
-    bindKey: bindKey("Ctrl-P", "Ctrl-P"),
+    bindKey: bindKey("Ctrl-Shift-P", "Ctrl-Shift-P"),
     exec: function(editor) { editor.jumpToMatching(); },
     multiSelectAction: "forEach",
     readOnly: true


### PR DESCRIPTION
Broken by 689bed38ffabf99463df94b450db2adb560dcf79

This is shadowing the default emacs cursor up binding.

Doesn't make much sense to support `ctrl-n` (down), `ctrl-b` (left), `ctrl-f` (right) and not up anymore.
