### PR TITLE
Fix not recognizing `\\` as an escape sequence.

### DIFF
--- a/lib/ace/mode/d_highlight_rules.js
+++ b/lib/ace/mode/d_highlight_rules.js
@@ -66,7 +66,7 @@ var DHighlightRules = function() {
     
     var stringEscapesSeq =  {
         token: "constant.language.escape",
-        regex: "\\\\(?:(?:x[0-9A-F]{2})|(?:[0-7]{1,3})|(?:['\"\\?0abfnrtv])|" +
+        regex: "\\\\(?:(?:x[0-9A-F]{2})|(?:[0-7]{1,3})|(?:['\"\\?0abfnrtv\\\\])|" +
             "(?:u[0-9a-fA-F]{4})|(?:U[0-9a-fA-F]{8}))"
     };
 


### PR DESCRIPTION
This should fix D mode not recognizing `\\` as an escape sequence.
