### PR TITLE
Fix scroll blocking when scrollPastEnd is enabled

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -1372,7 +1372,7 @@ var VirtualRenderer = function(container, theme) {
         if (deltaY < 0 && this.session.getScrollTop() >= 1 - this.scrollMargin.top)
            return true;
         if (deltaY > 0 && this.session.getScrollTop() + this.$size.scrollerHeight
-            - this.layerConfig.maxHeight - (this.$size.scrollerHeight - this.lineHeight) * this.$scrollPastEnd
+            - this.session.getScreenLength() * this.lineHeight - (this.$size.scrollerHeight - this.lineHeight) * this.$scrollPastEnd
             < -1 + this.scrollMargin.bottom)
            return true;
         if (deltaX < 0 && this.session.getScrollLeft() >= 1 - this.scrollMargin.left)


### PR DESCRIPTION
This is the proposal to fix the issue:
Ace steals mousewheel events even when it is not scrollable. The bug occurs when you scroll down and `scrollPastEnd` is enabled.

Should we cache getScreenLength() or is there a better approach to fix the issue?
