### PR TITLE
Update Chaos.css to include indent-guide and fold

### DIFF
--- a/lib/ace/theme/chaos.css
+++ b/lib/ace/theme/chaos.css
@@ -138,3 +138,19 @@
 .ace-chaos .ace_fold-widget.ace_closed:after {
   content: '‣'
 }
+
+.ace-chaos .ace_indent-guide {
+  border-right:1px dotted #333;
+  margin-right:-1px;
+}
+
+.ace-chaos .ace_fold { 
+  background: #222; 
+  border-radius: 3px; 
+  color: #7AF; 
+  border: none; 
+}
+.ace-chaos .ace_fold:hover {
+  background: #CCC; 
+  color: #000;
+}


### PR DESCRIPTION
Add indent guide to theme.
Modify ace_fold to be more subtle (the big inline ace_fold widgets are a bit distracting on this dark theme).
This is true to the original Chaos theme (Space Editor).
