### PR TITLE
fix php worker bogus error on use keyword

### DIFF
--- a/lib/ace/mode/php/php.js
+++ b/lib/ace/mode/php/php.js
@@ -173,6 +173,10 @@ PHP.Lexer = function( src, ini ) {
         openTagStart = (ini === undefined || (/^(on|true|1)$/i.test(ini.short_open_tag)) ? /^(\<\?php\s|\<\?|\<\%|\<script language\=('|")?php('|")?\>)/i : /^(\<\?php\s|<\?=|\<script language\=('|")?php('|")?\>)/i),
             tokens = [
             {
+                value: PHP.Constants.T_USE,
+                re: /^use(?=\s)/i
+            },
+            {
                 value: PHP.Constants.T_ABSTRACT,
                 re: /^abstract(?=\s)/i
             },


### PR DESCRIPTION
Not sure this is all that's required, but it fixes my problems which were false positive errors related to the `use` keyword in PHP code.

```
use SomeNamespace\SomeClass;
```

and

```
$func = function() use ($var) {
```

both trigger the error.
