### PR TITLE
Exposing internal functions of the dragDrop object - 'dragEnter', 'dragOver', 'drop' - to the $mouseHandler object.

### DIFF
--- a/lib/ace/mouse/dragdrop.js
+++ b/lib/ace/mouse/dragdrop.js
@@ -56,6 +56,8 @@ var DragdropHandler = function(mouseHandler) {
     function dragOver(e){
         if (editor.getReadOnly())
             return;
+        if (typeof (e) == "undefined")
+            return;
         var types = e.dataTransfer.types;
         if (types && Array.prototype.indexOf.call(types, "text/plain") === -1)
             return;
@@ -68,6 +70,8 @@ var DragdropHandler = function(mouseHandler) {
 
     function drop(e){
         if (!dragSelectionMarker)
+            return;
+        if (typeof (e) == "undefined")
             return;
         data = e.dataTransfer.getData('Text').substr(0,5)
         console.log(data)


### PR DESCRIPTION
I am developing an application in which the user drags a list-item from an outline to a document - upon which inserts all relevant information to that outline list item into the document.
Therefore, I need to change the default behavior of the ondrop listener for the Ace-powered document. My patch exposes the default methods for "dragEnter", "dragOver", and "drop", so that a developer can easily overwrite the default methods.
With this patch, the methods are accessible in both the **editor.$mouseHandler** object, and also in the **editor.$mouseHandler.dragDrop** object.
I will send my Contributors License Agreement as soon as I can.
