### PR TITLE
Make DragdropHandler more bulletproof

### DIFF
--- a/lib/ace/mouse/dragdrop_handler.js
+++ b/lib/ace/mouse/dragdrop_handler.js
@@ -84,7 +84,7 @@ function DragdropHandler(mouseHandler) {
         if (useragent.isOpera) {
             editor.container.appendChild(blankImage);
             // force layout
-            blankImage._top = blankImage.offsetTop;
+            blankImage.scrollTop = 0;
         }
         dataTransfer.setDragImage && dataTransfer.setDragImage(blankImage, 0, 0);
         if (useragent.isOpera) {
@@ -115,6 +115,8 @@ function DragdropHandler(mouseHandler) {
     this.onDragEnter = function(e) {
         if (editor.getReadOnly() || !canAccept(e.dataTransfer))
             return;
+        x = e.clientX;
+        y = e.clientY;
         if (!dragSelectionMarker)
             addDragMarker();
         counter++;
@@ -126,6 +128,8 @@ function DragdropHandler(mouseHandler) {
     this.onDragOver = function(e) {
         if (editor.getReadOnly() || !canAccept(e.dataTransfer))
             return;
+        x = e.clientX;
+        y = e.clientY;
         // Opera doesn't trigger dragenter event on drag start
         if (!dragSelectionMarker) {
             addDragMarker();
@@ -133,8 +137,6 @@ function DragdropHandler(mouseHandler) {
         }
         if (onMouseMoveTimer !== null)
             onMouseMoveTimer = null;
-        x = e.clientX;
-        y = e.clientY;
 
         e.dataTransfer.dropEffect = dragOperation = getDropEffect(e);
         return event.preventDefault(e);
@@ -150,7 +152,7 @@ function DragdropHandler(mouseHandler) {
     };
 
     this.onDrop = function(e) {
-        if (!dragSelectionMarker)
+        if (!dragCursor)
             return;
         var dataTransfer = e.dataTransfer;
         if (isInternal) {
@@ -264,6 +266,7 @@ function DragdropHandler(mouseHandler) {
         if (editor.isFocused())
             editor.renderer.$cursorLayer.setBlinking(false);
         clearInterval(timerId);
+        onDragInterval();
         timerId = setInterval(onDragInterval, 20);
         counter = 0;
         event.addListener(document, "mousemove", onMouseMove);
@@ -279,6 +282,7 @@ function DragdropHandler(mouseHandler) {
         if (editor.isFocused() && !isInternal)
             editor.renderer.$cursorLayer.setBlinking(!editor.getReadOnly());
         range = null;
+        dragCursor = null;
         counter = 0;
         autoScrollStartTime = null;
         cursorMovedTime = null;


### PR DESCRIPTION
This should fix https://github.com/ajaxorg/ace/issues/2113

dragCursor get initialized in `onDragInterval`, after 20ms delay. So if we get `drop` event before `onDragInterval`, we get error. 

So, lets call `onDragInterval` immediately.
