### PR TITLE
Add ability to specify first line number

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -1098,6 +1098,28 @@ var Editor = function(renderer, session) {
     };
 
     /**
+     * Sets the number displayed in the gutter for the first line of code.
+     * @param firstLineNumber The number displayed in the gutter for the first line of code.
+     */
+    this.setFirstLineNumber = function(firstLineNumber) {
+      var gutter = this.renderer.$gutterLayer;
+      if (gutter.getFirstLineNumber() == firstLineNumber)
+        return;
+
+      this.renderer.$gutterLayer.setFirstLineNumber(firstLineNumber);
+      this.renderer.updateFull();
+    }
+
+    /**
+     * Returns the number displayed in the gutter for the first line of code.
+     * @return {*} The number displayed in the gutter for the first line of code.
+     */
+    this.getFirstLineNumber = function() {
+      var gutter = this.renderer.$gutterLayer;
+      return gutter.getFirstLineNumber();
+    }
+
+    /**
      * Removes words of text from the editor. A "word" is defined as a string of characters bookended by whitespace.
      * @param {String} dir The direction of the deletion to occur, either "left" or "right"
      * 

--- a/lib/ace/layer/gutter.js
+++ b/lib/ace/layer/gutter.js
@@ -43,6 +43,7 @@ var Gutter = function(parentEl) {
     this.setShowFoldWidgets(this.$showFoldWidgets);
     
     this.gutterWidth = 0;
+    this.$firstLineNumber = 1;
 
     this.$annotations = [];
     this.$updateAnnotations = this.$updateAnnotations.bind(this);
@@ -142,7 +143,7 @@ var Gutter = function(parentEl) {
                 "<div class='ace_gutter-cell ",
                 breakpoints[i] || "", decorations[i] || "", annotation.className,
                 "' style='height:", this.session.getRowLength(i) * config.lineHeight, "px;'>", 
-                lastLineNumber = i + 1
+                lastLineNumber = i + this.$firstLineNumber
             );
 
             if (foldWidgets) {
@@ -190,7 +191,15 @@ var Gutter = function(parentEl) {
         this.$showFoldWidgets = show;
         this.$padding = null;
     };
-    
+ 
+    this.setFirstLineNumber = function(firstLineNumber) {
+        this.$firstLineNumber = firstLineNumber;
+    }
+
+    this.getFirstLineNumber = function() {
+        return this.$firstLineNumber;
+    }
+
     this.getShowFoldWidgets = function() {
         return this.$showFoldWidgets;
     };


### PR DESCRIPTION
I've added the ability for developers to specify the first line number that ace displays. This is useful for displaying code snippets, where the first line of text might be the Nth line in a file. 

All you need to do is call "editor.setFirstLineNumber(lineNumber)"
