### PR TITLE
Handle language-switching keystroke gracefully

### DIFF
--- a/lib/ace/lib/keys.js
+++ b/lib/ace/lib/keys.js
@@ -148,6 +148,10 @@ var Keys = (function() {
 oop.mixin(exports, Keys);
 
 exports.keyCodeToString = function(keyCode) {
+    // Language-switching keystroke in Chrome/Linux emits keyCode 0.
+    if (keyCode === 0) {
+        return '';
+    }
     return (Keys[keyCode] || String.fromCharCode(keyCode)).toLowerCase();
 };
 


### PR DESCRIPTION
This patch fixes a bug in the keypress handling flow. If I press a language-switching keystoke in Chrome/Linux, the browser emits keycode 0, which is mapped to number 48. This results in exception "48 does not have toLowerCase method".
Route cause of the bug: forward and reverse mapping are stored in the same dictionary.
This patch provides a workaround to handle this case.
