### PR TITLE
update Dart syntax highlighting

### DIFF
--- a/demo/kitchen-sink/docs/dart.dart
+++ b/demo/kitchen-sink/docs/dart.dart
@@ -1,58 +1,19 @@
-main() {
-  print('Hello World!');
+// Go ahead and modify this example.
+
+import "dart:html";
+
+// Computes the nth Fibonacci number.
+int fibonacci(int n) {
+  if (n < 2) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
 }
 
+// Displays a Fibonacci number.
+void main() {
+  int i = 20;
+  String message = "fibonacci($i) = ${fibonacci(i)}";
 
-int fib(int n) => (n > 1) ? (fib(n - 1) + fib(n - 2)) : n;
-main() {
-  print('fib(20) = ${fib(20)}');
+  // This example uses HTML to display the result and it will appear
+  // in a nested HTML frame (an iframe).
+  document.body.append(new HeadingElement.h1()..appendText(message));
 }
-/*asd
-asdad
-*/
-0.67
-77
-.86
-
-import("http://dartwatch.com/myOtherLibrary.dart");
-import("myOtherLibrary.dart", prefix:"lib1");
-
-"""asdasdads
-asdadsadsasd
-asdasdasdad"""
- 
-'23424'
-
-0x234
-
-foo is bar
-
-int x = 4 << 10 
-// Create a class for Point.
-class Point {
- 
-  // Final variables cannot be changed once they are assigned.
-  // Create two instance variables.
-  final num x, y;
- 
-  // A constructor, with syntactic sugar for setting instance variables.
-  Point(this.x, this.y);
- 
-  // A named constructor with an initializer list.
-  Point.origin() : x = 0, y = 0;
- 
-  // A method.
-  num distanceTo(Point other) {
-    var dx = x - other.x;
-    var dy = y - other.y;
-    return sqrt(dx * dx + dy * dy);
-  }
-}
- 
- // Check for null.
-var unicorn;
-assert(unicorn == null);
-
-// Check for NaN.
-var iMeantToDoThis = 0/0;
-assert(iMeantToDoThis.isNaN());

--- a/lib/ace/mode/dart_highlight_rules.js
+++ b/lib/ace/mode/dart_highlight_rules.js
@@ -15,7 +15,7 @@ var DartHighlightRules = function() {
     var keywordControl = "try|catch|finally|throw|break|case|continue|default|do|else|for|if|in|return|switch|while|new";
     var keywordDeclaration = "abstract|class|extends|external|factory|implements|get|native|operator|set|typedef";
     var storageModifier = "static|final|const";
-    var storageType = "void|bool|num|int|double|Dynamic|var|String";
+    var storageType = "void|bool|num|int|double|dynamic|var|String";
 
     var keywordMapper = this.createKeywordMapper({
         "constant.language.dart": constantLanguage,
@@ -52,7 +52,7 @@ var DartHighlightRules = function() {
         },
         {
             token: "keyword.other.import.dart",
-            regex: "(?:\\b)(?:library|import|source|part|of)(?:\\b)"
+            regex: "(?:\\b)(?:library|import|part|of)(?:\\b)"
         },
         {
             token : ["keyword.other.import.dart", "text"],

--- a/lib/ace/snippets/dart.snippets
+++ b/lib/ace/snippets/dart.snippets
@@ -1,14 +1,17 @@
 snippet lib
-	#library('${1}');
+	library ${1};
 	${2}
 snippet im
-	#import('${1}');
+	import '${1}';
 	${2}
-snippet so
-	#source('${1}');
+snippet pa
+	part '${1}';
+	${2}
+snippet pao
+	part of ${1};
 	${2}
 snippet main
-	static void main() {
+	void main() {
 	  ${1:/* code */}
 	}
 snippet st
@@ -23,8 +26,6 @@ snippet th
 	throw ${1}
 snippet cl
 	class ${1:`Filename("", "untitled")`} ${2}
-snippet in
-	interface ${1:`Filename("", "untitled")`} ${2}
 snippet imp
 	implements ${1}
 snippet ext


### PR DESCRIPTION
This pull request updates Dart syntax highlighting for ~recent language changes. Specifically:
- `Dynamic` ==> `dynamic`
- `source` and `interface` keywords removed
- `#import` ==> `import`
- `#library` ==> `library`
