### PR TITLE
Fix ctrl+wheel issue

### DIFF
--- a/lib/ace/mouse/default_handlers.js
+++ b/lib/ace/mouse/default_handlers.js
@@ -44,7 +44,7 @@ function DefaultHandlers(mouseHandler) {
     editor.setDefaultHandler("dblclick", this.onDoubleClick.bind(mouseHandler));
     editor.setDefaultHandler("tripleclick", this.onTripleClick.bind(mouseHandler));
     editor.setDefaultHandler("quadclick", this.onQuadClick.bind(mouseHandler));
-    editor.setDefaultHandler("mousewheel", this.onScroll.bind(mouseHandler));
+    editor.setDefaultHandler("mousewheel", this.onMouseWheel.bind(mouseHandler));
 
     var exports = ["select", "startSelect", "drag", "dragEnd", "dragWait",
         "dragWaitEnd", "startDrag", "focusWait"];
@@ -298,7 +298,10 @@ function DefaultHandlers(mouseHandler) {
         this.setState("null");
     };
 
-    this.onScroll = function(ev) {
+    this.onMouseWheel = function(ev) {
+        if (ev.getShiftKey() || ev.getAccelKey()){
+            return;
+        }
         var editor = this.editor;
         var isScrolable = editor.renderer.isScrollableBy(ev.wheelX * ev.speed, ev.wheelY * ev.speed);
         if (isScrolable) {


### PR DESCRIPTION
Fix https://github.com/ajaxorg/ace/issues/948

Ctrl+wheel should not be captured by ace, as far as Shift++.

Default shift +wheel  behavior is h-scrolling (Chrome) or history walking (IE, FF).

Maybe to force shift +wheel  to horizontal scrolling in all browsers ?

I have renamed onScroll to onMouseWheel, because this is mousewheel event handler, not scroll event.

Sorry, i mean ctrl+wheel instead of ctr++ :)
