### PR TITLE
Text cannot be dragged into a readOnly editor - fixes #1204 

### DIFF
--- a/lib/ace/commands/default_commands.js
+++ b/lib/ace/commands/default_commands.js
@@ -462,6 +462,9 @@ exports.commands = [{
     bindKey: bindKey("Ctrl-Shift-U", "Ctrl-Shift-U"),
     exec: function(editor) { editor.toLowerCase(); },
     multiSelectAction: "forEach"
+}, {
+    name: "drop",
+    exec: function(editor,args) { editor.drop(args.position, args.text); }
 }];
 
 });

--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -654,6 +654,13 @@ var Editor = function(renderer, session) {
         this.insert(text);
     };
 
+    this.drop = function(atPosition, text) {
+        var range = this.getSelectionRange();
+        range.start = atPosition;
+        range.end = this.session.insert(atPosition, text);
+        this.focus();
+        this.selection.setSelectionRange(range);
+    }
 
     this.execCommand = function(command, args) {
         this.commands.exec(command, this, args);

--- a/lib/ace/editor_text_edit_test.js
+++ b/lib/ace/editor_text_edit_test.js
@@ -545,6 +545,26 @@ module.exports = {
         editor.toLowerCase()
         assert.equal(session.getValue(), ["AJAX", "dot", "ORG"].join("\n"));
         assert.position(editor.getCursorPosition(), 1, 0);
+    },
+
+    "test: drop text at a given position inserts at that position": function() {
+        var session = new EditSession(["Drop something", "on me"]);
+        var editor = new Editor(new MockRenderer(), session);
+
+        editor.drop({row: 1, column: 3}, "top of ");
+
+        assert.equal(session.getValue(), ["Drop something", "on top of me"].join("\n"));
+    },
+
+    "test: drop text at a given position leaves dropped text selected": function() {
+        var session = new EditSession(["Drop something", "on me"]);
+        var editor = new Editor(new MockRenderer(), session);
+
+        editor.drop({row: 1, column: 3}, "top of ");
+
+        var range = editor.getSelectionRange();
+        assert.position(range.start, 1, 3);
+        assert.position(range.end, 1, 10);
     }
 };
 

--- a/lib/ace/mouse/dragdrop.js
+++ b/lib/ace/mouse/dragdrop.js
@@ -85,10 +85,7 @@ var DragdropHandler = function(mouseHandler) {
         editor.session.removeMarker(dragSelectionMarker);
         dragSelectionMarker = null;
 
-        range.end = editor.session.insert(dragCursor, e.dataTransfer.getData('Text'));
-        range.start = dragCursor;
-        editor.focus();
-        editor.selection.setSelectionRange(range);
+        editor.execCommand("drop", {position: dragCursor, text: e.dataTransfer.getData('Text')});
         return event.preventDefault(e);
     });
 


### PR DESCRIPTION
Implemented as a new command: 'drop' with readOnly: false

I have added tests around the new editor.drop, but not around the
original dragdrop.js which had nothing in place when it was written
