### PR TITLE
Restore old labeled break semantics

### DIFF
--- a/lib/ace/mode/javascript/jshint.js
+++ b/lib/ace/mode/javascript/jshint.js
@@ -1925,16 +1925,19 @@ klass:
 
 		for (;;) {
 			minus = false;
+			var breakOuterLoop;
 			for (;;) {
 				if (t.type === "special" && t.value === "*/") {
-					minus = false;
-					continue;
+					breakOuterLoop = true;
+					break;
 				}
 				if (t.id !== "(endline)" && t.id !== ",") {
 					break;
 				}
 				t = lex.token();
 			}
+			if (breakOuterLoop)
+				break;
 
 			if (o === "/*global" && t.value === "-") {
 				minus = true;


### PR DESCRIPTION
It seems jshint sometimes gets in an infinite loop; apparently the rewrite of https://github.com/ajaxorg/ace/pull/1259 wasn't completely accurate. This rewrites the labeled break to more closely match the original semantics (see the [diff](https://github.com/ajaxorg/ace/compare/83be0083bb4a192ecd2298bfd71479da369c9662...fix-100pct-cpu#L5L1926)). 

@ajaxorg/liskov 
