### PR TITLE
Fix bad type return

### DIFF
--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -779,7 +779,7 @@ var EditSession = function(text, mode) {
     * Returns the annotations for the `EditSession`.
     **/
     this.getAnnotations = function() {
-        return this.$annotations || {};
+        return this.$annotations || [];
     };
 
     /**


### PR DESCRIPTION
`this.$annotations` is always an Array, but the return type when `this.$annotations` is falsy is an object. This commit fixes that.

@ajaxorg/liskov @nightwing 
