### PR TITLE
Add auto-indent in CoffeeScript for if, for, while, and loop statements.

### DIFF
--- a/lib/ace/mode/coffee.js
+++ b/lib/ace/mode/coffee.js
@@ -50,7 +50,7 @@ oop.inherits(Mode, TextMode);
 
 (function() {
     
-    var indenter = /(?:[({[=:]|[-=]>|\b(?:else|switch|try|catch(?:\s*[$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*)?|finally))\s*$|^\s*(else\b\s*)?(?:if|for|while|loop)\b(?!.*\bthen\b)/;
+    var indenter = /(?:[({[=:]|[-=]>|\b(?:else|switch|(?:\s*[$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*)?|try|catch(?:\s*[$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*)?|finally))\s*$|^\s*(else\b\s*)?(?:if|for|while|loop)\b(?!.*\bthen\b)/;
     var commentLine = /^(\s*)#/;
     var hereComment = /^\s*###(?!#)/;
     var indentation = /^\s*/;


### PR DESCRIPTION
Submitted on behalf of David Bau(@davidbau).
This fixes a downstream bug(PencilCode/pencilcode-site#43).
