### PR TITLE
Prevent search/replace controls to submit the container form

### DIFF
--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -41,16 +41,16 @@ var keyUtil = require("../lib/keys");
 dom.importCssString(searchboxCss, "ace_searchbox");
 
 var html = '<div class="ace_search right">\
-    <button action="hide" class="ace_searchbtn_close"></button>\
+    <button type="button" action="hide" class="ace_searchbtn_close"></button>\
     <div class="ace_search_form">\
         <input class="ace_search_field" placeholder="Search for" spellcheck="false"></input>\
-        <button action="findNext" class="ace_searchbtn next"></button>\
-        <button action="findPrev" class="ace_searchbtn prev"></button>\
+        <button type="button" action="findNext" class="ace_searchbtn next"></button>\
+        <button type="button" action="findPrev" class="ace_searchbtn prev"></button>\
     </div>\
     <div class="ace_replace_form">\
         <input class="ace_search_field" placeholder="Replace with" spellcheck="false"></input>\
-        <button action="replace" class="ace_replacebtn">Replace</button>\
-        <button action="replaceAll" class="ace_replacebtn">All</button>\
+        <button type="button" action="replace" class="ace_replacebtn">Replace</button>\
+        <button type="button" action="replaceAll" class="ace_replacebtn">All</button>\
     </div>\
 </div>'.replace(/>\s+/g, ">");
 


### PR DESCRIPTION
The search/replace buttons are seen as `submit` type because the `type` attribute
is not specified. If ACE is embedded within a form (between `<form>...</form>`)
clicking on one of these button will submit the outer form.

Setting search/replace buttons `type` to `button` prevents the outer form to be
submitted.
