### PR TITLE
Fix JS highlight rules embedded in Jade

### DIFF
--- a/lib/ace/mode/jade_highlight_rules.js
+++ b/lib/ace/mode/jade_highlight_rules.js
@@ -120,11 +120,11 @@ var JadeHighlightRules = function() {
             "token": [ "storage.type.function.jade", "entity.name.function.jade"],
             "regex": "^(\\s*mixin)( [\\w\\-]+)"
         },
-       /* {
+        {
             "token": "source.js.embedded.jade",
-            "regex": "^\\s*-|=|!=",
-            "next": "js_code"
-        },*/
+            "regex": "^\\s*(?:-|=|!=)",
+            "next": "js-start"
+        },
         /*{
             "token": "entity.name.tag.script.jade",
             "regex": "^\\s*script",
@@ -219,7 +219,21 @@ var JadeHighlightRules = function() {
             "next": "start"
         }
     ],
-    "tag_attributes": [
+    "tag_attributes": [ 
+        {
+            "token" : "string",
+            "regex" : "'(?=.)",
+            "next"  : "qstring"
+        }, 
+        {
+            "token" : "string",
+            "regex" : '"(?=.)',
+            "next"  : "qqstring"
+        },
+        {
+            "token": "entity.other.attribute-name.jade",
+            "regex": "\\b[a-zA-Z\\-:]+"
+        },
         {
             "token": ["entity.other.attribute-name.jade", "punctuation"],
             "regex": "\\b([a-zA-Z:\\.-]+)(=)",
@@ -284,6 +298,12 @@ var JadeHighlightRules = function() {
         }
     ]
 };
+
+    this.embedRules(JavaScriptHighlightRules, "js-", [{
+        token: "text",
+        regex: ".$",
+        next: "start"
+    }]);
 /*
     this.embedRules(MarkdownHighlightRules, "markdown-", [{
        token : "support.function",


### PR DESCRIPTION
oops! I just noticed that JS highlighting rules embedded in Jade were not being highlighted. I'm not sure why I didn't do this in the beginning, maybe I forgot to get back to it?
