### PR TITLE
ie11 fix getBoundingClientRect() error

### DIFF
--- a/lib/ace/layer/font_metrics.js
+++ b/lib/ace/layer/font_metrics.js
@@ -132,7 +132,7 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
             try { 
                rect = this.$measureNode.getBoundingClientRect();
             } catch(e) {
-               rect = {width: 0, height:0 }
+               rect = {width: 0, height:0 };
             };
             var size = {
                 height: rect.height,


### PR DESCRIPTION
rect = this.$measureNode.getBoundingClientRect(); was thawing and exception on our site
this simple fix will prevent that exception!
