### PR TITLE
IE9 in Quirks mode fix

### DIFF
--- a/lib/ace/lib/useragent.js
+++ b/lib/ace/lib/useragent.js
@@ -78,7 +78,7 @@ exports.isIE =
     (navigator.appName == "Microsoft Internet Explorer" || navigator.appName.indexOf("MSAppHost") >= 0)
     && parseFloat(navigator.userAgent.match(/MSIE ([0-9]+[\.0-9]+)/)[1]);
     
-exports.isOldIE = exports.isIE && exports.isIE < 9;
+exports.isOldIE = exports.isIE && (exports.isIE < 9 || (exports.isIE < 10 && window.top.document.compatMode === "BackCompat" ));
 
 // Is this Firefox or related?
 exports.isGecko = exports.isMozilla = window.controllers && window.navigator.product === "Gecko";


### PR DESCRIPTION
Note that only IE9 in Quirks mode is affected, the editor now accepts input. Text color is locked in commentary color (at least in JavaScript mode).
