### PR TITLE
Include css rule name with lint results

### DIFF
--- a/lib/ace/mode/css_worker.js
+++ b/lib/ace/mode/css_worker.js
@@ -84,7 +84,8 @@ oop.inherits(Worker, Mirror);
                 row: msg.line - 1,
                 column: msg.col - 1,
                 text: msg.message,
-                type: infoRules[msg.rule.id] ? "info" : msg.type
+                type: infoRules[msg.rule.id] ? "info" : msg.type,
+                rule: msg.rule.name
             }
         }));
     };


### PR DESCRIPTION
This is similar to returning "raw" from JSHint, as it helps to identify the rule being applied.
