### PR TITLE
Two fixes for Firefox and IE

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -51,8 +51,8 @@ var TextInput = function(parentNode, host) {
     text.autocapitalize = "off";
     text.spellcheck = false;
 
-	if (!useragent.isWebKit)
-		text.style.position = "fixed";
+    if (!useragent.isWebKit)
+        text.style.position = "fixed";
     text.style.height = "0";
     text.style.opacity = "0";
     parentNode.insertBefore(text, parentNode.firstChild);


### PR DESCRIPTION
Firefox had an issue where on focus it scrolled to show the first line (where the [textarea] were added) and selected all text in between. We could also replicate the issue on your homepage's demo. This fix is tested with Firefox, IE (required an extra patch due to the recent removal of .style.bottom in the same file) and Safari. No regressions found.

This patch is clearly non-copyrightable so we trust that we don't need to sign the CLA for you to accept this patch.
