### PR TITLE
Autodetect workers during build instead of hardcoding them.

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -241,6 +241,13 @@ function jsFileList(path, filter) {
     }).filter(function(x){ return !!x });
 }
 
+function workers(path) {
+  return jsFileList(path).map(function(x) {
+    if (x.slice(-7) == "_worker")
+      return x.slice(0, -7);
+  }).filter(function(x) { return !!x; });
+}
+
 function addSuffix(options) {
     if (options.suffix == null) {
         options.suffix = "";
@@ -298,7 +305,7 @@ var buildAce = function(options) {
         modes: jsFileList("lib/ace/mode", /_highlight_rules|_test|_worker|xml_util|_outdent|behaviour/),
         themes: jsFileList("lib/ace/theme"),
         extensions: jsFileList("lib/ace/ext"),
-        workers: ["javascript", "coffee", "css", "json", "xquery"],
+        workers: workers("lib/ace/mode"),
         keybindings: ["vim", "emacs"]
     };
 


### PR DESCRIPTION
Currently to add a new mode I can just drop it in lib/ace/mode and it's automatically included in the build, but workers are hardcoded in Makefile.dryice.js, so I have to modify that file to add a worker.

This change "autodetects" workers by looking for all _worker files in lib/ace/mode.  

It has no behavioral impact, since presently it autodetects the set that was previously hardcoded (coffee, css, javascript, json, and xquery).
