### PR TITLE
Selective bracket insertion/skipping

### DIFF
--- a/lib/ace/mode/behaviour/cstyle.js
+++ b/lib/ace/mode/behaviour/cstyle.js
@@ -88,8 +88,6 @@ var CstyleBehaviour = function () {
 
     this.add("braces", "insertion", function (state, action, editor, session, text) {
         if (text == '{') {
-            if (!CstyleBehaviour.isSaneInsertion(editor, session))
-                return;
             var selection = editor.getSelectionRange();
             var selected = session.doc.getTextRange(selection);
             if (selected !== "" && selected !== "{") {
@@ -97,7 +95,7 @@ var CstyleBehaviour = function () {
                     text: '{' + selected + '}',
                     selection: false
                 };
-            } else {
+            } else if (CstyleBehaviour.isSaneInsertion(editor, session)) {
                 CstyleBehaviour.recordAutoInsert(editor, session, "}");
                 return {
                     text: '{}',
@@ -152,8 +150,6 @@ var CstyleBehaviour = function () {
 
     this.add("parens", "insertion", function (state, action, editor, session, text) {
         if (text == '(') {
-            if (!CstyleBehaviour.isSaneInsertion(editor, session))
-                return;
             var selection = editor.getSelectionRange();
             var selected = session.doc.getTextRange(selection);
             if (selected !== "") {
@@ -161,7 +157,7 @@ var CstyleBehaviour = function () {
                     text: '(' + selected + ')',
                     selection: false
                 };
-            } else {
+            } else if (CstyleBehaviour.isSaneInsertion(editor, session)) {
                 CstyleBehaviour.recordAutoInsert(editor, session, ")");
                 return {
                     text: '()',
@@ -199,8 +195,6 @@ var CstyleBehaviour = function () {
 
     this.add("brackets", "insertion", function (state, action, editor, session, text) {
         if (text == '[') {
-            if (!CstyleBehaviour.isSaneInsertion(editor, session))
-                return;
             var selection = editor.getSelectionRange();
             var selected = session.doc.getTextRange(selection);
             if (selected !== "") {
@@ -208,7 +202,7 @@ var CstyleBehaviour = function () {
                     text: '[' + selected + ']',
                     selection: false
                 };
-            } else {
+            } else if (CstyleBehaviour.isSaneInsertion(editor, session)) {
                 CstyleBehaviour.recordAutoInsert(editor, session, "]");
                 return {
                     text: '[]',


### PR DESCRIPTION
This changes bracket insertion to address #758. Essentially, it makes bracket insertion and closing bracket skipping more context-sensitive.
- For insertion, it looks at the current token and the token that follow the cursor.
- For the bracket skipping, it maintains a stack of "hot" closing brackets that the user can type over. So if you type `((()))` you get `((()))` but if you see a syntax error in some code like `foo(bar()` and type a new `)` it will still add that `)`.

I hope that with this we can enable bracket insertion by default in Cloud9 without it getting in the way. IDEs like Visual Studio and Eclipse have it enabled by default with similar techniques.

@ajaxorg/liskov @gjtorikian 
