### PR TITLE
Line numbers should start from 1

### DIFF
--- a/lib/ace/layer/gutter.js
+++ b/lib/ace/layer/gutter.js
@@ -129,7 +129,7 @@ var Gutter = function(parentEl) {
                 breakpoints[i] ? " ace_breakpoint " : " ",
                 annotation.className,
                 "' title='", annotation.text.join("\n"),
-                "' style='height:", this.session.getRowLength(i) * config.lineHeight, "px;'>", (i));
+                "' style='height:", this.session.getRowLength(i) * config.lineHeight, "px;'>", (i+1));
 
             if (foldWidgets) {
                 var c = foldWidgets[i];


### PR DESCRIPTION
A recent change caused line number display in the gutter to start counting from 0 instead of 1.
