### PR TITLE
Fix bug with searchbox keyboard handler

### DIFF
--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -177,7 +177,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
 
     this.hide = function () {
         this.element.style.display = "none";
-        this.editor.keyBinding.removeKeyboardHandler(this.$searchKeybingin);
+        this.editor.keyBinding.removeKeyboardHandler(this.$closeSearchBarKb);
         this.editor.focus();
     };
     this.show = function(value, isReplace) {


### PR DESCRIPTION
This typo caused a bug where ESC did not leave the Vim INSERT mode.
