### PR TITLE
add the rethrow keyword to the syntax highlighter

### DIFF
--- a/lib/ace/mode/dart_highlight_rules.js
+++ b/lib/ace/mode/dart_highlight_rules.js
@@ -13,7 +13,7 @@ var DartHighlightRules = function() {
 
     var constantLanguage = "true|false|null";
     var variableLanguage = "this|super";
-    var keywordControl = "try|catch|finally|throw|assert|break|case|continue|default|do|else|for|if|in|return|switch|while|new";
+    var keywordControl = "try|catch|finally|throw|rethrow|assert|break|case|continue|default|do|else|for|if|in|return|switch|while|new";
     var keywordDeclaration = "abstract|class|extends|external|factory|implements|get|native|operator|set|typedef|with";
     var storageModifier = "static|final|const";
     var storageType = "void|bool|num|int|double|dynamic|var|String";


### PR DESCRIPTION
Add the `rethrow` keyword to the Dart syntax highlighter.
