### PR TITLE
NEAR operator

### DIFF
--- a/lib/ace/mode/lucene_highlight_rules.js
+++ b/lib/ace/mode/lucene_highlight_rules.js
@@ -21,8 +21,8 @@ var LuceneHighlightRules = function() {
                 token: 'constant.character.proximity',
                 regex: '~[0-9]+\\b'
             }, {
-                token : 'keyword.operator',
-                regex: '(?:AND|OR|NOT)\\b'
+                token: 'keyword.operator',
+                regex: '(?:AND|OR|NOT|NEAR/[1-9][0-9]*)\\b'
             }, {
                 token : "paren.lparen",
                 regex : "[\\(]"

--- a/lib/ace/mode/lucene_highlight_rules_test.js
+++ b/lib/ace/mode/lucene_highlight_rules_test.js
@@ -16,6 +16,26 @@ module.exports = {
         this.tokenizer = new LuceneMode().getTokenizer();
     },
 
+    "test: recognises NEAR/1 as keyword" : function() {
+        var tokens = this.tokenizer.getLineTokens("NEAR/1 ", "start").tokens;
+        assert.equal("keyword.operator", tokens[0].type);
+    },
+
+    "test: recognises NEAR/100 as keyword" : function() {
+        var tokens = this.tokenizer.getLineTokens("NEAR/100", "start").tokens;
+        assert.equal("keyword.operator", tokens[0].type);
+    },
+
+    "test: does not recognise NEAR/0 as keyword" : function() {
+        var tokens = this.tokenizer.getLineTokens("NEAR", "start").tokens;
+        assert.notEqual("keyword.operator", tokens[0].type);
+    },
+
+     "test: does not recognise standalone NEAR as keyword" : function() {
+        var tokens = this.tokenizer.getLineTokens("NEAR", "start").tokens;
+        assert.notEqual("keyword.operator", tokens[0].type);
+    },
+
     "test: recognises AND as keyword" : function() {
         var tokens = this.tokenizer.getLineTokens("AND", "start").tokens;
         assert.equal("keyword.operator", tokens[0].type);


### PR DESCRIPTION
@grahamscott Ready for review. As discussed I've tweaked the regex by changing the + for a *, so that using NEAR with a single digit is recognised.
