### PR TITLE
fix dollar; add comma syntax

### DIFF
--- a/demo/kitchen-sink/docs/cirru.cirru
+++ b/demo/kitchen-sink/docs/cirru.cirru
@@ -34,3 +34,9 @@ print (add $ (int 1) (int 2))
 
 print $ unwrap $
   map (a $ int 1) (b $ int 2)
+
+print a
+  int 1
+  , b c
+  int 2
+  , d

--- a/lib/ace/mode/cirru_highlight_rules.js
+++ b/lib/ace/mode/cirru_highlight_rules.js
@@ -48,6 +48,10 @@ var CirruHighlightRules = function() {
             token: 'storage.modifier',
             regex: /\(/,
         }, {
+            token: 'storage.modifier',
+            regex: /\,/,
+            next: 'line',
+        }, {
             token: 'support.function',
             regex: /[^\(\)\"\s]+/,
             next: 'line'
@@ -89,6 +93,10 @@ var CirruHighlightRules = function() {
             regex: /^\s*/,
             next: 'start',
         }, {
+            token: 'storage.modifier',
+            regex: /\$/,
+            next: 'start',
+        }, {
             token: 'variable.parameter',
             regex: /[^\(\)\"\s]+/
         }, {
@@ -101,10 +109,6 @@ var CirruHighlightRules = function() {
         }, {
             token: 'markup.raw',
             regex: /^\ */,
-            next: 'start',
-        }, {
-            token: 'storage.modifier',
-            regex: /\$/,
             next: 'start',
         }, {
             token: 'string.quoted.double',


### PR DESCRIPTION
A bug was found in Cirru's highlight, I fixed it.
And highlighting for leading `,` is added.
