### PR TITLE
[vim] ctrl-c acts as esc

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -88,7 +88,7 @@ exports.handler = {
         if (hashId == 1)
             key = "ctrl-" + key;
         
-        if ((key == "esc" && hashId == 0) || key == "ctrl-[") {
+        if ((key == "esc" && hashId == 0) || key == "ctrl-[" || key == "ctrl-c") {
             return {command: coreCommands.stop};
         } else if (data.state == "start") {
             if (useragent.isMac && this.handleMacRepeat(data, hashId, key)) {


### PR DESCRIPTION
http://vimdoc.sourceforge.net/htmldoc/insert.html#i_CTRL-C

> Quit insert mode, go back to Normal mode.  Do not check for
>         abbreviations.  Does not trigger the |InsertLeave| autocommand
>         event.

http://stackoverflow.com/questions/5030164/whats-the-difference-between-ctrlc-and-ctrl

> It helps to think of CTRL+C in vim the same way you think of CTRL+C in a shell - you want to stop whatever you were doing ASAP and get control back. So in vim, if you're using CTRL+C to break out of insert mode, vim isn't going to bother checking if you just wrote part of an abbreviation, and it isn't going to run the fancy auto commands your plugins have set up for every time you leave insert mode, it's just going to dump you back in normal mode as soon as it can. If you're not using abbreviations or autocmds, then you're not going to notice this difference.
