### PR TITLE
Teach tmtheme.js how to convert a non-built-in theme

### DIFF
--- a/tool/tmtheme.js
+++ b/tool/tmtheme.js
@@ -337,6 +337,7 @@ function convertTheme(name, tmThemePath, outputDirectory) {
             css = cssStringify({stylesheet: {rules: oldRules}}, { compress: false });
         } catch(e) {
             console.log("Creating new file: " +  name + ".css")
+            css = cssStringify(cssParse(css), { compress: false });
         }
         
         var js = fillTemplate(jsTemplate, {


### PR DESCRIPTION
You can now pass a `.tmTheme` file on the command line to have it converted.
