### PR TITLE
Linking class for firing eclipse-style identifier ctrl + click link events.

### DIFF
--- a/lib/ace/ext/linking.js
+++ b/lib/ace/ext/linking.js
@@ -36,10 +36,10 @@ require("../config").defineOptions(Editor.prototype, "editor", {
     enableLinking: {
         set: function(val) {
             if (val) {
-                this.on("mousedown", onMouseDown);
+                this.on("click", onClick);
                 this.on("mousemove", onMouseMove);
             } else {
-                this.off("mousedown", onMouseDown);
+                this.off("click", onClick);
                 this.off("mousemove", onMouseMove);
             }
         },
@@ -57,11 +57,11 @@ function onMouseMove(e) {
         var session = editor.session;
         var token = session.getTokenAt(docPos.row, docPos.column);
 
-        editor._emit("link_hover", {position: docPos, token: token});
+        editor._emit("linkHover", {position: docPos, token: token});
     }
 }
 
-function onMouseDown(e) {
+function onClick(e) {
     var ctrl = e.getAccelKey();
     var button = e.getButton();
 
@@ -71,11 +71,8 @@ function onMouseDown(e) {
         var session = editor.session;
         var token = session.getTokenAt(docPos.row, docPos.column);
 
-        editor._emit("link", {position: docPos, token: token});
+        editor._emit("linkClick", {position: docPos, token: token});
     }
 }
-
-exports.onMouseMove = onMouseMove;
-exports.onMouseDown = onMouseDown;
 
 });


### PR DESCRIPTION
Made and implemented `Linking` class for firing eclipse-style identifier `ctrl + <click>` link events.  Off by default, this can be used by the listener to navigate to the declaration (multi-select must be disabled first, so the accelerator modifiers won't conflict).

Not quite sure how to create tests for this since is is pretty much direct from mouse to event listener.  
