### PR TITLE
multiline strings throw out error line numbers

### DIFF
--- a/lib/ace/mode/php/php.js
+++ b/lib/ace/mode/php/php.js
@@ -766,7 +766,7 @@ PHP.Lexer = function( src, ini ) {
                         return undefined;
 
                     } else {
-                        result = result.replace(/\n/g,"\n").replace(/\r/g,"");
+                        result = result.replace(/\r/g,"");
                     }
 
                     /*


### PR DESCRIPTION
e.g:

```
<?php
$foo = "test
multiline

string"
a
?>
```

shows  error on line 3 instead of 6.
