### PR TITLE
[Trivial] Add a postfix option for WorkerClients

### DIFF
--- a/lib/ace/worker/worker_client.js
+++ b/lib/ace/worker/worker_client.js
@@ -35,14 +35,14 @@ var oop = require("../lib/oop");
 var EventEmitter = require("../lib/event_emitter").EventEmitter;
 var config = require("../config");
 
-var WorkerClient = function(topLevelNamespaces, mod, classname) {
+var WorkerClient = function(topLevelNamespaces, mod, classname, urlPostfix) {
     this.changeListener = this.changeListener.bind(this);
     this.onMessage = this.onMessage.bind(this);
     this.onError = this.onError.bind(this);
 
     var workerUrl;
     if (config.get("packaged")) {
-        workerUrl = config.moduleUrl(mod, "worker");
+        workerUrl = config.moduleUrl(mod, "worker") + (urlPostfix || "");
     } else {
         var normalizePath = this.$normalizePath;
         if (typeof require.supports !== "undefined" && require.supports.indexOf("ucjs2-pinf-0") >= 0) {


### PR DESCRIPTION
To avoid browser caching, it can be useful to add a postfix to the URL of a worker file, e.g. `/worker-language.js?uniqueId=3551`. This adds an additional parameter to the WorkerClient do just that.

@ajaxorg/liskov 
