### PR TITLE
Fix error in IE8 when escapeRules is not passed

### DIFF
--- a/lib/ace/mode/text_highlight_rules.js
+++ b/lib/ace/mode/text_highlight_rules.js
@@ -81,9 +81,11 @@ var TextHighlightRules = function() {
         
         this.addRules(embedRules, prefix);
 
-        var addRules = Array.prototype[append ? "push" : "unshift"];
-        for (var i = 0; i < states.length; i++)
-            addRules.apply(this.$rules[states[i]], lang.deepCopy(escapeRules));       
+        if (escapeRules) {
+            var addRules = Array.prototype[append ? "push" : "unshift"];
+            for (var i = 0; i < states.length; i++)
+                addRules.apply(this.$rules[states[i]], lang.deepCopy(escapeRules));
+        }
 
         if (!this.$embeds)
             this.$embeds = [];


### PR DESCRIPTION
IE8 throws an "Object expected" error when editing a file in PHP mode. This is because one of the calls to `embedRules` in the PHP mode is not passing in the `escapeRules` parameter so it is trying to call `apply` with an undefined value.

Example:
`Array.protoype.unshift.apply([], undefined);`

IE9+, Firefox, and Chrome do not have this issue.

To fix we just need to make sure `escapeRules` is defined before trying to adjust the rules.

A quick grep through the code shows that the JSP mode would have the same error.
