### PR TITLE
Add VHDL to modelist

### DIFF
--- a/lib/ace/ext/modelist.js
+++ b/lib/ace/ext/modelist.js
@@ -151,6 +151,7 @@ var supportedModes = {
     VBScript:    ["vbs|vb"],
     Velocity:    ["vm"],
     Verilog:     ["v|vh|sv|svh"],
+    VHDL:        ["vhd|vhdl"],
     XML:         ["xml|rdf|rss|wsdl|xslt|atom|mathml|mml|xul|xbl"],
     XQuery:      ["xq"],
     YAML:        ["yaml|yml"]


### PR DESCRIPTION
##### What does this PR do?

There is already a VHDL syntax highlighter, but the filename detection fails, because the file extension is missing in the modelist.
