### PR TITLE
shift+mousewheel to horiz scroll

### DIFF
--- a/lib/ace/mouse/default_handlers.js
+++ b/lib/ace/mouse/default_handlers.js
@@ -235,8 +235,15 @@ function DefaultHandlers(mouseHandler) {
     };
 
     this.onMouseWheel = function(ev) {
-        if (ev.getShiftKey() || ev.getAccelKey())
+        if (ev.getAccelKey())
             return;
+
+		//shift wheel to horiz scroll
+        if (ev.getShiftKey() && ev.wheelY && !ev.wheelX) {
+            ev.wheelX = ev.wheelY;
+            ev.wheelY = 0;
+        }
+
         var t = ev.domEvent.timeStamp;
         var dt = t - (this.$lastScrollTime||0);
         


### PR DESCRIPTION
Converts shift+mousewheel to horizontal scroll.
This is in accordance with Chrome which supports this shortcut on webpages and textareas.
