### PR TITLE
Update language_tools.js to be able to cleardown existing completers via  a removeCompleters() function

### DIFF
--- a/lib/ace/ext/language_tools.js
+++ b/lib/ace/ext/language_tools.js
@@ -67,8 +67,14 @@ var snippetCompleter = {
     }
 };
 
-exports.removeCompleters = function() {
-    completers = [];
+// Allows default completers to be removed or replaced with a explict set of completers
+// A null argument here will result in an empty completer array, not a null attribute
+exports.setCompleters = function(val) {
+    if (val == null || val == undefined || (!(val instanceof Array)) ) {
+        completers = [];
+    } else {
+        completers = val;
+    }
 };
 
 var completers = [snippetCompleter, textCompleter, keyWordCompleter];


### PR DESCRIPTION
Added removeCompleters() function to language tools exports as it is not possible to access the completers array directly.

This is currently utilized by Ace GWT to cleardown existing completers (for entirely programmatic completers without snippets or  keyword completions) but I feel it belongs in the mainline (I have to manage a fork at the moment and there seems to be no other workaround).
