### PR TITLE
IE7 does not support inherit for 'font' style property

### DIFF
--- a/lib/ace/layer/font_metrics.js
+++ b/lib/ace/layer/font_metrics.js
@@ -85,8 +85,13 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
         style.visibility = "hidden";
         style.position = "fixed";
         style.whiteSpace = "pre";
-        style.font = "inherit";
         style.overflow = isRoot ? "hidden" : "visible";
+        try {
+		style.font = "inherit";
+	} catch ( e ) {
+		// not supported in IE7
+		// not continuing here, might leave the editor in a measuring death spiral
+	}
     };
 
     this.checkForSizeChanges = function() {


### PR DESCRIPTION
If we don't catch and continue here, but way higher in the code (as
MediaWiki does), the editor is left in a partially intialized state, that
seems to cause a (measuring?) death spiral.

Discovered while investigating IE7 issues on Wikipedia. #1929
