### PR TITLE
Fix django.js module header

### DIFF
--- a/lib/ace/mode/django.js
+++ b/lib/ace/mode/django.js
@@ -28,7 +28,7 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
-define('ace/mode/django', ['require', 'exports', 'module' , 'ace/lib/oop', 'ace/mode/html', 'ace/mode/text_highlight_rules', 'ace/tokenizer', 'ace/mode/html_highlight_rules'], function(require, exports, module) {
+define(function(require, exports, module) {
 
 var oop = require("../lib/oop");
 var HtmlMode = require("./html").Mode;


### PR DESCRIPTION
npm install was reporting:

```
mode django
Failed to find module: require
Failed to find module: exports
Failed to find module: module
```

This changes the header of that mode @nightwing 
