### PR TITLE
Highlight \ref, \vref, \cite and \citep as labels

### DIFF
--- a/lib/ace/mode/latex_highlight_rules.js
+++ b/lib/ace/mode/latex_highlight_rules.js
@@ -19,7 +19,7 @@ var LatexHighlightRules = function() {
         }, {
             // A label
             token : ["keyword","lparen", "variable.parameter", "rparen"],
-            regex : "(\\\\label)(?:({)([^}]*)(}))?"
+            regex : "(\\\\(?:label|v?ref|cite(?:[^{]*)))(?:({)([^}]*)(}))?"
         }, {
             // A block
             token : ["storage.type", "lparen", "variable.parameter", "rparen"],


### PR DESCRIPTION
The `\ref`, and `\cite` commands in LaTeX are similar to `\label`s in that they refer to user defined labels elsewhere in the text, and it makes sense to highlight them with the same color scheme. Particularly the coloring of arguments to `\ref` commands should match the color of `\label` commands because `\label` defines the strings that `\ref` then references.
