### PR TITLE
IE7 cause error when accessing the HTMLElement.style.font property.

### DIFF
--- a/lib/ace/layer/font_metrics.js
+++ b/lib/ace/layer/font_metrics.js
@@ -88,9 +88,9 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
         style.whiteSpace = "pre";
 
         if (useragent.isIE < 8) {
-          style['font-family'] = 'inherit';
+            style["font-family"] = "inherit";
         } else {
-          style.font = 'inherit';
+            style.font = "inherit";
         }
         style.overflow = isRoot ? "hidden" : "visible";
     };


### PR DESCRIPTION
In IE7 cause Invalid Arguments error when accessing HTMLElement.style.font property.
So I was changed property access of the font from-family from the font.
