### PR TITLE
fix "char" is reserved word in bracket_match.js

### DIFF
--- a/lib/ace/edit_session/bracket_match.js
+++ b/lib/ace/edit_session/bracket_match.js
@@ -37,10 +37,10 @@ var Range = require("../range").Range;
 
 function BracketMatch() {
 
-    this.findMatchingBracket = function(position, char) {
+    this.findMatchingBracket = function(position, chr) {
         if (position.column == 0) return null;
 
-        var charBeforeCursor = char || this.getLine(position.row).charAt(position.column-1);
+        var charBeforeCursor = chr || this.getLine(position.row).charAt(position.column-1);
         if (charBeforeCursor == "") return null;
 
         var match = charBeforeCursor.match(/([\(\[\{])|([\)\]\}])/);


### PR DESCRIPTION
I found it when trying to compress by yui compressor
