### PR TITLE
Isolate float regex matching to 1 char for + and -

### DIFF
--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -79,7 +79,7 @@ var YamlHighlightRules = function() {
                 regex : "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"
             }, {
                 token : "constant.numeric", // float
-                regex : /[+\-]?[\d_]+(?:(?:\.[\d_]*)?(?:[eE][+\-]?[\d_]+)?)?\b/
+                regex : /(\b|[+\-\.])[\d_]+(?:(?:\.[\d_]*)?(?:[eE][+\-]?[\d_]+)?)/
             }, {
                 token : "constant.numeric", // other number
                 regex : /[+\-]?\.inf\b|NaN\b|0x[\dA-Fa-f_]+|0b[10_]+/


### PR DESCRIPTION
This prevents highlighting on the "2" in "auth: oauth2". (signing CLA and sending in now)
