### PR TITLE
Fix contextual menu in Chrome (Windows)

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -325,7 +325,7 @@ var TextInput = function(parentNode, host) {
             host.renderer.$keepTextAreaAtCursor = null;
 
         // on windows context menu is opened after mouseup
-        if (useragent.isWin && (useragent.isGecko || useragent.isIE))
+        if (useragent.isWin)
             event.capture(host.container, function(e) {
                 text.style.left = e.clientX - 2 + "px";
                 text.style.top = e.clientY - 2 + "px";


### PR DESCRIPTION
Press right mouse button, move mouse a bit, release button. You get webpage context menu instead of editable element one.
