### PR TITLE
add event listener for double-click

### DIFF
--- a/lib/ace/mouse/mouse_handler.js
+++ b/lib/ace/mouse/mouse_handler.js
@@ -52,6 +52,8 @@ var MouseHandler = function(editor) {
 
     var mouseTarget = editor.renderer.getMouseEventTarget();
     event.addListener(mouseTarget, "click", this.onMouseEvent.bind(this, "click"));
+    event.addListener(mouseTarget, "dblclick", this.onMouseEvent.bind(this, "dblclick"));
+
     event.addListener(mouseTarget, "mousemove", this.onMouseMove.bind(this, "mousemove"));
     event.addMultiMouseDownListener(mouseTarget, [300, 300, 250], this, "onMouseEvent");
     event.addMouseWheelListener(editor.container, this.onMouseWheel.bind(this, "mousewheel"));


### PR DESCRIPTION
This needs more work, but it's a start toward fixing #956.

If this isn't the correct approach, something like this project may shed some light. It supposedly addresses this issue https://github.com/mckamey/doubleTap.js
