### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010, Ajax.org B.V.
+Copyright (c) 2014, Ajax.org B.V.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
