### PR TITLE
Actually fix "Cannot read property env of null"

### DIFF
--- a/lib/ace/ace.js
+++ b/lib/ace/ace.js
@@ -67,7 +67,7 @@ exports.edit = function(el) {
     if (typeof(el) == "string") {
         var _id = el;
         if (!(el = document.getElementById(el))) {
-          console.log("can't match div #" + _id);
+            return false;
         }
     }
 


### PR DESCRIPTION
Previous "Cannot read property env of null" commit only logged an a message to console and didn't prevent script continuing (and therefore failing)
