### PR TITLE
Teach tmlanguage.js to process multiple .tmLanguage files at once

### DIFF
--- a/tool/tmlanguage.js
+++ b/tool/tmlanguage.js
@@ -684,13 +684,14 @@ function convertTmLanguage(name, langStr) {
 
 if (!module.parent) {
     var args = process.argv.splice(2);
-    var tmLanguageFile  = args[0];
-    var devMode = args[1];
-    if (tmLanguageFile === undefined) {
-        console.error("Usage: node tmlanguage.js path/or/url/to/syntax.file");
+    var devMode = args[0] == "--dev";
+    if (devMode)
+        args.shift();
+    if (args.length < 1) {
+        console.error("Usage: node tmlanguage.js [--dev] path/or/url/to/syntax.file ...");
         process.exit(1);
     }
-    fetchAndConvert(tmLanguageFile);
+    args.forEach(fetchAndConvert);
 } else {
     exports.fetchAndConvert = fetchAndConvert;
 }


### PR DESCRIPTION
You can now pass more than one `.tmLanguage` file to `tmlanguage.js` and it will process each one in turn. This can vastly speed up the processing of multiple files as you don't have to pay the node/V8 startup cost for each file.

Note that the script's "dev mode" is now controlled by a `--dev` flag rather than an unnamed second argument.

/cc @gjtorikian 
