### PR TITLE
Fix newlines for text files

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -472,7 +472,6 @@ var detectTextModules = function(input, source) {
     var module = source.isLocation ? source.path : source;
 
     input = input.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    input = input.replace(/\n\s+/g, "\n");
     input = '"' + input.replace(/\r?\n/g, '\\n') + '"';
     textModules[module] = input;
 


### PR DESCRIPTION
This addressed an issue where the newlines generated when including snippet files does not contain newline characters, this causes SnippetManager.parseSnippetFile to always return empty.

Instead, of creating actual newlines and a multiline string with \, this adds newline characters.
