### PR TITLE
Update documentation to reflect change in paste event

### DIFF
--- a/api/editor.html
+++ b/api/editor.html
@@ -564,7 +564,7 @@
             <ul class="signatures">
               <li class="signature">
                 <ul>
-                  <li class="signature-call"><span class="eventObjName">Editor</span><span class="eventListenerStart">.on("</span><span id="Editor.event.paste" class="member-name eventMember methodClicker">paste</span><span class="eventListenerClose">", </span><span class="eventFunctionOpen">function(</span><a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/String" class="argument methodClicker" title="String" data-id="String">String</a> text<span class="eventFunctionClose">))</span></li>
+                  <li class="signature-call"><span class="eventObjName">Editor</span><span class="eventListenerStart">.on("</span><span id="Editor.event.paste" class="member-name eventMember methodClicker">paste</span><span class="eventListenerClose">", </span><span class="eventFunctionOpen">function(</span><a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object" class="argument methodClicker" title="Object" data-id="Object">Object</a> e<span class="eventFunctionClose">))</span></li>
                 </ul>
                 <ul class="metaInfo">
                 </ul>
@@ -577,7 +577,7 @@
             </div>
             <div class="description"><p>Emitted when text is pasted.</p>
 
-              <h4>Arguments</h4><table class="argumentTable argument-list table table-striped table-bordered"><tr class="argumentRow "><td class="argName ">text</td><td class="argType"><a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/String" class="" title="String" data-id="String">String</a></td><td class="argDescription "><p>Required. The pasted text</p>
+              <h4>Arguments</h4><table class="argumentTable argument-list table table-striped table-bordered"><tr class="argumentRow "><td class="argName ">e</td><td class="argType"><a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object" class="" title="Object" data-id="Object">Object</a></td><td class="argDescription "><p>Required. An object which contains one property, <code>text</code>, that represents the text to be pasted. Editing this property will alter the text that is pasted.</p>
 </td></tr></table>
             </div>
           </div>


### PR DESCRIPTION
The change allowing paste event handlers to alter the pasted text, introduced by commit: 9253fffb9f19a4efea2013066a7a345cab396810 is not reflected in the docs. This changeset fixes that. Also theres a little fix with an extraneous double quote mark in the td tags.
