### PR TITLE
remove the invalid rule from the go syntax file

### DIFF
--- a/lib/ace/mode/golang_highlight_rules.js
+++ b/lib/ace/mode/golang_highlight_rules.js
@@ -73,9 +73,6 @@ define(function(require, exports, module) {
                     token : "paren.rparen",
                     regex : "[\\])}]"
                 }, {
-                    token: "invalid",
-                    regex: "\\s+$"
-                }, {
                     token : "text",
                     regex : "\\s+"
                 }


### PR DESCRIPTION
Remove the `invalid` rule from the golang syntax highlighting file. It would display an highlighted error rectangle if a line ended in whitespace. This had a lot of false positives though, in that it would mark a line as an error as you were typing, before you typed the first non-ws char. It's a bit annoying for this to happen for every line you type.

![screen shot 2014-06-28 at 10 24 06 pm](https://cloud.githubusercontent.com/assets/1269969/3422582/fb8ee8c8-ff4d-11e3-8af8-e8d6c5862a4c.png)
