### PR TITLE
useragent.isGecko is false on Firefox 29

### DIFF
--- a/lib/ace/lib/useragent.js
+++ b/lib/ace/lib/useragent.js
@@ -82,7 +82,7 @@ exports.isIE =
 exports.isOldIE = exports.isIE && exports.isIE < 9;
 
 // Is this Firefox or related?
-exports.isGecko = exports.isMozilla = window.controllers && window.navigator.product === "Gecko";
+exports.isGecko = exports.isMozilla = (window.Controllers || window.controllers) && window.navigator.product === "Gecko";
 
 // oldGecko == rev < 2.0 
 exports.isOldGecko = exports.isGecko && parseInt((ua.match(/rv\:(\d+)/)||[])[1], 10) < 4;


### PR DESCRIPTION
`window.controllers` was renamed to `window.Controllers` in Firefox 29, and will back in Firefox 30.
I changed to check the existence of `Controllers` or `controllers`.
More information is available here: https://developer.mozilla.org/en-US/Firefox/Releases/29/Site_Compatibility
