### PR TITLE
Update lib/ace/lib/dom.js

### DIFF
--- a/lib/ace/lib/dom.js
+++ b/lib/ace/lib/dom.js
@@ -162,10 +162,11 @@ exports.importCssStylsheet = function(uri, doc) {
 };
 
 exports.getInnerWidth = function(element) {
+
     return (
         parseInt(exports.computedStyle(element, "paddingLeft"), 10) +
-        parseInt(exports.computedStyle(element, "paddingRight"), 10) + 
-        element.clientWidth
+
+        (element.clientWidth === 0) ? parseInt(exports.computedStyle(element, "width")) : element.clientWidth
     );
 };
 
@@ -173,7 +174,7 @@ exports.getInnerHeight = function(element) {
     return (
         parseInt(exports.computedStyle(element, "paddingTop"), 10) +
         parseInt(exports.computedStyle(element, "paddingBottom"), 10) +
-        element.clientHeight
+        (element.clientHeight === 0) ? parseInt(exports.computedStyle(element, "height")) : element.clientHeight
     );
 };
 


### PR DESCRIPTION
For IE only, element.clientWidth is 0 resulting in content of ACE not displayed.
