### PR TITLE
Emacs improvements

### DIFF
--- a/lib/ace/keyboard/emacs.js
+++ b/lib/ace/keyboard/emacs.js
@@ -103,6 +103,7 @@ exports.handler.attach = function(editor) {
     editor.on("changeSession",$kbSessionChange);
     editor.renderer.screenToTextCoordinates = screenToTextBlockCoordinates;
     editor.setStyle("emacs-mode");
+    editor.commands.addCommands(commands);
     exports.handler.platform = editor.commands.platform;
 };
 
@@ -113,6 +114,7 @@ exports.handler.detach = function(editor) {
     editor.removeEventListener("click",$resetMarkMode);
     editor.removeEventListener("changeSession",$kbSessionChange);
     editor.unsetStyle("emacs-mode");
+    editor.commands.removeCommands(commands);
 };
 
 var $kbSessionChange = function(e) {

--- a/lib/ace/keyboard/emacs_test.js
+++ b/lib/ace/keyboard/emacs_test.js
@@ -1,0 +1,73 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+if (typeof process !== "undefined") {
+    require("amd-loader");
+}
+
+define(function(require, exports, module) {
+"use strict";
+
+var EditSession = require("./../edit_session").EditSession,
+    Editor = require("./../editor").Editor,
+    MockRenderer = require("./../test/mockrenderer").MockRenderer,
+    emacs = require('./emacs'),
+    assert = require("./../test/assertions"),
+    editor;
+
+function initEditor(docString) {
+    var doc = new EditSession(docString.split("\n"));
+    editor = new Editor(new MockRenderer(), doc);
+    editor.setKeyboardHandler(emacs.handler);
+}
+
+module.exports = {
+
+    "test: detach removes emacs commands from command manager": function() {
+        initEditor('');
+        assert.ok(!!editor.commands.byName["keyboardQuit"], 'setup error: emacs commands not installed');
+        editor.keyBinding.removeKeyboardHandler(editor.getKeyboardHandler());
+        assert.ok(!editor.commands.byName["keyboardQuit"], 'emacs commands not removed');
+    },
+
+    "test: keyboardQuit clears selection": function() {
+        initEditor('foo');
+        editor.selectAll();
+        editor.execCommand('keyboardQuit');
+        assert.ok(editor.selection.isEmpty(), 'selection non-empty');
+    }
+
+};
+
+});
+
+if (typeof module !== "undefined" && module === require.main) {
+    require("asyncjs").test.testcase(module.exports).exec()
+}

--- a/lib/ace/test/all_browser.js
+++ b/lib/ace/test/all_browser.js
@@ -21,6 +21,7 @@ var testNames = [
     "ace/editor_navigation_test",
     "ace/editor_text_edit_test",
     "ace/ext/static_highlight_test",
+    "ace/keyboard/emacs_test",
     "ace/layer/text_test",
     "ace/lib/event_emitter_test",
     "ace/mode/coffee/parser_test",


### PR DESCRIPTION
- adding missing keyboardQuit
- platform-specific (mac/win) keybindings
- make CMD key available (Mac OS)
- emacs commands are added to command manager
- tests
