### PR TITLE
fix binding single keys

### DIFF
--- a/lib/ace/keyboard/keybinding.js
+++ b/lib/ace/keyboard/keybinding.js
@@ -132,7 +132,7 @@ var KeyBinding = function(editor) {
     };
 
     this.onTextInput = function(text) {
-        var success = this.$callKeyboardHandlers(-1, text);
+        var success = this.$callKeyboardHandlers(0, text);
         if (!success)
             this.$editor.commands.exec("insertstring", this.$editor, text);
     };


### PR DESCRIPTION
fix binding of single keys (i.e. non ctrl keys like ",< etc).

This worked before but was changed in:
a2a304390700e44141c014c52c47bf2344394dc6
