### PR TITLE
Defer gutter refresh until cursor is rendered

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -491,8 +491,14 @@ var VirtualRenderer = function(container, theme) {
     };
 
     this.$updateGutterLineHighlight = function() {
-        this.$gutterLineHighlight.style.top = this.$cursorLayer.$pixelPos.top - this.layerConfig.offset + "px";
-        this.$gutterLineHighlight.style.height = this.layerConfig.lineHeight + "px";
+      if (this.$cursorLayer.$pixelPos) {
+          this.$gutterLineHighlight.style.top = this.$cursorLayer.$pixelPos.top - this.layerConfig.offset + "px";
+          this.$gutterLineHighlight.style.height = this.layerConfig.lineHeight + "px";
+      } else {
+          // Defer gutter refresh until cursor renders
+          var editor = this;
+          setTimeout(function() { editor.$updateGutterLineHighlight(); }, 0);
+        }
     };
     
     this.$updatePrintMargin = function() {


### PR DESCRIPTION
`setHighlightGutterLine` crashes if you try to call it immediately after initializing an editor.

``` js
editor = ace.edit(div)
editor.setHighlightGutterLine(false)
```

Fixes regression from 0e5b77763f6433137837d328c6edf38c6403bb56

This doesn't seem like a great fix though. My the cursor should be rendered sooner? Or maybe the first line doesn't really even need to run if thats the case?
