### PR TITLE
Fix tab insertion when line is partly selected.

### DIFF
--- a/lib/ace/snippets.js
+++ b/lib/ace/snippets.js
@@ -413,6 +413,46 @@ var SnippetManager = function() {
         var before = line.substring(0, cursor.column);
         var after = line.substr(cursor.column);
 
+        function insertSnippet() {
+            editor.session.doc.removeInLine(cursor.row,
+                cursor.column - snippet.replaceBefore.length,
+                cursor.column + snippet.replaceAfter.length
+            );
+
+            this.variables.M__ = snippet.matchBefore;
+            this.variables.T__ = snippet.matchAfter;
+            this.insertSnippet(editor, snippet.content);
+
+            this.variables.M__ = this.variables.T__ = null;
+            return true;
+        }
+
+        function replaceTab() {
+            editor.session.doc.removeInLine(cursor.row, 
+                cursor.column - editor.getSelectedText.length,
+                cursor.column
+            );
+            editor.insert("\t");
+        }
+
+        function isFullLineSelect() {
+            return line === before || line === after;
+        }
+
+        function isMultLineSelect(){
+            var startRow = editor.selection.session.multiSelect.getRange().start.row;
+            var endRow = editor.selection.session.multiSelect.getRange().end.row;
+            return startRow != endRow;
+        }
+
+        function noSnippet() {
+            if(isMultLineSelect() || isFullLineSelect()) {
+                return false;
+            }
+            replaceTab();
+            return true;
+        }
+
         var snippetMap = this.snippetMap;
         var snippet;
         this.getActiveScopes(editor).some(function(scope) {
@@ -421,20 +461,11 @@ var SnippetManager = function() {
                 snippet = this.findMatchingSnippet(snippets, before, after);
             return !!snippet;
         }, this);
-        if (!snippet)
-            return false;
 
-        editor.session.doc.removeInLine(cursor.row,
-            cursor.column - snippet.replaceBefore.length,
-            cursor.column + snippet.replaceAfter.length
-        );
-
-        this.variables.M__ = snippet.matchBefore;
-        this.variables.T__ = snippet.matchAfter;
-        this.insertSnippet(editor, snippet.content);
-
-        this.variables.M__ = this.variables.T__ = null;
-        return true;
+        if(!snippet) {
+            return noSnippet();
+        }
+        return insertSnippet();
     };
 
     this.findMatchingSnippet = function(snippetList, before, after) {


### PR DESCRIPTION
Fixed the behavior when a tab is inserted and text is marked. When a whole
single line is selected or multiple lines are selected, the line(s) are
indented. Otherwise, therefore one line is partly selected, then the
selected text is overwritten with a tab.

Fixes #877
