### PR TITLE
Added missing hasOwnProperty check into for-each

### DIFF
--- a/lib/ace/mode/text_highlight_rules.js
+++ b/lib/ace/mode/text_highlight_rules.js
@@ -57,6 +57,8 @@ var TextHighlightRules = function() {
             return;
         }
         for (var key in rules) {
+            if (!rules.hasOwnProperty(key)) continue;
+            
             var state = rules[key];
             for (var i = 0; i < state.length; i++) {
                 var rule = state[i];


### PR DESCRIPTION
Without these checks, things break if someone adds properties to Object.prototype.
