### PR TITLE
Sets offset of fontMetrics div to be 0.

### DIFF
--- a/lib/ace/layer/font_metrics.js
+++ b/lib/ace/layer/font_metrics.js
@@ -82,9 +82,9 @@ var FontMetrics = exports.FontMetrics = function(parentEl, interval) {
     
     this.$setMeasureNodeStyles = function(style, isRoot) {
         style.width = style.height = "auto";
-        style.left = style.top = "-100px";
+        style.left = style.top = "0px";
         style.visibility = "hidden";
-        style.position = "fixed";
+        style.position = "absolute";
         style.whiteSpace = "pre";
 
         if (useragent.isIE < 8) {


### PR DESCRIPTION
Offsetting the fontMetrics div causes the 'ghost image' created when
drag and dropping an Ace Editor to be offset by that same amount. By
removing the offset we fix the problem. Closes #2240.
