### PR TITLE
add missing backslash

### DIFF
--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -79,7 +79,7 @@ var MarkdownHighlightRules = function() {
        github_embed("css", "csscode-"),
     { // Github style block
         token : "support.function",
-        regex : "^```\\s*\S*(?:{.*?\\})?\\s*$",
+        regex : "^```\\s*\\S*(?:{.*?\\})?\\s*$",
         next  : "githubblock"
     }, { // block quote
         token : "string.blockquote",


### PR DESCRIPTION
Not sure what happened in the previous pull request but the \S should be escaped
