### PR TITLE
add the show and hide keywords to the dart mode

### DIFF
--- a/lib/ace/mode/dart_highlight_rules.js
+++ b/lib/ace/mode/dart_highlight_rules.js
@@ -54,7 +54,7 @@ var DartHighlightRules = function() {
         },
         {
             token: "keyword.other.import.dart",
-            regex: "(?:\\b)(?:library|import|export|part|of)(?:\\b)"
+            regex: "(?:\\b)(?:library|import|export|part|of|show|hide)(?:\\b)"
         },
         {
             token : ["keyword.other.import.dart", "text"],


### PR DESCRIPTION
Add the `show` and `hide` keywords to the import syntax for the Dart mode.
