### PR TITLE
added 'themeChange' and 'themeLoaded' event

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -1281,7 +1281,7 @@ var VirtualRenderer = function(container, theme) {
         var _self = this;
 
         this.$themeValue = theme;
-        _self._dispatchEvent('themeChange',theme);
+        _self._dispatchEvent('themeChange',{theme:theme});
         
         if (!theme || typeof theme == "string") {
             var moduleName = theme || "ace/theme/textmate";
@@ -1332,7 +1332,7 @@ var VirtualRenderer = function(container, theme) {
                 _self.onResize();
             }
             
-            _self._dispatchEvent('themeLoaded');
+            _self._dispatchEvent('themeLoaded',{theme:theme});
         }
     };
 


### PR DESCRIPTION
added 'themeChange' event that is dispatched when the theme is about to change.

usage :
this.editor.renderer.on('themeChange',function(e){
    console.log('changing theme to ',e.theme);
});

added 'themeLoaded' event that is dispatched right after a theme is loaded.

usage :
this.editor.renderer.on('themeLoaded',function(e){
    console.log('theme loaded',e.theme);
});
