### PR TITLE
Font measuring and css transform webkit fix

### DIFF
--- a/lib/ace/layer/font_metrics.js
+++ b/lib/ace/layer/font_metrics.js
@@ -34,6 +34,7 @@ var oop = require("../lib/oop");
 var dom = require("../lib/dom");
 var lang = require("../lib/lang");
 var EventEmitter = require("../lib/event_emitter").EventEmitter;
+var useragent = require("../lib/useragent");
 
 var CHAR_COUNT = 0;
 
@@ -110,7 +111,7 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
             self.checkForSizeChanges();
         }, 500);
     };
-    
+
     this.setPolling = function(val) {
         if (val) {
             this.$pollSizeChanges();
@@ -120,7 +121,23 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
         }
     };
 
+    this.$invertTransforms = function(el) {
+        // Applying an inverse transform is currently only supprted for Webkit
+        if (!useragent.isWebKit) return;
+        var node = el.parentNode,
+            tfm = new WebKitCSSMatrix();
+
+        while (node) {
+            if (node.style && node.style.webkitTransform) {
+                tfm = tfm.multiply(new WebKitCSSMatrix(node.style.webkitTransform));
+            }
+            node = node.parentNode;
+        }
+        el.style.webkitTransform = tfm.inverse();
+    };
+
     this.$measureSizes = function() {
+        this.$invertTransforms(this.$measureNode);
         var rect = this.$measureNode.getBoundingClientRect();
         var size = {
             height: rect.height,
@@ -128,9 +145,7 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
         };
         // Size and width can be null if the editor is not visible or
         // detached from the document
-        if (size.width === 0 || size.height === 0)
-            return null;
-        return size;
+        return size.width === 0 || size.height === 0 ?  null : size;
     };
 
     this.$measureCharWidth = function(ch) {
@@ -138,7 +153,7 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
         var rect = this.$main.getBoundingClientRect();
         return rect.width / CHAR_COUNT;
     };
