### PR TITLE
Use current document to process <script> tags (fixes ajaxorg/ace#2003)

### DIFF
--- a/lib/ace/config.js
+++ b/lib/ace/config.js
@@ -153,7 +153,8 @@ function init(packaged) {
     var scriptOptions = {};
     var scriptUrl = "";
 
-    var currentScript = (document.currentScript || document._currentScript );
+    // Use currentScript.ownerDocument in case this file was loaded from imported document. (HTML Imports)
+    var currentScript = (document.currentScript || document._currentScript ); // native or polyfill
     var currentDocument = currentScript && currentScript.ownerDocument || document;
     
     var scripts = currentDocument.getElementsByTagName("script");


### PR DESCRIPTION
Use current document not the main document for checking other `<script>` tags.

Should fix loading `ace.js` from HTML Imported documents.

PS> How should I deliver signed CLA?
