### PR TITLE
Enabled C-style behaviors for Ruby

### DIFF
--- a/lib/ace/mode/ruby.js
+++ b/lib/ace/mode/ruby.js
@@ -36,11 +36,13 @@ var TextMode = require("./text").Mode;
 var RubyHighlightRules = require("./ruby_highlight_rules").RubyHighlightRules;
 var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutdent;
 var Range = require("../range").Range;
+var CstyleBehaviour = require("./behaviour/cstyle").CstyleBehaviour;
 var FoldMode = require("./folding/coffee").FoldMode;
 
 var Mode = function() {
     this.HighlightRules = RubyHighlightRules;
     this.$outdent = new MatchingBraceOutdent();
+    this.$behaviour = new CstyleBehaviour();
     this.foldingRules = new FoldMode();
 };
 oop.inherits(Mode, TextMode);


### PR DESCRIPTION
Somebody requested behaviors for Ruby (zedapp/zed#432). As it turns out C-style behaviors apply to Ruby to, so let's enable them.
