### PR TITLE
Add a Syntax Highlighter for the Curly template language

### DIFF
--- a/demo/kitchen-sink/doclist.js
+++ b/demo/kitchen-sink/doclist.js
@@ -72,6 +72,7 @@ var docs = {
     "docs/cpp.cpp": "C/C++",
     "docs/csharp.cs": "C#",
     "docs/css.css": "CSS",
+    "docs/curly.curly": "Curly",
     "docs/dart.dart": "Dart",
     "docs/diff.diff": "Diff",
     "docs/dot.dot": "Dot",

--- a/demo/kitchen-sink/docs/curly.curly
+++ b/demo/kitchen-sink/docs/curly.curly
@@ -1,0 +1,16 @@
+<html>
+    <head>
+
+    <style type="text/css">
+        .text-layer {
+            font-family: Monaco, "Courier New", monospace;
+            font-size: 12px;
+            cursor: text;
+        }
+    </style>
+
+    </head>
+    <body>
+        <h1 style="color:red">{{author_name}}</h1>
+    </body>
+</html>

--- a/demo/kitchen-sink/modelist.js
+++ b/demo/kitchen-sink/modelist.js
@@ -42,6 +42,7 @@ var modesByName = {
     coldfusion: ["ColdFusion"   , "cfm"],
     csharp:     ["C#"           , "cs"],
     css:        ["CSS"          , "css"],
+    curly:      ["Curly"        , "curly"],
     dart:       ["Dart"         , "dart"],
     diff:       ["Diff"         , "diff|patch"],
     dot:        ["Dot"          , "dot"],

--- a/lib/ace/mode/curly.js
+++ b/lib/ace/mode/curly.js
@@ -1,0 +1,88 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2012, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * Contributor(s):
+ *
+ * Libo Cannici <libo AT zendesk DOT com>
+ *
+ *
+ *
+ * ***** END LICENSE BLOCK ***** */
+define(function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+// defines the parent mode
+var HtmlMode = require("./html").Mode;
+var Tokenizer = require("../tokenizer").Tokenizer;
+var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutdent;
+var HtmlHighlightRules = require("./html_highlight_rules").HtmlHighlightRules;
+var HtmlFoldMode = require("./folding/html").FoldMode;
+
+// defines the language specific highlighters and folding rules
+var CurlyHighlightRules = require("./curly_highlight_rules").CurlyHighlightRules;
+
+var Mode = function() {
+    // set everything up
+    var highlighter = new CurlyHighlightRules();
+    this.$outdent = new MatchingBraceOutdent();
+    this.foldingRules = new HtmlFoldMode();
+
+    this.$tokenizer = new Tokenizer(highlighter.getRules());
+};
+oop.inherits(Mode, HtmlMode);
+
+(function() {
+    // Extra logic goes here--we won't be covering all of this
+
+    /* These are all optional pieces of code!
+    this.getNextLineIndent = function(state, line, tab) {
+        var indent = this.$getIndent(line);
+        return indent;
+    };
+
+    this.checkOutdent = function(state, line, input) {
+        return this.$outdent.checkOutdent(line, input);
+    };
+
+    this.autoOutdent = function(state, doc, row) {
+        this.$outdent.autoOutdent(doc, row);
+    };
+
+    this.createWorker = function(session) {
+        var worker = new WorkerClient(["ace"], "ace/mode/mynew_worker", "NewWorker");
+        worker.attachToDocument(session.getDocument());
+
+        return worker;
+    };
+    */
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+});

--- a/lib/ace/mode/curly_highlight_rules.js
+++ b/lib/ace/mode/curly_highlight_rules.js
@@ -1,0 +1,79 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2012, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * Contributor(s):
+ *
+ * Libo Cannici <libo AT zendesk DOT com>
+ *
+ *
+ *
+ * ***** END LICENSE BLOCK ***** */
+define(function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var HtmlHighlightRules = require("./html_highlight_rules").HtmlHighlightRules;
+
+
+var CurlyHighlightRules = function() {
+   var CurlyRules = {
+        "start" : [
+            {
+                token: "variable",
+                regex: "{{",
+                next: "curly_mode"
+            }
+        ],
+
+        "curly_mode" : [
+            {
+                token: "variable",
+                regex: "}}",
+                next: "start"
+            }
+        ]
+    };
+
+    var htmlRules = new HtmlHighlightRules().getRules();
+
+    // Inject Curly start array into HTML rules
+    htmlRules.start = CurlyRules.start.concat(htmlRules.start);
+
+    // Inject Mustach mode array into HTML rules
+    htmlRules.curly_mode = CurlyRules.curly_mode;
+
+    // Return the augmented HTML rules
+    this.$rules = htmlRules;
+};
+
+oop.inherits(CurlyHighlightRules, HtmlHighlightRules);
+
+exports.CurlyHighlightRules = CurlyHighlightRules;
+
+});

--- a/lib/ace/mode/curly_highlight_rules_test.js
+++ b/lib/ace/mode/curly_highlight_rules_test.js
@@ -1,0 +1,202 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+if (typeof process !== "undefined") {
+    require("amd-loader");
+}
+
+define(function(require, exports, module) {
+"use strict";
+
+var CurlyMode = require("./curly").Mode;
+var assert = require("../test/assertions");
+
+var testData = {
+    "test: tokenize Curly template" : [{
+        text: "{{test}}",
+        state: ["start", "start"],
+        tokens: [{
+            type: "variable",
+            value: "{{"
+        }, {
+            type: "text",
+            value: "test"
+        }, {
+            type: "variable",
+            value: "}}"
+        }]
+    }],
+
+    "test: tokenize embedded script" : [{
+        text: "<script a='a'>var</script>'123'",
+        state: ["start", "start"],
+        tokens: [{
+            type: "meta.tag",
+            value: "<"
+        }, {
+            type: "meta.tag.tag-name.script",
+            value: "script"
+        }, {
+            type: "text",
+            value: " "
+        }, {
+            type: "entity.other.attribute-name",
+            value: "a"
+        }, {
+            type: "keyword.operator",
+            value: "="
+        }, {
+            type: "string",
+            value: "'a'"
+        }, {
+            type: "meta.tag.r",
+            value: ">"
+        }, {
+            type: "storage.type",
+            value: "var"
+        }, {
+            type: "meta.tag",
+            value: "</"
+        }, {
+            type: "meta.tag.tag-name.script",
+            value: "script"
+        }, {
+            type: "meta.tag.r",
+            value: ">"
+        }, {
+            type: "text",
+            value: "'123'"
+        }]
+    }],
+
+    "test: tokenize multiline attribute value with double quotes": [{
+        text: "<a href=\"abc",
+        state: [ "start", "tag_qqstring"],
+        tokens: [{
+                type: "meta.tag",
+                value: "<"
+            }, {
+                type: "meta.tag.tag-name.anchor",
+                value: "a"
+            }, {
+                type: "text",
+                value: " "
+            }, {
+                type: "entity.other.attribute-name",
+                value: "href"
+            }, {
+                type: "keyword.operator",
+                value: "="
+            }, {
+                type: "string",
+                value: "\"abc"
+            }
+        ]
+    }, {
+        text: "def\">",
+        state: [ "tag_qqstring", "start" ],
+        tokens: [ {
+                type: "string",
+                value: "def\""
+            }, {
+                type: "meta.tag.r",
+                value: ">"
+            }
+        ]
+    }],
+
+    "test: tokenize multiline attribute value with single quotes": [{
+        text: "<a href='abc",
+        state: ["start", "tag_qstring"],
+        tokens: [{
+                type: "meta.tag",
+                value: "<"
+            }, {
+                type: "meta.tag.tag-name.anchor",
+                value: "a"
+            }, {
+                type: "text",
+                value: " "
+            }, {
+                type: "entity.other.attribute-name",
+                value: "href"
+            }, {
+                type: "keyword.operator",
+                value: "="
+            }, {
+                type: "string",
+                value: "'abc"
+            }
+        ]
+    }, {
+        text: "def\"'>",
+        state: [ "tag_qstring", "start" ],
+        tokens: [ {
+                type: "string",
+                value: "def\"'"
+            }, {
+                type: "meta.tag.r",
+                value: ">"
+            }
+        ]
+    }]
+};
+
+function generateTest(exampleData) {
+    return function testTokenizer() {
+        for (var i = 0; i < exampleData.length; i++) {
+            var s = exampleData[i];
+
+            var lineTokens = tokenizer.getLineTokens(s.text, s.state[0]);
+
+            assert.equal(
+                JSON.stringify(lineTokens, null, 4),
+                JSON.stringify({tokens:s.tokens, state: s.state[1]}, null, 4)
+            );
+        }
+    }
+}
+
+var tokenizer;
+module.exports = {
+    setUp : function() {
+        tokenizer = new CurlyMode().getTokenizer();
+    }
+}
+
+for (var i in testData) {
+    module.exports[i] = generateTest(testData[i])
+}
+
+});
+
+if (typeof module !== "undefined" && module === require.main) {
+    require("asyncjs").test.testcase(module.exports).exec();
+}


### PR DESCRIPTION
This is a very simple template language we use at Zendesk.
Basically it is a subset of http://mustache.github.com/ 

It's my first commit on Ace so I hope everything is fine. 
I think we might already have submitted a Corporate CLA from Zendesk, if not please let me know.
