### PR TITLE
Changed FilteredList.setFilter unique matches computing in autocomplete.js

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -345,7 +345,7 @@ var FilteredList = function(array, filterText, mutateData) {
         // make unique
         var prev = null;
         matches = matches.filter(function(item){
-            var caption = item.value || item.caption || item.snippet;
+            var caption = item.snippet || item.caption || item.value;
             if (caption === prev) return false;
             prev = caption;
             return true;


### PR DESCRIPTION
For example `std::set<T>::insert` in C++ have many overloads. Passing from custom completer to ace something like this:

``` javascript
[
    (...)
    {
        caption: "insert(const value_type& value)",
        meta: "std::pair<iterator,bool>",
        snippet: "insert(${1:const value_type& value})${2}",
        value: "insert"
    },
    {
        caption: "insert(InputIt first, InputIt last)",
        meta: "void",
        snippet: "insert(${1:InputIt first}, ${2:InputIt last})${3}",
        value: "insert"
    }
    (...)
]
```

Is resulting in leaving just one overload because it eliminates entries with same `value`. I'm setting same `value` on this entries because the matching is performed on this field, and I want to match only to the method name. My pull request changes the order of fields compared in unique entries computation to fix this issue.
