### PR TITLE
missing bitwise xor function

### DIFF
--- a/lib/ace/mode/php/php.js
+++ b/lib/ace/mode/php/php.js
@@ -4810,6 +4810,16 @@ PHP.Parser.prototype.Node_Expr_BitwiseOr = function() {
 
 };
 
+PHP.Parser.prototype.Node_Expr_BitwiseXor = function() {
+    return {
+        type: "Node_Expr_BitwiseXor",
+        left: arguments[ 0 ],
+        right: arguments[ 1 ],
+        attributes: arguments[ 2 ]
+    };
+
+};
+
 PHP.Parser.prototype.Node_Expr_BitwiseNot = function() {
     return {
         type: "Node_Expr_BitwiseNot",


### PR DESCRIPTION
Fixes error:

```
[object Object] has no method 'Node_Expr_BitwiseXor' 
```

Which results from using xor e.g:

```
error_reporting(E_ALL ^ E_NOTICE);

also reported to phpjs project:
https://github.com/niklasvh/php.js/pull/48
```
