### PR TITLE
Make wrapping behavior optional 

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -1025,7 +1025,9 @@ var Editor = function(renderer, session) {
      * Editor.setBehavioursEnabled(enabled) 
      * - enabled (Boolean): Enables or disables behaviors
      * 
-     * Specifies whether to use behaviors or not. ["Behaviors" in this case is the auto-pairing of special characters, like quotation marks, parenthesis, or brackets.]{: #BehaviorsDef}
+     * Specifies whether to use behaviors or not.
+     * See [[Editor.setWrapBehavioursEnabled]].
+     * ["Behaviors" in this case is the auto-pairing of special characters, like quotation marks, parenthesis, or brackets.]{: #BehaviorsDef}
      **/
     this.setBehavioursEnabled = function (enabled) {
         this.$modeBehaviours = enabled;
@@ -1038,6 +1040,28 @@ var Editor = function(renderer, session) {
      **/
     this.getBehavioursEnabled = function () {
         return this.$modeBehaviours;
+    };
+
+    this.$modeWrapBehaviours = true;
+
+    /**
+     * Editor.setWrapBehavioursEnabled(enabled) 
+     * - enabled (Boolean): Enables or disables wrapping behaviors
+     * 
+     * Specifies whether to use wrapping behaviors or not, i.e. automatically wrapping the selection with characters such as brackets
+     * when such a character is typed in.
+     **/
+    this.setWrapBehavioursEnabled = function (enabled) {
+        this.$modeWrapBehaviours = enabled;
+    };
+
+    /**
+     * Editor.getWrapBehavioursEnabled() -> Boolean
+     * 
+     * Returns `true` if the wrapping behaviors are currently enabled.
+     **/
+    this.getWrapBehavioursEnabled = function () {
+        return this.$modeWrapBehaviours;
     };
 
     /**

--- a/lib/ace/mode/behaviour/cstyle.js
+++ b/lib/ace/mode/behaviour/cstyle.js
@@ -126,7 +126,7 @@ var CstyleBehaviour = function () {
         if (text == '{') {
             var selection = editor.getSelectionRange();
             var selected = session.doc.getTextRange(selection);
-            if (selected !== "" && selected !== "{") {
+            if (selected !== "" && selected !== "{" && editor.getWrapBehavioursEnabled()) {
                 return {
                     text: '{' + selected + '}',
                     selection: false
@@ -199,7 +199,7 @@ var CstyleBehaviour = function () {
         if (text == '(') {
             var selection = editor.getSelectionRange();
             var selected = session.doc.getTextRange(selection);
-            if (selected !== "") {
+            if (selected !== "" && editor.getWrapBehavioursEnabled()) {
                 return {
                     text: '(' + selected + ')',
                     selection: false
@@ -244,7 +244,7 @@ var CstyleBehaviour = function () {
         if (text == '[') {
             var selection = editor.getSelectionRange();
             var selected = session.doc.getTextRange(selection);
-            if (selected !== "") {
+            if (selected !== "" && editor.getWrapBehavioursEnabled()) {
                 return {
                     text: '[' + selected + ']',
                     selection: false
@@ -290,7 +290,7 @@ var CstyleBehaviour = function () {
             var quote = text;
             var selection = editor.getSelectionRange();
             var selected = session.doc.getTextRange(selection);
-            if (selected !== "" && selected !== "'" && selected != '"') {
+            if (selected !== "" && selected !== "'" && selected != '"' && editor.getWrapBehavioursEnabled()) {
                 return {
                     text: quote + selected + quote,
                     selection: false


### PR DESCRIPTION
This makes the textual wrapping behavior optional, but still enabled by default.
