### PR TITLE
Fixing typos in selection docs.

### DIFF
--- a/api/selection.html
+++ b/api/selection.html
@@ -163,7 +163,7 @@
     <article id="Selection" data-title="Selection (class)" class="article">
       <div class="section description">
         <div class="memberContent"><p>Contains the cursor position and the text selection of an edit session.</p>
-<p>The row/columns used in the selection are in document coordinates representing ths coordinates as they appear in the document before applying soft wrap and folding.</p>
+<p>The row/columns used in the selection are in document coordinates representing the coordinates as they appear in the document before applying soft wrap and folding.</p>
 
         </div>
       </div>


### PR DESCRIPTION
I'm not sure what's up with the diff at the end of the file. I didn't change anything there.
