### PR TITLE
Update lib/ace/mode/markdown_highlight_rules.js

### DIFF
--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -73,7 +73,7 @@ var MarkdownHighlightRules = function() {
             token: "markup.heading.1",
             regex: "^=+(?=\\s*$)"
         }, { // h2
-            token: "markup.heading.1",
+            token: "markup.heading.2",
             regex: "^\\-+(?=\\s*$)"
         }, { // header
             token : function(value) {


### PR DESCRIPTION
fix typo of "h2" highlight rule
