### PR TITLE
Autoindent doesn't always occur

### DIFF
--- a/lib/ace/mode/behaviour/xml.js
+++ b/lib/ace/mode/behaviour/xml.js
@@ -165,7 +165,7 @@ var XmlBehaviour = function () {
                 }
 
                 var tag = token.value;
-                var column = iterator.getCurrentTokenColumn()-1;
+                var row = iterator.getCurrentTokenRow();
 
                 //don't indent after closing tag
                 token = iterator.stepBackward();
@@ -175,12 +175,13 @@ var XmlBehaviour = function () {
 
                 if (this.voidElements && !this.voidElements[tag]) {
                     var nextToken = session.getTokenAt(cursor.row, cursor.column+1);
-                    var next_indent = lang.stringRepeat(" ", column);
-                    var indent = next_indent + session.getTabString();
+                    var line = session.getLine(row);
+                    var nextIndent = this.$getIndent(line);
+                    var indent = nextIndent + session.getTabString();
 
                     if (nextToken && nextToken.value === "</") {
                         return {
-                            text: "\n" + indent + "\n" + next_indent,
+                            text: "\n" + indent + "\n" + nextIndent,
                             selection: [1, indent.length, 1, indent.length]
                         };
                     } else {


### PR DESCRIPTION
Currently autoindent only kicks in as so: 

```
<div>|</div>
```

This allows it to also work with:

```
<div>|

</div>
```
