### PR TITLE
Dirty check bug fixed

### DIFF
--- a/lib/ace/undomanager.js
+++ b/lib/ace/undomanager.js
@@ -88,9 +88,9 @@ var UndoManager = function() {
             undoSelectionRange =
                 this.$doc.undoChanges(deltas, dontSelect);
             this.$redoStack.push(deltas);
+            this.dirtyCounter--;
         }
 
-        this.dirtyCounter--;
         return undoSelectionRange;
     };
 
@@ -107,9 +107,9 @@ var UndoManager = function() {
             redoSelectionRange =
                 this.$doc.redoChanges(deltas, dontSelect);
             this.$undoStack.push(deltas);
+            this.dirtyCounter++;
         }
 
-        this.dirtyCounter++;
         return redoSelectionRange;
     };
 


### PR DESCRIPTION
I made a mistake in dirty check functionality.

Undoing/redoing when there is no action to undo/redo should not change the dirty counter.
