### PR TITLE
Fix issue with Chrome 39.0.2171.95

### DIFF
--- a/lib/ace/lib/app_config.js
+++ b/lib/ace/lib/app_config.js
@@ -143,8 +143,9 @@ var AppConfig = function() {
     };
 
     this.setDefaultValues = function(path, optionHash) {
+        var appconfig = this;
         Object.keys(optionHash).forEach(function(key) {
-            this.setDefaultValue(path, key, optionHash[key]);
+            appconfig.setDefaultValue(path, key, optionHash[key]);
         });
     };
     


### PR DESCRIPTION
In  Chrome 39.0.2171.95 (64-bit) the "this" inside the foreach is a Window object when the function is called from tool/mode_creator.js in the statement

require("ace/config").setDefaultValues("editor", {
    enableBasicAutocompletion: true,
    enableSnippets: true
});

This seems to have changed. It used to work in Chrome 39.0.2171.71. But since I updated 2 days ago whenever I run the mode_creator from a local ace served via static.py I get the error "undefined" is not a function at the this.setDefaultValue(...) call. When I placed a breakpoint there and inspected "this" it turned out to be a Window object.
