### PR TITLE
Addresses an issue where IE8 does not properly handle the RegExp in _par...

### DIFF
--- a/lib/ace/mode/folding/xml.js
+++ b/lib/ace/mode/folding/xml.js
@@ -80,9 +80,8 @@ oop.inherits(FoldMode, BaseFoldMode);
     this.tagRe = /^(\s*)(<?(\/?)([-_a-zA-Z0-9:!]*)\s*(\/?)>?)/;
     this._parseTag = function(tag) {
         
-        var match = this.tagRe.exec(tag);
-        var column = this.tagRe.lastIndex || 0;
-        this.tagRe.lastIndex = 0;
+        var match = tag.match(this.tagRe);
+        var column = 0;
 
         return {
             value: tag,


### PR DESCRIPTION
...seTag, causing folding not to work for the XML mode (or modes that inherit XML). Tested XML mode in IE8/9 and major browsers. Should resolve #1384
