### PR TITLE
Improve WheelEvent handling (scroll by lines)

### DIFF
--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -140,31 +140,71 @@ else {
 
 exports.addMouseWheelListener = function(el, callback) {
     if ("onmousewheel" in el) {
-        var factor = 8;
         exports.addListener(el, "mousewheel", function(e) {
+            var deltaX, deltaY;
             if (e.wheelDeltaX !== undefined) {
-                e.wheelX = -e.wheelDeltaX / factor;
-                e.wheelY = -e.wheelDeltaY / factor;
+                deltaX = -e.wheelDeltaX;
+                deltaY = -e.wheelDeltaY;
             } else {
-                e.wheelX = 0;
-                e.wheelY = -e.wheelDelta / factor;
+                deltaX = 0;
+                deltaY = -e.wheelDelta;
+            }
+            if (e.deltaMode === undefined) {
+                e.DOM_DELTA_PIXEL = 0x00;
+                e.DOM_DELTA_LINE  = 0x01;
+                e.DOM_DELTA_PAGE  = 0x02;
+                e.deltaMode = e.DOM_DELTA_PIXEL;
+            }
+            switch (e.deltaMode) {
+                case e.DOM_DELTA_PIXEL:
+                    if (useragent.isMac && !useragent.isOpera) {
+                        e.deltaX = deltaX / 3;
+                        e.deltaY = deltaY / 3;
+                    } else {
+                        delete e.deltaMode;
+                        e.deltaMode = e.DOM_DELTA_LINE;
+                        e.deltaX = deltaX / 40;
+                        e.deltaY = deltaY / 40;
+                    }
+                    break;
+                case e.DOM_DELTA_LINE:
+                    // XXX is any useragent, supporting this?
+                    e.deltaX = deltaX;
+                    e.deltaY = deltaY;
+                    break;
+                case e.DOM_DELTA_PAGE:
+                    // only webkit supports this
+                    e.deltaX = deltaX > 0 ? 1 : (deltaX < 0 ? -1 : 0);
+                    e.deltaY = deltaY > 0 ? 1 : (deltaY < 0 ? -1 : 0);
+                    break;
             }
             callback(e);
         });
     } else if ("onwheel" in el) {
         exports.addListener(el, "wheel",  function(e) {
-            e.wheelX = (e.deltaX || 0) * 5;
-            e.wheelY = (e.deltaY || 0) * 5;
             callback(e);
         });
     } else {
         exports.addListener(el, "DOMMouseScroll", function(e) {
-            if (e.axis && e.axis == e.HORIZONTAL_AXIS) {
-                e.wheelX = (e.detail || 0) * 5;
-                e.wheelY = 0;
+            e.DOM_DELTA_PIXEL = 0x00;
+            e.DOM_DELTA_LINE  = 0x01;
+            e.DOM_DELTA_PAGE  = 0x02;
+
+            var DELTA_PAGE_DETAIL = 32768;
+            var delta;
+            if (Math.abs(e.detail) == DELTA_PAGE_DETAIL) {
+                e.deltaMode = e.DOM_DELTA_PAGE;
+                delta = e.detail > 0 ? 1 : -1;
             } else {
-                e.wheelX = 0;
-                e.wheelY = (e.detail || 0) * 5;
+                e.deltaMode = e.DOM_DELTA_LINE;
+                delta = e.detail || 0;
+            }
+            if (e.axis && e.axis == e.HORIZONTAL_AXIS) {
+                e.deltaX = delta;
+                e.deltaY = 0;
+            } else {
+                e.deltaX = 0;
+                e.deltaY = delta;
             }
             callback(e);
         });

--- a/lib/ace/mouse/default_handlers.js
+++ b/lib/ace/mouse/default_handlers.js
@@ -299,14 +299,33 @@ function DefaultHandlers(mouseHandler) {
     this.onMouseWheel = function(ev) {
         if (ev.getShiftKey() || ev.getAccelKey())
             return;
-        var t = ev.domEvent.timeStamp;
+        var domEv = ev.domEvent;
+        var t = domEv.timeStamp;
         var dt = t - (this.$lastScrollTime||0);
         
         var editor = this.editor;
-        var isScrolable = editor.renderer.isScrollableBy(ev.wheelX * ev.speed, ev.wheelY * ev.speed);
+        var config = editor.renderer.layerConfig;
+        // respect event delta mode
+        var deltaX = ev.deltaX;
+        var deltaY = ev.deltaY;
+        switch (domEv.deltaMode) {
+            case domEv.DOM_DELTA_PIXEL:
+                break;
+            case domEv.DOM_DELTA_LINE:
+                deltaX *= config.characterWidth;
+                deltaY *= config.lineHeight;
+                break;
+            case domEv.DOM_DELTA_PAGE:
+                var rows = Math.floor(config.height / config.lineHeight);
+                var pageHeight = rows * config.lineHeight;
+                deltaX *= pageHeight;
+                deltaY *= pageHeight;
+                break;
+        }
+        var isScrolable = editor.renderer.isScrollableBy(deltaX * ev.speed, deltaY * ev.speed);
         if (isScrolable || dt < 200) {
             this.$lastScrollTime = t;
-            editor.renderer.scrollBy(ev.wheelX * ev.speed, ev.wheelY * ev.speed);
+            editor.renderer.scrollBy(deltaX * ev.speed, deltaY * ev.speed);
             return ev.stop();
         }
     };

--- a/lib/ace/mouse/mouse_handler.js
+++ b/lib/ace/mouse/mouse_handler.js
@@ -85,9 +85,9 @@ var MouseHandler = function(editor) {
 
     this.onMouseWheel = function(name, e) {
         var mouseEvent = new MouseEvent(e, this.editor);
-        mouseEvent.speed = this.$scrollSpeed * 2;
-        mouseEvent.wheelX = e.wheelX;
-        mouseEvent.wheelY = e.wheelY;
+        mouseEvent.speed = this.$scrollSpeed;
+        mouseEvent.deltaX = e.deltaX;
+        mouseEvent.deltaY = e.deltaY;
 
         this.editor._emit(name, mouseEvent);
     };
@@ -143,7 +143,7 @@ var MouseHandler = function(editor) {
 }).call(MouseHandler.prototype);
 
 config.defineOptions(MouseHandler.prototype, "mouseHandler", {
-    scrollSpeed: {initialValue: 2},
+    scrollSpeed: {initialValue: 1},
     dragDelay: {initialValue: 150},
     focusTimout: {initialValue: 0}
 });


### PR DESCRIPTION
Editor should respect system scroll speed settings.
This works perfectly on Firefox (tested on Windows FF23 and on Linux FF16). Firefox always provides delta in lines unit.
This seems to work fine with Opera (Presto) (tested on Windows). By the way Opera dispatches no event when `Scroll By Pages` system setting is `on`.
IE and WebKit do not reflect `Scroll Lines Number` setting. In this case, default value is `3`.
WebKit reflects `Scroll By Pages` setting, while IE doesn't.

I did not test much Safari on MacOS, but it seems to work the way the OS works.
IE9+ supports DOM3 `wheel`, but it is not used by ACE, because there is no `onwheel` property defined. Besides, this event provides incorrect delta value.

Blink is going to add DOM3 `wheel` event: https://code.google.com/p/chromium/issues/detail?id=227454 .But it seems they are going to use DOL_DELTA_PIXEL delta unit. I don't like that. @nightwing what do you think?
This will cause us to sniff OS, because MacOS scrolls by pixel, while on Windows and Linux we must convert pixels to lines (just like for `mousewheel` event for now). That's not good. I am going to discuss that there, but I don't think somebody will listen me ((
