### PR TITLE
Adding highlight support for the UNION SQL keyword

### DIFF
--- a/lib/ace/mode/sql_highlight_rules.js
+++ b/lib/ace/mode/sql_highlight_rules.js
@@ -38,7 +38,7 @@ var SqlHighlightRules = function() {
 
     var keywords = (
         "select|insert|update|delete|from|where|and|or|group|by|order|limit|offset|having|as|case|" +
-        "when|else|end|type|left|right|join|on|outer|desc|asc"
+        "when|else|end|type|left|right|join|on|outer|desc|asc|union"
     );
 
     var builtinConstants = (


### PR DESCRIPTION
Looks like the `UNION` SQL keyword isn't supported by Ace's current SQL mode. This pull request adds it to the list of supported keywords.
