### PR TITLE
Rename "commmandKeyBinding" to have 33% less "m"

### DIFF
--- a/lib/ace/commands/command_manager.js
+++ b/lib/ace/commands/command_manager.js
@@ -21,7 +21,7 @@ var EventEmitter = require("../lib/event_emitter").EventEmitter;
 var CommandManager = function(platform, commands) {
     this.platform = platform;
     this.commands = this.byName = {};
-    this.commmandKeyBinding = {};
+    this.commandKeyBinding = {};
 
     this.addCommands(commands);
 

--- a/lib/ace/ext/menu_tools/get_editor_keyboard_shortcuts.js
+++ b/lib/ace/ext/menu_tools/get_editor_keyboard_shortcuts.js
@@ -67,7 +67,7 @@ module.exports.getEditorKeybordShortcuts = function(editor) {
     var keybindings = [];
     var commandMap = {};
     editor.keyBinding.$handlers.forEach(function(handler) {
-        var ckb = handler.commmandKeyBinding;
+        var ckb = handler.commandKeyBinding;
         for (var i in ckb) {
             var modifier = parseInt(i);
             if (modifier == -1) {

--- a/lib/ace/keyboard/emacs.js
+++ b/lib/ace/keyboard/emacs.js
@@ -198,7 +198,7 @@ exports.handler.bindKey = function(key, command) {
     if (!key)
         return;
 
-    var ckb = this.commmandKeyBinding;
+    var ckb = this.commandKeyBinding;
     key.split("|").forEach(function(keyPart) {
         keyPart = keyPart.toLowerCase();
         ckb[keyPart] = command;
@@ -206,7 +206,7 @@ exports.handler.bindKey = function(key, command) {
         // to be able to activate key combos with arbitrary length
         // Example: if keyPart is "C-c C-l t" then "C-c C-l t" will
         // get command assigned and "C-c" and "C-c C-l" will get
-        // a null command assigned in this.commmandKeyBinding. For
+        // a null command assigned in this.commandKeyBinding. For
         // the lookup logic see handleKeyboard()
         var keyParts = keyPart.split(" ").slice(0,-1);
         keyParts.reduce(function(keyMapKeys, keyPart, i) {
@@ -257,9 +257,9 @@ exports.handler.handleKeyboard = function(data, hashId, key, keyCode) {
     if (data.keyChain) key = data.keyChain += " " + key;
 
     // Key combo prefixes get stored as "null" (String!) in this
-    // this.commmandKeyBinding. When encountered no command is invoked but we
+    // this.commandKeyBinding. When encountered no command is invoked but we
     // buld up data.keyChain
-    var command = this.commmandKeyBinding[key];
+    var command = this.commandKeyBinding[key];
     data.keyChain = command == "null" ? key : "";
 
     // there really is no command

--- a/lib/ace/keyboard/hash_handler.js
+++ b/lib/ace/keyboard/hash_handler.js
@@ -37,7 +37,7 @@ var useragent = require("../lib/useragent");
 function HashHandler(config, platform) {
     this.platform = platform || (useragent.isMac ? "mac" : "win");
     this.commands = {};
-    this.commmandKeyBinding = {};
+    this.commandKeyBinding = {};
 
     this.addCommands(config);
 };
@@ -61,7 +61,7 @@ function HashHandler(config, platform) {
 
         // exhaustive search is brute force but since removeCommand is
         // not a performance critical operation this should be OK
-        var ckb = this.commmandKeyBinding;
+        var ckb = this.commandKeyBinding;
         for (var hashId in ckb) {
             for (var key in ckb[hashId]) {
                 if (ckb[hashId][key] == command)
@@ -78,7 +78,7 @@ function HashHandler(config, platform) {
             return;
         }
 
-        var ckb = this.commmandKeyBinding;
+        var ckb = this.commandKeyBinding;
         key.split("|").forEach(function(keyPart) {
             var binding = this.parseKeys(keyPart, command);
             var hashId = binding.hashId;
@@ -158,7 +158,7 @@ function HashHandler(config, platform) {
     };
 
     this.findKeyCommand = function findKeyCommand(hashId, keyString) {
-        var ckbr = this.commmandKeyBinding;
+        var ckbr = this.commandKeyBinding;
         return ckbr[hashId] && ckbr[hashId][keyString];
     };
 


### PR DESCRIPTION
This is just a little typo, but it has been driving my inner copy editor nuts. Hoping you guys can take this, and then I can stop running sed on all my Ace builds in the future.
