### PR TITLE
Make sure the CORS blobworker loads absolute URLs

### DIFF
--- a/lib/ace/lib/net.js
+++ b/lib/ace/lib/net.js
@@ -38,4 +38,14 @@ exports.loadScript = function(path, callback) {
     };
 };
 
+/*
+ * Convert a url into a fully qualified absolute URL
+ * This function does not work in IE6
+ */
+exports.qualifyURL = function(url) {
+    var a = document.createElement('a');
+    a.href = url;
+    return a.href;
+}
+
 });

--- a/lib/ace/worker/worker_client.js
+++ b/lib/ace/worker/worker_client.js
@@ -32,6 +32,7 @@ define(function(require, exports, module) {
 "use strict";
 
 var oop = require("../lib/oop");
+var net = require("../lib/net");
 var EventEmitter = require("../lib/event_emitter").EventEmitter;
 var config = require("../config");
 
@@ -179,7 +180,9 @@ var WorkerClient = function(topLevelNamespaces, mod, classname, workerUrl) {
     };
 
     this.$workerBlob = function(workerUrl) {
-        var script = "importScripts('" + workerUrl + "');";
+        // workerUrl can be protocol relative
+        // importScripts only takes fully qualified urls
+        var script = "importScripts('" + net.qualifyURL( workerUrl ) + "');";
         try {
             return new Blob([script], {"type": "application/javascript"});
         } catch (e) { // Backwards-compatibility


### PR DESCRIPTION
The only situation where this is really needed, is if the workerURL is
protocol relative, since we only end up in this situation if workerurl
is on a different server to begin with.