-    
+
     this.getCharacterWidth = function(ch) {
         var w = this.charSizes[ch];
         if (w === undefined) {

--- a/lib/ace/layer/text_test.js
+++ b/lib/ace/layer/text_test.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -52,26 +52,26 @@ module.exports = {
             characterWidth: 10,
             lineHeight: 20
         };
-        next()
+        next();
     },
 
     "test: render line with hard tabs should render the same as lines with soft tabs" : function() {
         this.session.setValue("a\ta\ta\t\na   a   a   \n");
         this.textLayer.$computeTabString();
-        
+
         // row with hard tabs
         var stringBuilder = [];
         this.textLayer.$renderLine(stringBuilder, 0);
-        
+
         // row with soft tabs
         var stringBuilder2 = [];
         this.textLayer.$renderLine(stringBuilder2, 1);
         assert.equal(stringBuilder.join(""), stringBuilder2.join(""));
     },
-    
+
     "test rendering width of ideographic space (U+3000)" : function() {
         this.session.setValue("\u3000");
-        
+
         var stringBuilder = [];
         this.textLayer.$renderLine(stringBuilder, 0, true);
         assert.equal(stringBuilder.join(""), "<span class='ace_cjk' style='width:20px'></span>");
@@ -85,8 +85,8 @@ module.exports = {
             + "<span class='ace_invisible'>\xB6</span>"
         );
     },
-    
-    "test rendering of indent guides" : function() {       
+
+    "test rendering of indent guides" : function() {
         var textLayer = this.textLayer
         var EOL = "<span class='ace_invisible'>" + textLayer.EOL_CHAR + "</span>";
         var SPACE = function(i) {return Array(i+1).join("\xa0")}
@@ -99,7 +99,7 @@ module.exports = {
                 assert.equal(stringBuilder.join(""), results[i]);
             }
         }
-        
+
         this.session.setValue("      \n\t\tf\n   ");
         testRender([
             "<span class='ace_indent-guide'>" + SPACE(4) + "</span>" + SPACE(2),
@@ -122,5 +122,5 @@ module.exports = {
 });
 
 if (typeof module !== "undefined" && module === require.main) {
-    require("asyncjs").test.testcase(module.exports).exec()
+    require("asyncjs").test.testcase(module.exports).exec();
 }

--- a/lib/ace/virtual_renderer_test.js
+++ b/lib/ace/virtual_renderer_test.js
@@ -122,10 +122,10 @@ module.exports = {
         var charHeightTransform = renderer.lineHeight;
         var charWidthTransform = renderer.characterWidth;
 
-        assert.equal(charHeightTransform, charHeight,
+        assert.equal(charHeightTransform.toFixed(2), charHeight.toFixed(2),
             'measured char height was changed by transform: '
             + charHeightTransform + ' vs. ' + charHeight);
-        assert.equal(charWidthTransform, charWidth,
+        assert.equal(charWidthTransform.toFixed(2), charWidth.toFixed(2),
             'measured char width was changed by transform'
             + charHeightTransform + ' vs. ' + charHeight);
     }

--- a/lib/ace/virtual_renderer_test.js
+++ b/lib/ace/virtual_renderer_test.js
@@ -36,27 +36,48 @@ if (typeof process !== "undefined") {
 define(function(require, exports, module) {
 "use strict";
 
+var useragent = require("./lib/useragent");
 var EditSession = require("./edit_session").EditSession;
 var VirtualRenderer = require("./virtual_renderer").VirtualRenderer;
+var TextInput = require("./keyboard/textinput").TextInput;
 var assert = require("./test/assertions");
 
+var el, outerEl, renderer;
+
 module.exports = {
+
+    setUp: function(next) {
+        outerEl = document.createElement("div");
+        el = document.createElement("div");
+
+        el.style.left = "20px";
+        el.style.top = "30px";
+        el.style.width = "300px";
+        el.style.height = "100px";
+        document.body.appendChild(outerEl);
+        outerEl.appendChild(el);
+
+        renderer = new VirtualRenderer(el);
+        renderer.setPadding(0);
+        var editorMock = {addEventListener: function() {}, onCommandKey: function() {}, renderer: renderer};
+        var textInput  = new TextInput(renderer.getTextAreaContainer(), editorMock);
+        renderer.textarea = textInput.getElement();
+
+        next();
+    },
+
+    tearDown : function(next) {
+        document.body.removeChild(outerEl);
+        next();
+    },
+
     "test: screen2text the column should be rounded to the next character edge" : function() {
-        var el = document.createElement("div");
 
         if (!el.getBoundingClientRect) {
             console.log("Skipping test: This test only runs in the browser");
             return;
         }
 
-        el.style.left = "20px";
-        el.style.top = "30px";
-        el.style.width = "300px";
-        el.style.height = "100px";
-        document.body.appendChild(el);
-
-        var renderer = new VirtualRenderer(el);
-        renderer.setPadding(0);
         renderer.setSession(new EditSession("1234"));
 
         var r = renderer.scroller.getBoundingClientRect();
@@ -73,9 +94,40 @@ module.exports = {
         testPixelToText(10, 0, 0, 1);
         testPixelToText(14, 0, 0, 1);
         testPixelToText(15, 0, 0, 2);
-        document.body.removeChild(el);
-    }
+    },
 
+    "test: correct text measuring with CSS transformations": function() {
+        if (!el.getBoundingClientRect || !useragent.isWebKit) {
+            console.log("Skipping test: This test only runs in the webkit browsers");
+            return;
+        }
+
+        renderer.setSession(new EditSession("xxx"));
+        renderer.updateFull(true);
+
+        var charHeight = renderer.lineHeight;
+        var charWidth = renderer.characterWidth;
+
+        outerEl.style["-webkit-transform"] =
+            outerEl.style["-o-transform"] =
+            outerEl.style["transform"] = "rotate(10deg) scale(1.2,1.2)";
+
+        el.style["-webkit-transform"] =
+            el.style["-o-transform"] =
+            el.style["transform"] = "rotate(10deg)";
+
+        renderer.$fontMetrics.checkForSizeChanges()
+
+        var charHeightTransform = renderer.lineHeight;
+        var charWidthTransform = renderer.characterWidth;
+
+        assert.equal(charHeightTransform, charHeight,
+            'measured char height was changed by transform: '
+            + charHeightTransform + ' vs. ' + charHeight);
+        assert.equal(charWidthTransform, charWidth,
+            'measured char width was changed by transform'
+            + charHeightTransform + ' vs. ' + charHeight);
+    }
 };
 
 });

--- a/lib/ace/virtual_renderer_test.js
+++ b/lib/ace/virtual_renderer_test.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -76,7 +76,6 @@ module.exports = {
         document.body.removeChild(el);
     }
 
-    // change tab size after setDocument (for text layer)
 };
 
 });

--- a/lib/ace/virtual_renderer_test.js
+++ b/lib/ace/virtual_renderer_test.js
@@ -57,6 +57,7 @@ module.exports = {
         document.body.appendChild(outerEl);
         outerEl.appendChild(el);
 
+        if (!el.getBoundingClientRect) { /*see below*/ next(); return; }
         renderer = new VirtualRenderer(el);
         renderer.setPadding(0);
         var editorMock = {addEventListener: function() {}, onCommandKey: function() {}, renderer: renderer};


### PR DESCRIPTION
When ace is being CSS transformed then font measuring is off, resulting in broken selections and cursor positions.

See http://jsfiddle.net/LGwxy/

This fixes the issue for Webkit browsers.
