### PR TITLE
Reduce default right padding of gutter cell

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -44,7 +44,7 @@
 
 .ace_gutter-cell {
     padding-left: 19px;
-    padding-right: 6px;
+    padding-right: 4px;
     background-repeat: no-repeat;
 }
 


### PR DESCRIPTION
I am finding in some browsers that when disabling code folding, 1-2 pixels of the folding arrow's left side is still showing. Reducing the right padding of the gutter cell seems to help.
