### PR TITLE
Remove trailing comma's, which break scripts in IE7

### DIFF
--- a/lib/ace/ext/themelist.js
+++ b/lib/ace/ext/themelist.js
@@ -76,7 +76,7 @@ var themeData = [
     ["Tomorrow Night Bright","tomorrow_night_bright"   ,  "dark"],
     ["Tomorrow Night 80s"   ,"tomorrow_night_eighties" ,  "dark"],
     ["Twilight"             ,"twilight"                ,  "dark"],
-    ["Vibrant Ink"          ,"vibrant_ink"             ,  "dark"],
+    ["Vibrant Ink"          ,"vibrant_ink"             ,  "dark"]
 ]
 
 

--- a/lib/ace/mode/sjs_highlight_rules.js
+++ b/lib/ace/mode/sjs_highlight_rules.js
@@ -194,7 +194,7 @@ var SJSHighlightRules = function() {
             token: "paren.lparen",
             regex: '{',
             next: "string_interp"
-        }),
+        })
     ].concat(embeddableRules);
 
     // backtick strings can have single interpolation, which accept


### PR DESCRIPTION
I'm not signing a CLA for removing two comma's, so either it's good this way, or someone with a CLA can resubmit :)
