### PR TITLE
Avoid creating too many timeout handlers

### DIFF
--- a/lib/ace/worker/mirror.js
+++ b/lib/ace/worker/mirror.js
@@ -8,7 +8,7 @@ var Mirror = exports.Mirror = function(sender) {
     this.sender = sender;
     var doc = this.doc = new Document("");
     
-    var deferredUpdate = this.deferredUpdate = lang.deferredCall(this.onUpdate.bind(this));
+    var deferredUpdate = this.deferredUpdate = lang.delayedCall(this.onUpdate.bind(this));
     
     var _self = this;
     sender.on("change", function(e) {


### PR DESCRIPTION
This fixes a Chrome crash, which can be reproduced on OSX by opening a JavaScript large file in the kitchen sink, selecting the contents, and holding command-/. It seems in that scenario, a new setTimeout() is done for every line commented/uncommented

@nightwing @mostafaeweda 
