### PR TITLE
Fix   Cannot read property 'env' of null

### DIFF
--- a/lib/ace/ace.js
+++ b/lib/ace/ace.js
@@ -65,7 +65,10 @@ exports.config = require("./config");
      **/
 exports.edit = function(el) {
     if (typeof(el) == "string") {
-        el = document.getElementById(el);
+        var _id = el;
+        if (!(el = document.getElementById(el))) {
+          console.log("can't match div #" + _id);
+        }
     }
 
     if (el.env && el.env.editor instanceof Editor)


### PR DESCRIPTION
Display verbose debug information in the console log.
