### PR TITLE
More subtle scroll shadow

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -72,7 +72,7 @@
 }
 
 .ace_scroller.ace_scroll-left {
-    box-shadow: 17px 0 16px -16px rgba(0, 0, 0, 0.4) inset;
+    box-shadow: 2px 0 1px -1px rgba(0, 0, 0, 0.2) inset;
 }
 
 .ace_gutter-cell {


### PR DESCRIPTION
The current scroll shadow is a tad strong, and adds quite a lot of noise to the code. This makes it more subtle. (It almost looks a bit too subtle in the resized screenshot, but paste the change into the inspector and try it out—it's still clear you've scrolled horizontally.)

Before:

![screen shot 2014-09-11 at 10 30 42](https://cloud.githubusercontent.com/assets/211284/4231332/ee88e04e-398f-11e4-8626-38ded53cc437.png)

After:

![screen shot 2014-09-11 at 10 33 41](https://cloud.githubusercontent.com/assets/211284/4231335/f4b70680-398f-11e4-90c8-2dbe251c5aaa.png)
