### PR TITLE
Redraw lines and active line highlight when offscreen updates are made

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -708,6 +708,7 @@ var Editor = function(renderer, session) {
 
         // update cursor because tab characters can influence the cursor position
         this.$cursorChange();
+        this.$updateHighlightActiveLine();
     };
 
     this.onTokenizerUpdate = function(e) {

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -276,8 +276,13 @@ var VirtualRenderer = function(container, theme) {
                 this.$changedLines.lastRow = lastRow;
         }
 
-        if (this.$changedLines.firstRow > this.layerConfig.lastRow ||
-            this.$changedLines.lastRow < this.layerConfig.firstRow)
+        // If the change happened offscreen above us then it's possible
+        // that a new line wrap will affect the position of the lines on our
+        // screen so they need redrawn.
+        if (this.$changedLines.lastRow < this.layerConfig.firstRow)
+            this.$changedLines.lastRow = this.layerConfig.lastRow
+
+        if (this.$changedLines.firstRow > this.layerConfig.lastRow)
             return;
         this.$loop.schedule(this.CHANGE_LINES);
     };


### PR DESCRIPTION
The lines and active line highlight do not correctly update when line wrapping is on and text is inserted offscreen above the cursor which causes it to wrap onto a new line.

This bug is illustrated in an example here: http://jsfiddle.net/jpallen/TK7Fq/2/ You can see that the cursor moves to the correct position when text is inserted above, but the contents of the lines, and the active line highlight do not. As soon as you type anything, it triggers a full render and everything goes back to normal.

This pull request fixes this by updating the active line highlight on every document change, and redrawing the onscreen lines if the changed lines are above us. Both of these things introduce more renderer work, but I don't think either of them should be a performance problem. Happy to be pointed at a better solution though.
