### PR TITLE
Change Vim emulation to use long-word selection.

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -57,6 +57,8 @@ var startCommands = {
     }
 };
 
+var $formerLineStart;
+
 exports.handler = {
 	$id: "ace/keyboard/vim",
     // workaround for j not repeating with `defaults write -g ApplePressAndHoldEnabled -bool true`
@@ -166,6 +168,8 @@ exports.handler = {
 
     attach: function(editor) {
         editor.on("click", exports.onCursorMove);
+        $formerLongWords = editor.session.$selectLongWords;
+        editor.session.$selectLongWords = true;
         if (util.currentMode !== "insert")
             cmds.coreCommands.stop.exec(editor);
         editor.$vimModeHandler = this;
@@ -175,6 +179,7 @@ exports.handler = {
 
     detach: function(editor) {
         editor.removeListener("click", exports.onCursorMove);
+        editor.session.$selectLongWords = $formerLongWords;
         util.noMode(editor);
         util.currentMode = "normal";
         this.updateMacCompositionHandlers(editor, false);


### PR DESCRIPTION
Key bindings like i_<C-W> should delete through whitespace. While this change does not even begin to emulate Vim's selection behaviour, it should at least ameliorate it for now. 

This patch is unnecessary as it doesn't quite resolve this misbehaviour. This change will likely later need to be removed in favor of a Vim-specific selection implementation.
