### PR TITLE
fix for anchor & insertRight behavior

### DIFF
--- a/lib/ace/anchor.js
+++ b/lib/ace/anchor.js
@@ -131,7 +131,10 @@ var Anchor = exports.Anchor = function(doc, row, column) {
                 row += end.row - start.row;
             }
         } else if (delta.action === "insertLines") {
-            if (start.row <= row) {
+            if (start.row === row && column === 0 && this.$insertRight) {
+                // do nothing
+            }
+            else if (start.row <= row) {
                 row += end.row - start.row;
             }
         } else if (delta.action === "removeText") {

--- a/lib/ace/anchor_test.js
+++ b/lib/ace/anchor_test.js
@@ -57,6 +57,15 @@ module.exports = {
         doc.insert({row: 1, column: 1}, "123");
         assert.position(anchor.getPosition(), 1, 7);
     },
+
+    "test insert text at anchor should not move anchor when insertRight is true": function() {
+        var doc = new Document("juhu\nkinners");
+        var anchor = new Anchor(doc, 1, 4);
+        anchor.$insertRight = true;
+        
+        doc.insert({row: 1, column: 4}, "123");
+        assert.position(anchor.getPosition(), 1, 4);
+    },    
     
     "test insert lines before cursor should move anchor row": function() {
         var doc = new Document("juhu\nkinners");
@@ -64,6 +73,32 @@ module.exports = {
         
         doc.insertLines(1, ["123", "456"]);
         assert.position(anchor.getPosition(), 3, 4);    
+    },
+
+    "test insert lines at anchor position should move anchor down": function() {
+        var doc = new Document("juhu\nkinners");
+        var anchor = new Anchor(doc, 1, 0);
+        
+        doc.insertLines(1, ["line"]);
+        assert.position(anchor.getPosition(), 2, 0);
+    },
+    
+    "test insert lines at anchor position should not move anchor down when insertRight is true and column is 0": function() {
+        var doc = new Document("juhu\nkinners");
+        var anchor = new Anchor(doc, 1, 0);
+        anchor.$insertRight = true;
+        
+        doc.insertLines(1, ["line"]);
+        assert.position(anchor.getPosition(), 1, 0);
+    }, 
+
+    "test insert lines at anchor row should move anchor down when column > 0": function() {
+        var doc = new Document("juhu\nkinners");
+        var anchor = new Anchor(doc, 1, 2);
+        anchor.$insertRight = true;
+        
+        doc.insertLines(1, ["line"]);
+        assert.position(anchor.getPosition(), 2, 2);            
     },
     
     "test insert new line before cursor should move anchor column": function() {


### PR DESCRIPTION
When you have an anchor set to insertRight and at column 0 when you call insertNewLine() or insertInLine() the anchor stays at its current position.

However, if you attempt to insertLines() at the same row as the anchor, the anchor is moved down. This doesn't seem to match the intended behavior of $insertRight, since all new text at the anchor position should go to the right of the anchor. 

This pull request changes the behavior of the anchor so that if $insertRight is true and it is at column 0, then when you insertLines() at the anchor's row, the anchor does not move.
