### PR TITLE
remove yaml comment syntax highlighting - it's too aggressive

### DIFF
--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -87,9 +87,6 @@ var YamlHighlightRules = function() {
                 token : "constant.language.boolean",
                 regex : "(?:true|false|TRUE|FALSE|True|False|yes|no)\\b"
             }, {
-                token : "invalid.illegal", // comments are not allowed
-                regex : "\\/\\/.*$"
-            }, {
                 token : "paren.lparen",
                 regex : "[[({]"
             }, {


### PR DESCRIPTION
This PR removes the yaml file formats syntax highlighting for line comments. It's too aggressive and matches valid yaml file contents (like urls).

![screen shot 2014-02-22 at 9 53 31 am](https://f.cloud.github.com/assets/1269969/2238366/902bffba-9bea-11e3-9d3b-d3df17048bba.png)
