### PR TITLE
Fix GFM blocks within lists

### DIFF
--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -46,7 +46,7 @@ var escaped = function(ch) {
 function github_embed(tag, prefix) {
     return { // Github style block
         token : "support.function",
-        regex : "^```" + tag + "\\s*$",
+        regex : "^\\s*```" + tag + "\\s*$",
         push  : prefix + "start"
     };
 }
@@ -79,7 +79,7 @@ var MarkdownHighlightRules = function() {
        github_embed("css", "csscode-"),
     { // Github style block
         token : "support.function",
-        regex : "^```\\s*\\S*(?:{.*?\\})?\\s*$",
+        regex : "^\\s*```\\s*\\S*(?:{.*?\\})?\\s*$",
         next  : "githubblock"
     }, { // block quote
         token : "string.blockquote",
@@ -164,11 +164,15 @@ var MarkdownHighlightRules = function() {
             next  : "listblock-start"
         }, {
             include : "basic", noEscape: true
+        }, { // Github style block
+            token : "support.function",
+            regex : "^\\s*```\\s*[a-zA-Z]*(?:{.*?\\})?\\s*$",
+            next  : "githubblock"
         }, {
             defaultToken : "list" //do not use markup.list to allow stling leading `*` differntly
         } ],
 
-        "blockquote" : [ { // BLockquotes only escape on blank lines.
+        "blockquote" : [ { // Blockquotes only escape on blank lines.
             token : "empty_line",
             regex : "^\\s*$",
             next  : "start"
@@ -184,7 +188,7 @@ var MarkdownHighlightRules = function() {
 
         "githubblock" : [ {
             token : "support.function",
-            regex : "^```",
+            regex : "^\\s*```",
             next  : "start"
         }, {
             token : "support.function",
@@ -194,25 +198,25 @@ var MarkdownHighlightRules = function() {
 
     this.embedRules(JavaScriptHighlightRules, "jscode-", [{
        token : "support.function",
-       regex : "^```",
+       regex : "^\\s*```",
        next  : "pop"
     }]);
 
     this.embedRules(HtmlHighlightRules, "htmlcode-", [{
        token : "support.function",
-       regex : "^```",
+       regex : "^\\s*```",
        next  : "pop"
     }]);
 
     this.embedRules(CssHighlightRules, "csscode-", [{
        token : "support.function",
-       regex : "^```",
+       regex : "^\\s*```",
        next  : "pop"
     }]);
 
     this.embedRules(XmlHighlightRules, "xmlcode-", [{
        token : "support.function",
-       regex : "^```",
+       regex : "^\\s*```",
        next  : "pop"
     }]);
 


### PR DESCRIPTION
A couple of fixes going on here:
1. GFM-style code blocks were not rendered correctly in lists. For example:

``````
* Your directory tree should be similar to this: 
   \`\`\`
    + the-openvj-project/       (any name)
      + openvj/                 (git://openvj)
        - openvj-package.box
        + .git/
        + doc/
        + src/
        - …
      + openvj-git-service/     (git://openvj-git-service)
        + .git/
        - …
      + openvj-bg-service/      (git://openvj-bg-service)
        + .git/
        - …
      + openvj-data/
        + git/
    ```
``````
1. Tagential to the above, any number of spaces before a GFM style block should be permissible:

```
 \`\`\`
+ the-openvj-project/       (any name)
  + openvj/                 (git://openvj)
    - openvj-package.box
    + .git/
    + doc/
    + src/
    - …
  + openvj-git-service/     (git://openvj-git-service)
    + .git/
    - …
  + openvj-bg-service/      (git://openvj-bg-service)
    + .git/
    - …
  + openvj-data/
    + git/
 \`\`\`
```
