### PR TITLE
Improve WheelEvent handling (scroll by lines in Firefox)

### DIFF
--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -115,45 +115,66 @@ exports.capture = function(el, eventHandler, releaseCaptureHandler) {
     return onMouseUp;
 };
 
+
+var DOM_DELTA_PIXEL = 0x00;
+var DOM_DELTA_LINE = 0x01;
+var DOM_DELTA_PAGE = 0x02;
+
+function fixWheelEvent(event, deltaMode, deltaX, deltaY) {
+    event.DOM_DELTA_PIXEL = DOM_DELTA_PIXEL;
+    event.DOM_DELTA_LINE = DOM_DELTA_LINE;
+    event.DOM_DELTA_PAGE = DOM_DELTA_PAGE;
+
+    event.deltaMode = deltaMode;
+    event.deltaX = deltaX;
+    event.deltaY = deltaY;
+}
+
 exports.addMouseWheelListener = function(el, callback) {
-    if ("onmousewheel" in el) {
-        exports.addListener(el, "mousewheel", function(e) {
-            var factor = 8;
-            if (e.wheelDeltaX !== undefined) {
-                e.wheelX = -e.wheelDeltaX / factor;
-                e.wheelY = -e.wheelDeltaY / factor;
-            } else {
-                e.wheelX = 0;
-                e.wheelY = -e.wheelDelta / factor;
-            }
+    if ("onwheel" in el) {
+        exports.addListener(el, "wheel", function(e) {
             callback(e);
         });
-    } else if ("onwheel" in el) {
-        exports.addListener(el, "wheel",  function(e) {
-            var factor = 0.35;
-            switch (e.deltaMode) {
-                case e.DOM_DELTA_PIXEL:
-                    e.wheelX = e.deltaX * factor || 0;
-                    e.wheelY = e.deltaY * factor || 0;
-                    break;
-                case e.DOM_DELTA_LINE:
-                case e.DOM_DELTA_PAGE:
-                    e.wheelX = (e.deltaX || 0) * 5;
-                    e.wheelY = (e.deltaY || 0) * 5;
-                    break;
+    } else if ("onmousewheel" in el) {
+        exports.addListener(el, "mousewheel", function(e) {
+            var factor = 2;
+
+            var deltaX;
+            var deltaY;
+            if (e.wheelDeltaX !== undefined) {
+                deltaX = -e.wheelDeltaX / factor;
+                deltaY = -e.wheelDeltaY / factor;
+            } else {
+                deltaX = 0;
+                deltaY = -e.wheelDelta / factor;
             }
-            
+            fixWheelEvent(e, DOM_DELTA_PIXEL, deltaX, deltaY);
             callback(e);
         });
     } else {
         exports.addListener(el, "DOMMouseScroll", function(e) {
-            if (e.axis && e.axis == e.HORIZONTAL_AXIS) {
-                e.wheelX = (e.detail || 0) * 5;
-                e.wheelY = 0;
+            var DELTA_PAGE_DETAIL = 1 << 15;
+
+            var delta;
+            var deltaMode;
+            if (e.detail == DELTA_PAGE_DETAIL) {
+                deltaMode = DOM_DELTA_PAGE;
+                delta = e.detail / DELTA_PAGE_DETAIL;
             } else {
-                e.wheelX = 0;
-                e.wheelY = (e.detail || 0) * 5;
+                deltaMode = DOM_DELTA_LINE;
+                delta = e.detail || 0;
             }
+
+            var deltaX;
+            var deltaY;
+            if (e.axis === e.HORIZONTAL_AXIS) {
+                deltaX = delta;
+                deltaY = 0;
+            } else {
+                deltaX = 0;
+                deltaY = delta;
+            }
+            fixWheelEvent(e, deltaMode, deltaX, deltaY);
             callback(e);
         });
     }

--- a/lib/ace/mouse/default_handlers.js
+++ b/lib/ace/mouse/default_handlers.js
@@ -236,19 +236,41 @@ function DefaultHandlers(mouseHandler) {
             return;
 
         //shift wheel to horiz scroll
-        if (ev.getShiftKey() && ev.wheelY && !ev.wheelX) {
-            ev.wheelX = ev.wheelY;
-            ev.wheelY = 0;
+        if (ev.getShiftKey() && ev.deltaY && !ev.deltaX) {
+            ev.deltaX = ev.deltaY;
+            ev.deltaY = 0;
         }
 
-        var t = ev.domEvent.timeStamp;
+        var domEvent = ev.domEvent;
+        var t = domEvent.timeStamp;
         var dt = t - (this.$lastScrollTime||0);
-        
+
         var editor = this.editor;
-        var isScrolable = editor.renderer.isScrollableBy(ev.wheelX * ev.speed, ev.wheelY * ev.speed);
+        var layerConfig = editor.renderer.layerConfig;
+
+        var deltaX = ev.deltaX;
+        var deltaY = ev.deltaY;
+        // respect event delta mode
+        switch (domEvent.deltaMode) {
+            case domEvent.DOM_DELTA_PIXEL:
+                break;
+            case domEvent.DOM_DELTA_LINE:
+                deltaX *= layerConfig.characterWidth;
+                deltaY *= layerConfig.lineHeight;
+            break;
+            case domEvent.DOM_DELTA_PAGE:
+                var lineCount = Math.floor(layerConfig.height / layerConfig.lineHeight);
+                var pageHeight = lineCount * layerConfig.lineHeight;
+                deltaX *= pageHeight;
+                deltaY *= pageHeight;
+            break;
+        }
+        deltaX *= ev.speed;
+        deltaY *= ev.speed;
+        var isScrolable = editor.renderer.isScrollableBy(deltaX, deltaY);
         if (isScrolable || dt < 200) {
             this.$lastScrollTime = t;
-            editor.renderer.scrollBy(ev.wheelX * ev.speed, ev.wheelY * ev.speed);
+            editor.renderer.scrollBy(deltaX, deltaY);
             return ev.stop();
         }
     };

--- a/lib/ace/mouse/mouse_handler.js
+++ b/lib/ace/mouse/mouse_handler.js
@@ -112,9 +112,9 @@ var MouseHandler = function(editor) {
 
     this.onMouseWheel = function(name, e) {
         var mouseEvent = new MouseEvent(e, this.editor);
-        mouseEvent.speed = this.$scrollSpeed * 2;
-        mouseEvent.wheelX = e.wheelX;
-        mouseEvent.wheelY = e.wheelY;
+        mouseEvent.speed = this.$scrollSpeed;
+        mouseEvent.deltaX = e.deltaX;
+        mouseEvent.deltaY = e.deltaY;
 
         this.editor._emit(name, mouseEvent);
     };
@@ -191,7 +191,7 @@ var MouseHandler = function(editor) {
 }).call(MouseHandler.prototype);
 
 config.defineOptions(MouseHandler.prototype, "mouseHandler", {
-    scrollSpeed: {initialValue: 2},
+    scrollSpeed: {initialValue: 1},
     dragDelay: {initialValue: (useragent.isMac ? 150 : 0)},
     dragEnabled: {initialValue: true},
     focusTimout: {initialValue: 0},


### PR DESCRIPTION
Ok, I switched to Firefox, so it would be good to have good scroll at least in this browser. Especially when Chrome devs don't want to listen about the DOM_DELTA_LINE, so you Chrome, _давай досвидания_ )

With this patch:
- We use DOM_DELTA_LINE if available.
- We use `wheel` instead on `mousewheel` if available (on Chrome)
- `wheelX` renamed to `deltaX` (so is Y)

We still:
- Do not use `wheel` in IE (`onwheel` feature detection does not work for IE)

We could:
- use e.detail as DOM_DELTA_LINE in Opera Presto. But I am not sure about Opera for Mac.
- use wheel in IE. This event respects OS mouse settings (wheel speed).

I tested it in Firefox 33 (win), Chrome 38 (win), Opera 12 (win), IE 11 (win).

Scrolling in Chrome became faster. Especially if `scrollSpeed` user value is increased, scrolling goes crazy ))
