### PR TITLE
Fixed passing non-Ranges into Document methods

### DIFF
--- a/lib/ace/document.js
+++ b/lib/ace/document.js
@@ -402,7 +402,7 @@ var Document = function(text) {
     *
     **/
     this.remove = function(range) {
-        if (!range instanceof Range)
+        if (!(range instanceof Range))
             range = Range.fromPoints(range.start, range.end);
         // clip to document
         range.start = this.$clipPosition(range.start);
@@ -522,7 +522,7 @@ var Document = function(text) {
     *
     **/
     this.replace = function(range, text) {
-        if (!range instanceof Range)
+        if (!(range instanceof Range))
             range = Range.fromPoints(range.start, range.end);
         if (text.length == 0 && range.isEmpty())
             return range.start;


### PR DESCRIPTION
Fixed issue introduced in b23265ad: ! takes precedence over instanceof.
