### PR TITLE
Revert "don't build on install"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "lib": "lib/ace"
     },
     "scripts": {
-        "test": "node lib/ace/test/all.js"
+        "test": "node lib/ace/test/all.js",
+        "postinstall": "node ./install.js"
     },
     "config": {
         "github.com/sourcemint/bundler-js/0/-meta/config/0": {


### PR DESCRIPTION
This reverts commit 36685c4f8a38abdcc974ce70dd3b261ea39efd37, which included a necessary build step used in Cloud9. And at the very least it's a great sanity check.

See also ajaxorg/cloud9#2261

@ajaxorg/liskov 
