### PR TITLE
Remove mode and snippet dependency during build

### DIFF
--- a/lib/ace/snippets/javascript-jquery.js
+++ b/lib/ace/snippets/javascript-jquery.js
@@ -1,0 +1,7 @@
+define(function(require, exports, module) {
+"use strict";
+
+exports.snippetText = require("../requirejs/text!./javascript-jquery.snippets");
+exports.scope = "javascript-jquery";
+
+});

--- a/lib/ace/snippets/xslt.js
+++ b/lib/ace/snippets/xslt.js
@@ -1,0 +1,7 @@
+define(function(require, exports, module) {
+"use strict";
+
+exports.snippetText = require("../requirejs/text!./xslt.snippets");
+exports.scope = "xslt";
+
+});


### PR DESCRIPTION
Removed the one-to-one relationship of snippets to modes. The builder will create any snippet files for modes that do not have one, and will walk over the snippets folder and generate a snippet file for each.
