### PR TITLE
Fixed hotkeys for changing font size in demo (fixes #1914)

### DIFF
--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -184,7 +184,7 @@ env.editor.commands.addCommands([{
     }
 }, {
     name: "increaseFontSize",
-    bindKey: "Ctrl-+",
+    bindKey: "Ctrl-=",
     exec: function(editor) {
         var size = parseInt(editor.getFontSize(), 10) || 12;
         editor.setFontSize(size + 1);


### PR DESCRIPTION
Hotkey for `increaseFontSize` does not work, `+` key should actually be
`=`.
