### PR TITLE
Added two missing hasOwnProperty checks

### DIFF
--- a/lib/ace/mode/text_highlight_rules.js
+++ b/lib/ace/mode/text_highlight_rules.js
@@ -57,6 +57,8 @@ var TextHighlightRules = function() {
             return;
         }
         for (var key in rules) {
+            if (!rules.hasOwnProperty(key)) continue;
+            
             var state = rules[key];
             for (var i = 0; i < state.length; i++) {
                 var rule = state[i];
@@ -88,8 +90,11 @@ var TextHighlightRules = function() {
                 states[i] = prefix + states[i];
         } else {
             states = [];
-            for (var key in embedRules)
+            for (var key in embedRules) {
+                if (!embedRules.hasOwnProperty(key)) continue;
+                
                 states.push(prefix + key);
+            }
         }
 
         this.addRules(embedRules, prefix);


### PR DESCRIPTION
Without this kind of hasOwnProperty check, for-each loops break if properties have been added to Object.prototype.
