### PR TITLE
do not mess with global require

### DIFF
--- a/build_support/mini_require.js
+++ b/build_support/mini_require.js
@@ -42,24 +42,9 @@ var global = (function() {
     return this;
 })();
 
-// take care of the case when requirejs is used and we just need to patch it a little bit
-if (!ACE_NAMESPACE && typeof requirejs !== "undefined") {
 
-    var define = global.define;
-    global.define = function(id, deps, callback) {
-        if (typeof callback !== "function")
-            return define.apply(this, arguments);
-
-        return define(id, deps, function(require, exports, module) {
-            if (deps[2] == "module")
-                module.packaged = true;
-            return callback.apply(this, arguments);
-        });
-    };
-    global.define.packaged = true;
-
+if (!ACE_NAMESPACE && typeof requirejs !== "undefined")
     return;
-}
 
 
 var _define = function(module, deps, payload) {


### PR DESCRIPTION
this was breaking 

``` js
define("text!foo.xml", [], function() {})
```

calls for require.js 2

and module.packaged isn't used anywhere (google search for it shows only our code:)
