### PR TITLE
Allow arbitrary language names in gfm fenced blocks

### DIFF
--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -79,7 +79,7 @@ var MarkdownHighlightRules = function() {
        github_embed("css", "csscode-"),
     { // Github style block
         token : "support.function",
-        regex : "^```\\s*[a-zA-Z\.]*(?:{.*?\\})?\\s*$",
+        regex : "^```\\s*\S*(?:{.*?\\})?\\s*$",
         next  : "githubblock"
     }, { // block quote
         token : "string.blockquote",


### PR DESCRIPTION
This change allows things like

``````
```c++
```
``````

and 

``````
```awesome-sauce
```
``````

Not truly necessary but a nice feature that allows some flexibility for future language names or customizations
