### PR TITLE
Use shim blob with importScripts to use CORS for Worker

### DIFF
--- a/lib/ace/worker/worker_client.js
+++ b/lib/ace/worker/worker_client.js
@@ -57,7 +57,21 @@ var WorkerClient = function(topLevelNamespaces, mod, classname) {
         });
     }
 
-    this.$worker = new Worker(workerUrl);
+    try {
+        this.$worker = new Worker(workerUrl);
+    } catch ( e ) {
+        if ( e instanceof DOMException ) {
+            // Likely same origin problem. Use importScripts from a shim Worker
+            var blob = this.blobWorker(workerUrl),
+                URL = URL || webkitURL,
+                blobURL = URL.createObjectURL(blob);
+
+            this.$worker = new Worker(blobURL);
+            URL.revokeObjectURL(blobURL);
+        } else {
+            throw e;
+        }
+    }
     this.$worker.postMessage({
         init : true,
         tlns: tlns,
@@ -163,7 +177,24 @@ var WorkerClient = function(topLevelNamespaces, mod, classname) {
             this.call("setValue", [this.$doc.getValue()]);
         } else
             this.emit("change", {data: q});
-    }
+    };
+
+    this.blobWorker = function(workerUrl) {
+        var script = 'importScripts("' + workerUrl + '");',
+            blob;
+        try {
+            blob = new Blob(
+                [script],
+                { 'type' : 'application/javascript' }
+            );
+        } catch (e) { // Backwards-compatibility
+            var BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder,
+                blobBuilder = new BlobBuilder();
+            blobBuilder.append(script);
+            blob = blobBuilder.getBlob('application/javascript');
+        }
+        return blob;
+    };
 
 }).call(WorkerClient.prototype);
 


### PR DESCRIPTION
I suggest this to overcome problems with cross origin loading of the Workers. Bypassing your CDN for this kind of stuff is simply not desirable.

importScripts unlike Worker constructors do support CORS, which makes no sense whatsoever.
