### PR TITLE
Correct fold-widget style

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -260,15 +260,15 @@
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
 
-    margin: 0 -12px 1px 1px;
+    margin: 0 -12px 0 1px;
     display: inline-block;
-    height: 14px;
+    height: 100%;
     width: 11px;
-    vertical-align: text-bottom;
+    vertical-align: bottom;
 
     background-image: url("data:image/png,%89PNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%05%00%00%00%05%08%06%00%00%00%8Do%26%E5%00%00%004IDATx%DAe%8A%B1%0D%000%0C%C2%F2%2CK%96%BC%D0%8F9%81%88H%E9%D0%0E%96%C0%10%92%3E%02%80%5E%82%E4%A9*-%EEsw%C8%CC%11%EE%96w%D8%DC%E9*Eh%0C%151(%00%00%00%00IEND%AEB%60%82");
     background-repeat: no-repeat;
-    background-position: center 4px;
+    background-position: center;
 
     border-radius: 3px;
     
@@ -289,7 +289,6 @@
     -moz-box-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
     -webkit-box-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
     box-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
-    background-position: center 4px;
 }
 
 .ace_fold-widget:active {


### PR DESCRIPTION
Little stylefix for a fold widget:

Corrected vertical alignment of gutter number and fold widget.
Set height: 100% for fold widget, centered arrow.

This improvements are observable on either small or big font size.
