### PR TITLE
Set CSS manually in the context menu handler

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -178,7 +178,7 @@ var TextInput = function(parentNode, host) {
             }
             inComposition ? onCompositionUpdate() : onCompositionStart();
         });
-        // when user presses backspace after focusing the editor 
+        // when user presses backspace after focusing the editor
         // propertychange isn't called for the next character
         event.addListener(text, "keydown", function (e) {
             syncProperty.schedule(50);
@@ -431,7 +431,10 @@ var TextInput = function(parentNode, host) {
         if (!tempStyle)
             tempStyle = text.style.cssText;
 
-        text.style.cssText = "z-index:100000;" + (useragent.isIE ? "opacity:0.1;" : "");
+        text.style.zIndex = "100000";
+        if (useragent.isIE) {
+          text.style.opacity = "0.1";
+        }
 
         resetSelection(host.selection.isEmpty());
         host._emit("nativecontextmenu", {target: host, domEvent: e});
@@ -443,7 +446,7 @@ var TextInput = function(parentNode, host) {
         var move = function(e) {
             text.style.left = e.clientX - left - 2 + "px";
             text.style.top = Math.min(e.clientY - top - 2, maxTop) + "px";
-        }; 
+        };
         move(e);
 
         if (e.type != "mousedown")


### PR DESCRIPTION
In Chrome apps (and, I assume, other secure pages), Ace triggers the content security policy against unsafe-eval when it uses the `style.cssText` parameter. Most of the time, I don't think this matters, but in the case of the textinput context menu, the error prevents the correct context menu from opening up with copy/paste/etc. I think this is a new change in Chrome 34, because it always worked before. Thanks Google!

This pull request sets the styles manually, which should be safe cross-browser for zIndex and opacity at this point. It's a little more clumsy than the `cssText` solution, but it lets context menus open up in Chrome apps again. 
