### PR TITLE
Fixed typo in text.js plugin that caused r.js to fail building

### DIFF
--- a/lib/ace/requirejs/text.js
+++ b/lib/ace/requirejs/text.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
     exports.load = function (name, req, onLoad, config) {
         //Using special require.nodeRequire, something added by r.js.
         if (globalRequire && globalRequire.nodeRequire)
-            onLoad(('fs').readFileSync(req.toUrl(name), 'utf8'));
+            onLoad(fs.readFileSync(req.toUrl(name), 'utf8'));
         else
             require("ace/lib/net").get(req.toUrl(name), onLoad);
     };


### PR DESCRIPTION
The bug was introduced in commit: https://github.com/pahen/ace/commit/3cc878f4c1550857986a27858577b2ca579a8397
