### PR TITLE
IE7 cause error when accessing the HTMLElement.style.font property.

### DIFF
--- a/lib/ace/layer/font_metrics.js
+++ b/lib/ace/layer/font_metrics.js
@@ -85,7 +85,7 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
         style.visibility = "hidden";
         style.position = "fixed";
         style.whiteSpace = "pre";
-        style.font = "inherit";
+        style['font-family'] = style['font-style'] = style['font-weight'] = 'inherit';
         style.overflow = isRoot ? "hidden" : "visible";
     };
 


### PR DESCRIPTION
In IE7 cause Invalid Arguments error when accessing HTMLElement.style.font property,
so fix style.font to style.font-family, style.font-style, style.font-weight.
