### PR TITLE
fix multiple replacements in search/ replace

### DIFF
--- a/lib/ace/search.js
+++ b/lib/ace/search.js
@@ -209,7 +209,7 @@ var Search = function() {
             return;
 
         var match = re.exec(input);
-        if (!match || match[0].length != input.length)
+        if (!match)
             return null;
         
         replacement = input.replace(re, replacement);


### PR DESCRIPTION
There is a check in the search/ replace function to ensure the input length is the same as the match length.
The docs state that the input is "The text to search in". Therefore the length should be irrelevant.
