### PR TITLE
Fixed matlab syntax highlighting bug.

### DIFF
--- a/lib/ace/mode/matlab_highlight_rules.js
+++ b/lib/ace/mode/matlab_highlight_rules.js
@@ -166,7 +166,7 @@ var keywords = (
     this.$rules = {
         "start" : [ {
             token : "comment",
-            regex : "^%[^\r\n]*"
+            regex : "%[^\r\n]*"
         }, {
              token : "string",           // " string
             regex : '".*?"'
@@ -181,7 +181,7 @@ var keywords = (
             regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
         }, {
             token : "keyword.operator",
-            regex : "\\+|\\-|\\/|\\/\\/|%|<@>|@>|<@|&|\\^|~|<|>|<=|=>|==|!=|<>|="
+            regex : "\\+|\\-|\\/|\\/\\/|<@>|@>|<@|&|\\^|~|<|>|<=|=>|==|!=|<>|="
         }, {
              token : "punctuation.operator",
              regex : "\\?|\\:|\\,|\\;|\\."


### PR DESCRIPTION
Matlab comment character is no longer an operator, and the comment highlight is no longer anchored to the line start.
