### PR TITLE
Added missing hasOwnProperty check into for-each

### DIFF
--- a/lib/ace/layer/marker.js
+++ b/lib/ace/layer/marker.js
@@ -65,6 +65,8 @@ var Marker = function(parentEl) {
 
         var html = [];
         for (var key in this.markers) {
+            if (!this.markers.hasOwnProperty(key)) continue;
+            
             var marker = this.markers[key];
 
             if (!marker.range) {


### PR DESCRIPTION
Without this kind of hasOwnProperty check, for-each loops break if properties have been added to Object.prototype.
