### PR TITLE
Fix double click php var selects the $ sign #2

### DIFF
--- a/lib/ace/mode/php.js
+++ b/lib/ace/mode/php.js
@@ -39,6 +39,7 @@ var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutd
 var Range = require("../range").Range;
 var CstyleBehaviour = require("./behaviour/cstyle").CstyleBehaviour;
 var CStyleFoldMode = require("./folding/cstyle").FoldMode;
+var unicode = require("../unicode");
 
 var Mode = function() {
     this.$tokenizer = new Tokenizer(new PhpHighlightRules().getRules());
@@ -49,6 +50,20 @@ var Mode = function() {
 oop.inherits(Mode, TextMode);
 
 (function() {
+
+    this.tokenRe = new RegExp("^["
+        + unicode.packages.L
+        + unicode.packages.Mn + unicode.packages.Mc
+        + unicode.packages.Nd
+        + unicode.packages.Pc + "\_]+", "g"
+    );
+    
+    this.nonTokenRe = new RegExp("^(?:[^"
+        + unicode.packages.L
+        + unicode.packages.Mn + unicode.packages.Mc
+        + unicode.packages.Nd
+        + unicode.packages.Pc + "\_]|\s])+", "g"
+    );
 
     this.toggleCommentLines = function(state, doc, startRow, endRow) {
         var outdent = true;


### PR DESCRIPTION
Fix #654: double clicking php vars selects the $ sign 

@nightwing
