### PR TITLE
Fix #654: double clicking php vars selects the $ sign

### DIFF
--- a/lib/ace/mode/text.js
+++ b/lib/ace/mode/text.js
@@ -47,14 +47,14 @@ var Mode = function() {
         + unicode.packages.L
         + unicode.packages.Mn + unicode.packages.Mc
         + unicode.packages.Nd
-        + unicode.packages.Pc + "\\$_]+", "g"
+        + unicode.packages.Pc + "\_]+", "g"
     );
     
     this.nonTokenRe = new RegExp("^(?:[^"
         + unicode.packages.L
         + unicode.packages.Mn + unicode.packages.Mc
         + unicode.packages.Nd
-        + unicode.packages.Pc + "\\$_]|\s])+", "g"
+        + unicode.packages.Pc + "\_]|\s])+", "g"
     );
 
     this.getTokenizer = function() {


### PR DESCRIPTION
Fix for #654

In most editors (even textarea), double-clicking a php var selects just the variable name and not the $ sign. Ace selects both.
