### PR TITLE
Use native e.detail click count in event.addMultiMouseDownListener

### DIFF
--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -180,16 +180,20 @@ exports.addMultiMouseDownListener = function(el, timeouts, eventHandler, callbac
         if (exports.getButton(e) != 0) {
             clicks = 0;
         } else {
-            var isNewClick = Math.abs(e.clientX - startX) > 5 || Math.abs(e.clientY - startY) > 5;
+            if (useragent.isGecko || useragent.isOldIE){
+                var isNewClick = Math.abs(e.clientX - startX) > 5 || Math.abs(e.clientY - startY) > 5;
 
-            if (!timer || isNewClick)
-                clicks = 0;
+                if (!timer || isNewClick)
+                    clicks = 0;
 
-            clicks += 1;
+                clicks += 1;
 
-            if (timer)
-                clearTimeout(timer)
-            timer = setTimeout(function() {timer = null}, timeouts[clicks - 1] || 600);
+                if (timer)
+                    clearTimeout(timer)
+                timer = setTimeout(function() {timer = null}, timeouts[clicks - 1] || 600);
+            } else {
+                clicks = (e.detail + 3) % 4 + 1;
+            }
         }
         if (clicks == 1) {
             startX = e.clientX;


### PR DESCRIPTION
Fixes https://github.com/ajaxorg/ace/issues/978 in non-gecko browsers .
WebKit need this to support native d'n'd properly.
