### PR TITLE
handle undefined values

### DIFF
--- a/lib/ace/layer/text.js
+++ b/lib/ace/layer/text.js
@@ -409,6 +409,9 @@ var Text = function(parentEl) {
     };
 
     this.$renderToken = function(stringBuilder, screenColumn, token, value) {
+        if (typeof value === "undefined") {
+          return;
+        }    
         var self = this;
         var replaceReg = /\t|&|<|( +)|([\x00-\x1f\x80-\xa0\u1680\u180E\u2000-\u200f\u2028\u2029\u202F\u205F\u3000\uFEFF])|[\u1100-\u115F\u11A3-\u11A7\u11FA-\u11FF\u2329-\u232A\u2E80-\u2E99\u2E9B-\u2EF3\u2F00-\u2FD5\u2FF0-\u2FFB\u3000-\u303E\u3041-\u3096\u3099-\u30FF\u3105-\u312D\u3131-\u318E\u3190-\u31BA\u31C0-\u31E3\u31F0-\u321E\u3220-\u3247\u3250-\u32FE\u3300-\u4DBF\u4E00-\uA48C\uA490-\uA4C6\uA960-\uA97C\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFAFF\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE66\uFE68-\uFE6B\uFF01-\uFF60\uFFE0-\uFFE6]/g;
         var replaceFunc = function(c, a, b, tabIdx, idx4) {


### PR DESCRIPTION
This commit fixes an issue for me, that occurs kind of randomly.
I guess this is not the best fix for this problem, but at least it works for me ;)

Error:
"TypeError: value is undefined" in line 448 (var output = value.replace(replaceReg, replaceFunc);
) in text.js

Steps to reproduce:
Call editor.setValue(result); multiple times with only a short time between the calls.
der result variable is a rather long text

When I am calling the SetValue Method a couple of times, at some point (after 10-50 times) the value becomes undefined, normally 2 times for one editor.setValue(result) call.

I have no clue why this happens, but this fix ignores the undefined values and it has no effects on the rendering (it renders all elements) and  i have found so side effects so far.

This problem occurs in Firefox as well in Chrome (latest versions).
