### PR TITLE
Slightly improved auto indent for Clojure

### DIFF
--- a/lib/ace/mode/clojure.js
+++ b/lib/ace/mode/clojure.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,7 +35,7 @@ var oop = require("../lib/oop");
 var TextMode = require("./text").Mode;
 var ClojureHighlightRules = require("./clojure_highlight_rules").ClojureHighlightRules;
 var MatchingParensOutdent = require("./matching_parens_outdent").MatchingParensOutdent;
-var Range = require("../range").Range;
+var lang = require("../lib/lang");
 
 var Mode = function() {
     this.HighlightRules = ClojureHighlightRules;
@@ -47,6 +47,19 @@ oop.inherits(Mode, TextMode);
 
     this.lineCommentStart = ";";
 
+    this.$checkBracketDelta = function (line) {
+        var delta = 0;
+        for(var i = 0; i < line.length; i++) {
+            var ch = line[i];
+            if(ch === '(' || ch === '[' || ch === '{') {
+                delta++;
+            } else if(ch === ')' || ch === ']' || ch === '}') {
+                delta--;
+            }
+        }
+        return delta;
+    };
+
     this.getNextLineIndent = function(state, line, tab) {
         var indent = this.$getIndent(line);
 
@@ -56,15 +69,13 @@ oop.inherits(Mode, TextMode);
         if (tokens.length && tokens[tokens.length-1].type == "comment") {
             return indent;
         }
-        
+
         if (state == "start") {
-            var match = line.match(/[\(\[]/);
-            if (match) {
-                indent += "  ";
-            }
-            match = line.match(/[\)]/);
-            if (match) {
-              indent = "";
+            var delta = this.$checkBracketDelta(line);
+            if (delta > 0) {
+                indent += tab;
+            } else if (delta < 0) {
+                indent = indent.substring(0, indent.length - tab.length);
             }
         }
 


### PR DESCRIPTION
Previous one was bad, this one's slightly better (for "proper" indent you need to consider everything preceding the cursor, but that's not available at this time). This is OK for now, though.
