### PR TITLE
Put tooltip to bottom

### DIFF
--- a/demo/kitchen-sink/token_tooltip.js
+++ b/demo/kitchen-sink/token_tooltip.js
@@ -146,11 +146,9 @@ var TokenTooltip = function(editor) {
         var st = tooltipNode.style;
         if (x + 10 + this.tooltipWidth > this.maxWidth)
             x = innerWidth - this.tooltipWidth - 10;
-        if (y > innerHeight * 0.75 || y + 20 + this.tooltipHeight > this.maxHeight);
-            y = y - this.tooltipHeight - 30;
         
         st.left = x + 10 + "px";
-        st.top = y + 20 + "px";
+        st.top = y + "px";
     };
 
     this.$init = function() {


### PR DESCRIPTION
When you try to get the tooltip at the top of a document, the mode creator tool obscures the info: http://screencast.com/t/LakUqOpYEcbz

This pushes the tooltip to be below the mouse.
