### PR TITLE
improve drag cursor on windows

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -15,6 +15,7 @@
     -moz-user-select: none;
     -webkit-user-select: none;
     user-select: none;
+    cursor: text;
 }
 
 .ace_content {
@@ -22,12 +23,7 @@
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-    cursor: text;
     min-width: 100%;
-}
-
-.ace_dragging, .ace_dragging * {
-    cursor: move !important;
 }
 
 .ace_dragging .ace_scroller:before{

--- a/lib/ace/mouse/dragdrop_handler.js
+++ b/lib/ace/mouse/dragdrop_handler.js
@@ -110,6 +110,7 @@ function DragdropHandler(mouseHandler) {
             editor.renderer.$cursorLayer.setBlinking(true);
         }
         this.editor.unsetStyle("ace_dragging");
+        this.editor.renderer.setCursorStyle("");
     };
 
     this.onDragEnter = function(e) {
@@ -349,15 +350,19 @@ function DragdropHandler(mouseHandler) {
     this.dragReadyEnd = function(e) {
         this.editor.renderer.$cursorLayer.setBlinking(!this.editor.getReadOnly());
         this.editor.unsetStyle("ace_dragging");
+        this.editor.renderer.setCursorStyle("");
         this.dragWaitEnd();
     };
 
     this.startDrag = function(){
         this.cancelDrag = false;
-        var target = this.editor.container;
+        var editor = this.editor;
+        var target = editor.container;
         target.draggable = true;
-        this.editor.renderer.$cursorLayer.setBlinking(false);
-        this.editor.setStyle("ace_dragging");
+        editor.renderer.$cursorLayer.setBlinking(false);
+        editor.setStyle("ace_dragging");
+        var cursorStyle = useragent.isWin ? "default" : "move";
+        editor.renderer.setCursorStyle(cursorStyle);
         this.setState("dragReady");
     };
 

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -1443,26 +1443,26 @@ var VirtualRenderer = function(container, theme) {
     };
 
     /**
-    *
-    * Focuses the current container.
-    **/
+     *
+     * Focuses the current container.
+     **/
     this.visualizeFocus = function() {
         dom.addCssClass(this.container, "ace_focus");
     };
 
     /**
-    *
-    * Blurs the current container.
-    **/
+     *
+     * Blurs the current container.
+     **/
     this.visualizeBlur = function() {
         dom.removeCssClass(this.container, "ace_focus");
     };
 
     /**
-    * @param {Number} position
-    *
-    * @private
-    **/
+     * @param {Number} position
+     *
+     * @private
+     **/
     this.showComposition = function(position) {
         if (!this.$composition)
             this.$composition = {
@@ -1477,18 +1477,18 @@ var VirtualRenderer = function(container, theme) {
     };
 
     /**
-    * @param {String} text A string of text to use
-    *
-    * Sets the inner text of the current composition to `text`.
-    **/
+     * @param {String} text A string of text to use
+     *
+     * Sets the inner text of the current composition to `text`.
+     **/
     this.setCompositionText = function(text) {
         this.$moveTextAreaToCursor();
     };
 
     /**
-    *
-    * Hides the current composition.
-    **/
+     *
+     * Hides the current composition.
+     **/
     this.hideComposition = function() {
         if (!this.$composition)
             return;
@@ -1500,11 +1500,11 @@ var VirtualRenderer = function(container, theme) {
     };
 
     /**
-    * [Sets a new theme for the editor. `theme` should exist, and be a directory path, like `ace/theme/textmate`.]{: #VirtualRenderer.setTheme}
-    * @param {String} theme The path to a theme
-    * @param {Function} cb optional callback
-    *
-    **/
+     * [Sets a new theme for the editor. `theme` should exist, and be a directory path, like `ace/theme/textmate`.]{: #VirtualRenderer.setTheme}
+     * @param {String} theme The path to a theme
+     * @param {Function} cb optional callback
+     *
+     **/
     this.setTheme = function(theme, cb) {
         var _self = this;
         this.$themeId = theme;
@@ -1555,9 +1555,9 @@ var VirtualRenderer = function(container, theme) {
     };
 
     /**
-    * [Returns the path of the current theme.]{: #VirtualRenderer.getTheme}
-    * @returns {String}
-    **/
+     * [Returns the path of the current theme.]{: #VirtualRenderer.getTheme}
+     * @returns {String}
+     **/
     this.getTheme = function() {
         return this.$themeId;
     };
@@ -1567,39 +1567,39 @@ var VirtualRenderer = function(container, theme) {
     // a certain mode that editor is in.
 
     /**
-    * [Adds a new class, `style`, to the editor.]{: #VirtualRenderer.setStyle}
-    * @param {String} style A class name
-    *
-    **/
+     * [Adds a new class, `style`, to the editor.]{: #VirtualRenderer.setStyle}
+     * @param {String} style A class name
+     *
+     **/
     this.setStyle = function(style, include) {
         dom.setCssClass(this.container, style, include !== false);
     };
 
     /**
-    * [Removes the class `style` from the editor.]{: #VirtualRenderer.unsetStyle}
-    * @param {String} style A class name
-    *
-    **/
+     * [Removes the class `style` from the editor.]{: #VirtualRenderer.unsetStyle}
+     * @param {String} style A class name
+     *
+     **/
     this.unsetStyle = function(style) {
         dom.removeCssClass(this.container, style);
     };
     
     this.setCursorStyle = function(style) {
-        if (this.content.style.cursor != style)
-            this.content.style.cursor = style;
+        if (this.scroller.style.cursor != style)
+            this.scroller.style.cursor = style;
     };
 
     /**
-    * @param {String} cursorStyle A css cursor style
-    *
-    **/
+     * @param {String} cursorStyle A css cursor style
+     *
+     **/
     this.setMouseCursor = function(cursorStyle) {
-        this.content.style.cursor = cursorStyle;
+        this.scroller.style.cursor = cursorStyle;
     };
 
     /**
-    * Destroys the text and cursor layers for this renderer.
-    **/
+     * Destroys the text and cursor layers for this renderer.
+     **/
     this.destroy = function() {
         this.$textLayer.destroy();
         this.$cursorLayer.destroy();


### PR DESCRIPTION
Setting cursor to move while dragging looks very bad on windows, especially with latest changes for disabling drag delay and showing arrow on hover, http://screencast.com/t/2TvAWoAkuwzk
This pr makes ace to behave like other windows editors on windows, keeping move cursor on mac and linux.
