### PR TITLE
Fixed typo `forown`

### DIFF
--- a/lib/ace/mode/coffee_highlight_rules.js
+++ b/lib/ace/mode/coffee_highlight_rules.js
@@ -41,7 +41,7 @@ define(function(require, exports, module) {
 
         var keywords = (
             "this|throw|then|try|typeof|super|switch|return|break|by|continue|" +
-            "catch|class|in|instanceof|is|isnt|if|else|extends|for|forown|" +
+            "catch|class|in|instanceof|is|isnt|if|else|extends|for|own|" +
             "finally|function|while|when|new|no|not|delete|debugger|do|loop|of|off|" +
             "or|on|unless|until|and|yes"
         );


### PR DESCRIPTION
Changed a fragment `for|forown` to `for|own`, so that now the keyword `own` should be highlighted properly.
