### PR TITLE
{ symbol also starts autocomplete

### DIFF
--- a/lib/ace/autocomplete/util.js
+++ b/lib/ace/autocomplete/util.js
@@ -45,7 +45,7 @@ exports.parForEach = function(array, fn, callback) {
     }
 };
 
-var ID_REGEX = /[a-zA-Z_0-9\$\-\u00A2-\uFFFF]/;
+var ID_REGEX = /[a-zA-Z_0-9{\$\-\u00A2-\uFFFF]/;
 
 exports.retrievePrecedingIdentifier = function(text, pos, regex) {
     regex = regex || ID_REGEX;


### PR DESCRIPTION
We work with [curly](https://github.com/zendesk/curly), a template language in which the curly bracket ("{") is an essential part of the syntax. We are having problems to start autocompletion when a user starts writing the curly bracket, and we think that it should be in the regular expression that matches for the start of the autocompletion.
