### PR TITLE
Match platform specifics for dragDelay of text

### DIFF
--- a/lib/ace/mouse/mouse_handler.js
+++ b/lib/ace/mouse/mouse_handler.js
@@ -192,7 +192,7 @@ var MouseHandler = function(editor) {
 
 config.defineOptions(MouseHandler.prototype, "mouseHandler", {
     scrollSpeed: {initialValue: 2},
-    dragDelay: {initialValue: 150},
+    dragDelay: {initialValue: (useragent.isMac ? 150 : 0)},
     dragEnabled: {initialValue: true},
     focusTimout: {initialValue: 0},
     tooltipFollowsMouse: {initialValue: true}


### PR DESCRIPTION
On Mac it is actually 1000ms by default. On other platforms it either
does not exist or at most it's very small.

This fixes issue #1879
