### PR TITLE
Specify type of Markdown string (strong, emphasis, blockquote)

### DIFF
--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -82,7 +82,7 @@ var MarkdownHighlightRules = function() {
         regex : "^```\\s*[a-zA-Z]*(?:{.*?\\})?\\s*$",
         next  : "githubblock"
     }, { // block quote
-        token : "string",
+        token : "string.blockquote",
         regex : "^>[ ].+$",
         next  : "blockquote"
     }, { // HR * - _
@@ -119,10 +119,10 @@ var MarkdownHighlightRules = function() {
                     '(\\s*"' +  escaped('"') + '"\\s*)?' +            // "title"
                     "(\\))"                                           // )
         }, { // strong ** __
-            token : "string",
+            token : "string.strong",
             regex : "([*]{2}|[_]{2}(?=\\S))(.*?\\S[*_]*)(\\1)"
         }, { // emphasis * _
-            token : "string",
+            token : "string.emphasis",
             regex : "([*]|[_](?=\\S))(.*?\\S[*_]*)(\\1)"
         }, { //
             token : ["text", "url", "text"],


### PR DESCRIPTION
This is helpful for styling a Markdown text editor, as [discussed in the Google Group](https://groups.google.com/forum/#!topic/ace-discuss/w4--51A5zbQ).
