### PR TITLE
Add autoSelect option to auto completion

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -48,7 +48,7 @@ var Autocomplete = function() {
     this.changeListener = this.changeListener.bind(this);
     this.mousedownListener = this.mousedownListener.bind(this);
     this.mousewheelListener = this.mousewheelListener.bind(this);
-    
+
     this.changeTimer = lang.delayedCall(function() {
         this.updateCompletions(true);
     }.bind(this))
@@ -75,10 +75,10 @@ var Autocomplete = function() {
             this.popup.setFontSize(editor.getFontSize());
 
             var lineHeight = renderer.layerConfig.lineHeight;
-            
-            var pos = renderer.$cursorLayer.getPixelPosition(this.base, true);            
+
+            var pos = renderer.$cursorLayer.getPixelPosition(this.base, true);
             pos.left -= this.popup.getTextLeftOffset();
-            
+
             var rect = editor.container.getBoundingClientRect();
             pos.top += rect.top - renderer.layerConfig.offset;
             pos.left += rect.left - editor.renderer.scrollLeft;
@@ -95,7 +95,7 @@ var Autocomplete = function() {
         this.editor.off("mousedown", this.mousedownListener);
         this.editor.off("mousewheel", this.mousewheelListener);
         this.changeTimer.cancel();
-        
+
         if (this.popup)
             this.popup.hide();
 
@@ -173,7 +173,7 @@ var Autocomplete = function() {
         "Esc": function(editor) { editor.completer.detach(); },
         "Space": function(editor) { editor.completer.detach(); editor.insert(" ");},
         "Return": function(editor) {
-            if(editor.completer.popup.getRow() > -1) {
+            if (editor.completer.popup.getRow() > -1) {
                 editor.completer.insertMatch();
             } else {
                 editor.insert("\n");
@@ -189,10 +189,10 @@ var Autocomplete = function() {
     this.gatherCompletions = function(editor, callback) {
         var session = editor.getSession();
         var pos = editor.getCursorPosition();
-        
+
         var line = session.getLine(pos.row);
         var prefix = util.retrievePrecedingIdentifier(line, pos.column);
-        
+
         this.base = editor.getCursorPosition();
         this.base.column -= prefix.length;
 
@@ -215,7 +215,7 @@ var Autocomplete = function() {
     this.showPopup = function(editor) {
         if (this.editor)
             this.detach();
-        
+
         this.activated = true;
 
         this.editor = editor;
@@ -230,10 +230,10 @@ var Autocomplete = function() {
         editor.on("blur", this.blurListener);
         editor.on("mousedown", this.mousedownListener);
         editor.on("mousewheel", this.mousewheelListener);
-        
+
         this.updateCompletions();
     };
-    
+
     this.updateCompletions = function(keepPopupPosition) {
         if (keepPopupPosition && this.base && this.completions) {
             var pos = this.editor.getCursorPosition();
@@ -250,7 +250,7 @@ var Autocomplete = function() {
             var matches = results && results.matches;
             if (!matches || !matches.length)
                 return this.detach();
-            // TODO reenable this when we have proper change tracking 
+            // TODO reenable this when we have proper change tracking
             // if (matches.length == 1)
             //     return this.insertMatch(matches[0]);
 
@@ -306,16 +306,16 @@ var FilteredList = function(array, filterText, mutateData) {
         matches = matches.sort(function(a, b) {
             return b.exactMatch - a.exactMatch || b.score - a.score;
         });
-        
+
         // make unique
         var prev = null;
         matches = matches.filter(function(item){
-            var caption = item.value || item.caption || item.snippet; 
+            var caption = item.value || item.caption || item.snippet;
             if (caption === prev) return false;
             prev = caption;
             return true;
         });
-        
+
         this.filtered = matches;
     };
     this.filterCompletions = function(items, needle) {


### PR DESCRIPTION
By setting this to `false` no completion will be selected by default and pressing `Return` will simply insert a new line, rather than the first match. This is useful if one would want to implement continuous completion, for instance.
