### PR TITLE
add dartdoc indentation handling to the dart mode

### DIFF
--- a/lib/ace/mode/dart_highlight_rules.js
+++ b/lib/ace/mode/dart_highlight_rules.js
@@ -6,6 +6,7 @@ define(function(require, exports, module) {
 "use strict";
 
 var oop = require("../lib/oop");
+var DocCommentHighlightRules = require("./doc_comment_highlight_rules").DocCommentHighlightRules;
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 
 var DartHighlightRules = function() {
@@ -41,6 +42,7 @@ var DartHighlightRules = function() {
             token : "comment",
             regex : /\/\/.*$/
         },
+        DocCommentHighlightRules.getStartRule("doc-start"),
         {
             token : "comment", // multi line comment
             regex : /\/\*/,
@@ -174,6 +176,8 @@ var DartHighlightRules = function() {
         }, stringfill]
 }
 
+    this.embedRules(DocCommentHighlightRules, "doc-",
+        [ DocCommentHighlightRules.getEndRule("start") ]);
 };
 
 oop.inherits(DartHighlightRules, TextHighlightRules);


### PR DESCRIPTION
This PR adds auto-ident support for dartdoc in the dart mode. So, indenting with `*` when appropriate. See also https://github.com/ajaxorg/ace/blob/master/lib/ace/mode/java_highlight_rules.js.
