### PR TITLE
Keep apparent scroll position fixed when changes are made offscreen

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -809,6 +809,15 @@ var VirtualRenderer = function(container, theme) {
             changes & this.CHANGE_H_SCROLL
         ) {
             changes |= this.$computeLayerConfig();
+            // If a change is made offscreen and wrapMode is on, then the onscreen
+            // lines may have been pushed down. If so, the first screen row will not
+            // have changed, but the first actual row will. In that case, adjust 
+            // scrollTop so that the cursor and onscreen content stays in the same place.
+            if (config.firstRow != this.layerConfig.firstRow && config.firstRowScreen == this.layerConfig.firstRowScreen) {
+                this.scrollTop = this.scrollTop + (config.firstRow - this.layerConfig.firstRow) * this.lineHeight;
+                changes = changes | this.CHANGE_SCROLL;
+                changes |= this.$computeLayerConfig();
+            }
             config = this.layerConfig;
             // update scrollbar first to not lose scroll position when gutter calls resize
             this.$updateScrollBarV();


### PR DESCRIPTION
As discussed with @nightwing in #2041, this keeps the cursor and on-screen lines unchanged when changes are made to the document off screen. This is only an issue when using line wrapping, since a soft-wrap will cause all the content below to be pushed down by a row. This might happen in a collaborative editing context for example.
