### PR TITLE
Fix current state loosing between lines in the tokenizer.

### DIFF
--- a/lib/ace/mode/text_highlight_rules.js
+++ b/lib/ace/mode/text_highlight_rules.js
@@ -109,14 +109,14 @@ var TextHighlightRules = function() {
 
     var pushState = function(currentState, stack) {
         if (currentState != "start")
-            stack.unshift(this.nextState, currentState);
+            stack.unshift(this.nextState);
         return this.nextState;
     };
     var popState = function(currentState, stack) {
         if (stack[0] !== currentState)
             return "start";
         stack.shift();
-        return stack.shift();
+        return stack[0] || "start";
     };
 
     this.normalizeRules = function() {

--- a/lib/ace/tokenizer.js
+++ b/lib/ace/tokenizer.js
@@ -215,8 +215,9 @@ var Tokenizer = function(rules) {
         if (startState && typeof startState != "string") {
             var stack = startState.slice(0);
             startState = stack[0];
-        } else
-            var stack = [];
+        } else {
+            var stack = [startState || "start"];
+        }
 
         var currentState = startState || "start";
         var state = this.states[currentState];
@@ -262,6 +263,7 @@ var Tokenizer = function(rules) {
                         currentState = rule.next;
                     else
                         currentState = rule.next(currentState, stack);
+                    stack[0] = currentState;
 
                     state = this.states[currentState];
                     if (!state) {
@@ -321,7 +323,7 @@ var Tokenizer = function(rules) {
 
         return {
             tokens : tokens,
-            state : stack.length ? stack : currentState
+            state : stack.length > 1 ? stack : currentState
         };
     };
 


### PR DESCRIPTION
Fix for https://github.com/ajaxorg/ace/issues/1555

We lost last state of previous line when stack was not empy and last transition was not `push`.
Now a top element of a stack always points to a current state to never loose it.
