### PR TITLE
Fix Webkit context menu on second click

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -490,10 +490,12 @@ var TextInput = function(parentNode, host) {
 
     // firefox fires contextmenu event after opening it
     if (!useragent.isGecko || useragent.isMac) {
-        event.addListener(text, "contextmenu", function(e) {
+        var onContextMenu = function(e) {
             host.textInput.onContextMenu(e);
             onContextMenuClose();
-        });
+        };
+        event.addListener(host.renderer.scroller, "contextmenu", onContextMenu);
+        event.addListener(text, "contextmenu", onContextMenu);
     }
 };
 


### PR DESCRIPTION
Try to click right mouse button twice in Google Chrome to reproduce the bug.
