### PR TITLE
Fix Range resolution

### DIFF
--- a/lib/ace/autocomplete/text_completer.js
+++ b/lib/ace/autocomplete/text_completer.js
@@ -29,7 +29,7 @@
  * ***** END LICENSE BLOCK ***** */
 
 define(function(require, exports, module) {
-    var Range = require("ace/range").Range;
+    var Range = require("../range").Range;
     
     var splitRegex = /[^a-zA-Z_0-9\$\-]+/;
 


### PR DESCRIPTION
using the absolute path was breaking the resolution of the Range class if imported from a mode.
To reproduce the bug:
Add the following line in a mode:
var LanguageTools = require("../ext/language_tools");

see https://github.com/28msec/ace/blob/xquery_refactoring/lib/ace/mode/xquery.js#L42 for instance.
