### PR TITLE
Prevent repeat firing of render callback

### DIFF
--- a/lib/ace/ext/static_highlight.js
+++ b/lib/ace/ext/static_highlight.js
@@ -100,7 +100,7 @@ var highlight = function(el, opts, callback) {
  */
 
 highlight.render = function(input, mode, theme, lineStart, disableGutter, callback) {
-    var waiting = 0;
+    var waiting = 1;
     var modeCache = EditSession.prototype.$modes;
 
     // if either the theme or the mode were specified as objects
@@ -127,7 +127,7 @@ highlight.render = function(input, mode, theme, lineStart, disableGutter, callba
         var result = highlight.renderSync(input, mode, theme, lineStart, disableGutter);
         return callback ? callback(result) : result;
     }
-    return waiting || done();
+    return --waiting || done();
 };
 
 /* 


### PR DESCRIPTION
**Issue**

If either the theme or mode are already cached, callback will be fired more than once.

This is because `config.loadModule` appears to fire its callback synchronously. This means that in the event that the theme is already cached, `waiting` will first be incremented then decremented in the same pass, resulting in `done` being called a first time.

Control will then flow to the `return` statement where waiting is still `0` and so the `callback` will fire a 2nd time.

**Changes**

Instead of changing the semantics of `config.loadModule`, I increment waiting at creation so that it will never fire until at least line 130 (`return` statement).
