### PR TITLE
Velocity mode less than operator improvements

### DIFF
--- a/lib/ace/mode/velocity_highlight_rules.js
+++ b/lib/ace/mode/velocity_highlight_rules.js
@@ -54,7 +54,7 @@ var VelocityHighlightRules = function() {
                 next : "style"
             }, {
                 token : "meta.tag", // opening tag
-                regex : "<\\/?",
+                regex : "<\\/?(?:[a-z])",
                 next : "tag"
             }, {
                 token : "comment",
@@ -182,7 +182,7 @@ var VelocityHighlightRules = function() {
                 regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
             }, {
                 token : "keyword.operator",
-                regex : "!|&|\\*|\\-|\\+|=|!=|<=|>=<|>|&&|\\|\\|"
+                regex : "!|&|\\*|\\-|\\+|=|!=|<=|>=|<|>|&&|\\|\\|"
             }, {
                 token : "lparen",
                 regex : "[[({]"


### PR DESCRIPTION
Less than operator was not included and the `meta.tag` regex was always matching on any `<` sign, even inside of Velocity code.
