### PR TITLE
Fix broken GitHub ribbon image src.

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <a href="http://github.com/ajaxorg/ace">
-        <img style="z-index: 50000; position: absolute; top: 0; right: 0; border: 0; width: 125px; height: 125px" src="https://a248.e.akamai.net/camo.github.com/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" />
+        <img style="z-index: 50000; position: absolute; top: 0; right: 0; border: 0; width: 125px; height: 125px" src="https://camo.githubusercontent.com/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" />
         </a>
         <div id="wrapper">
             <div class="content">


### PR DESCRIPTION
It seems that `a248.e.akamai.net/camo.github.com` does not works now. So I fixed it to `camo.githubusercontent.com`. Copied new url from https://github.com/blog/273-github-ribbons. Changed only host, not path so theme of ribbon may be same with previous one.

``` bash
$ curl -I "https://a248.e.akamai.net/camo.github.com/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67"
HTTP/1.1 400 Bad Request
Server: Apache
Content-Type: text/html; charset=iso-8859-1
Date: Fri, 09 May 2014 06:15:48 GMT
Connection: keep-alive
```
