### PR TITLE
Allow Ctrl-C to be same as Esc in insert mode

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -89,7 +89,7 @@ exports.handler = {
         if (hashId == 1)
             key = "ctrl-" + key;
         
-        if ((key == "esc" && hashId == 0) || key == "ctrl-[") {
+        if ((key == "esc" && hashId == 0) || key == "ctrl-[" || key == "ctrl-c") {
             return {command: coreCommands.stop};
         } else if (data.state == "start") {
             if (useragent.isMac && this.handleMacRepeat(data, hashId, key)) {


### PR DESCRIPTION
This is consistent with Vim's desktop functionality.
