### PR TITLE
 '/' in vim mode maps to search

### DIFF
--- a/lib/ace/keyboard/vim/commands.js
+++ b/lib/ace/keyboard/vim/commands.js
@@ -38,6 +38,7 @@ var motions = require("./maps/motions");
 var operators = require("./maps/operators");
 var alias = require("./maps/aliases");
 var registers = require("./registers");
+var search = require("../../ext/searchbox").Search;
 
 var NUMBER = 1;
 var OPERATOR = 2;
@@ -309,8 +310,7 @@ var actions = exports.actions = {
     },
     "/": {
         fn: function(editor, range, count, param) {
-            if (editor.showCommandLine)
-                editor.showCommandLine("/");
+            search(editor);
         }
     },
     "?": {


### PR DESCRIPTION
This pull request maps '/' to search. Issue raised in #2034. 
