### PR TITLE
Fix: HTML attribute autocomplete

### DIFF
--- a/lib/ace/mode/html_completions.js
+++ b/lib/ace/mode/html_completions.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -243,7 +243,7 @@ function findTagName(session, pos) {
             token = iterator.stepBackward();
         } while (token && (hasType(token, 'string') || hasType(token, 'operator') || hasType(token, 'attribute-name') || hasType(token, 'text')));
     }
-    if (token && hasType(token, 'tag-name') && !iterator.stepBackward().value.match('/'))
+    if (token && hasType(token, 'tag.name') && !iterator.stepBackward().value.match('/'))
         return token.value;
 }
 
@@ -260,7 +260,7 @@ var HtmlCompletions = function() {
             return [];
 
         // tag name
-        if (hasType(token, "tag-name") || (token.value == '<' && hasType(token, "text")))
+        if (hasType(token, "tag.name") || (token.value == '<' && hasType(token, "text")))
             return this.getTagCompletions(state, session, pos, prefix);
 
         // tag attribute


### PR DESCRIPTION
It was using “tag-name” that now seems deprecated in favor of
“tag.name” by the lexers however the autocomplete code hadn’t been
updated accordingly.

So I simply replaced “tag-name” with “tag.name”
