### PR TITLE
cstyle behaviour fix for entering braces

### DIFF
--- a/lib/ace/mode/behaviour/cstyle.js
+++ b/lib/ace/mode/behaviour/cstyle.js
@@ -166,7 +166,7 @@ var CstyleBehaviour = function () {
             }
             var rightChar = line.substring(cursor.column, cursor.column + 1);
             if (rightChar == '}' || closing !== "") {
-                var openBracePos = session.findMatchingBracket({row: cursor.row, column: cursor.column}, '}');
+                var openBracePos = session.findMatchingBracket({row: cursor.row, column: cursor.column+1}, '}');
                 if (!openBracePos)
                      return null;
 


### PR DESCRIPTION
fix cstyle behaviour when inserting braces and doing a newline. Previous behaviour would not add a closing brace when no other opening brace was present

(try typing "{" + enter in an empty text)

Btw. I personally find current "maybe" closing brace insertion behavior annoying (only insert a closing brace when enter was pressed). Why isn't the behavior the same as for brackets and parens (immediately inserting the closing brace)? If there isn't a reason then please use the code below to make the brace insertion more uniform.

``` js
   this.add("braces", "insertion", function (state, action, editor, session, text) {
            if (text == '{') {
                var selection = editor.getSelectionRange();
                var selected = session.doc.getTextRange(selection);
                if (selected !== "" && editor.getWrapBehavioursEnabled()) {
                    return {
                        text: '{' + selected + '}',
                        selection: false
                    };
                } else if (CstyleBehaviour.isSaneInsertion(editor, session)) {
                    CstyleBehaviour.recordAutoInsert(editor, session, '}');
                    return {
                        text: '{}',
                        selection: [1, 1]
                    };
                }
            } else if (text == '}') {
                var cursor = editor.getCursorPosition();
                var line = session.doc.getLine(cursor.row);
                var rightChar = line.substring(cursor.column, cursor.column + 1);
                if (rightChar == '}') {
                    var matching = session.$findOpeningBracket('}', {column: cursor.column + 1, row: cursor.row});
                    if (matching !== null && CstyleBehaviour.isAutoInsertedClosing(cursor, line, text)) {
                        CstyleBehaviour.popAutoInsertedClosing();
                        return {
                            text: '',
                            selection: [1, 1]
                        };
                    }
                }
            } else if (text == "\n" || text == "\r\n") {
                // if we are left of a closing brace and press enter then move
                // that closing brace down one more line to open a typically
                // c-style block and indent it correctly
                var cursor = editor.getCursorPosition();
                var line = session.doc.getLine(cursor.row);
                var rightChar = line.substring(cursor.column, cursor.column + 1);
                if (rightChar == '}') {
                    var openBracePos = session.findMatchingBracket({row: cursor.row, column: cursor.column+1}, '}');
                    if (!openBracePos)
                         return null;

                    var indent = this.getNextLineIndent(state, line.substring(0, cursor.column), session.getTabString());
                    var next_indent = this.$getIndent(line);

                    return {
                        text: '\n' + indent + '\n' + next_indent, // <- existing bracket will be indented
                        selection: [1, indent.length, 1, indent.length]
                    };
                }
            }
        });
```
