### PR TITLE
fix move to EOL behaviour for visual block mode

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -2118,7 +2118,11 @@ dom.importCssString(".normal-mode .ace_cursor{\
             newHead = copyCursor(origHead);
           }
           if (vim.visualMode) {
-            newHead = clipCursorToContent(cm, newHead, vim.visualBlock);
+
+            if (!(vim.visualBlock && motion === "moveToEol")) {
+              newHead = clipCursorToContent(cm, newHead, vim.visualBlock);
+            }
+            
             if (newAnchor) {
               newAnchor = clipCursorToContent(cm, newAnchor, true);
             }

--- a/lib/ace/keyboard/vim_test.js
+++ b/lib/ace/keyboard/vim_test.js
@@ -1957,6 +1957,14 @@ testVim('visual_line', function(cm, vim, helpers) {
   helpers.doKeys('l', 'V', 'l', 'j', 'j', 'd');
   eq(' 4\n 5', cm.getValue());
 }, { value: ' 1\n 2\n 3\n 4\n 5' });
+testVim('visual_block_move_to_eol', function(cm, vim, helpers) {
+  // moveToEol should move all block cursors to end of line
+  cm.setCursor(0, 0);
+  helpers.doKeys('<C-v>', 'G', '$');
+  var selections = cm.getSelections().join();
+  console.log(selections);
+  eq("123,45,6", selections);
+}, {value: '123\n45\n6'});
 testVim('visual_block_different_line_lengths', function(cm, vim, helpers) {
   // test the block selection with lines of different length
   // i.e. extending the selection


### PR DESCRIPTION
This fixes a bug where `moveToEol` would truncate the selection according to the current line (we want to move all selections to the end of their respective lines).
## Before

![vim-before](https://cloud.githubusercontent.com/assets/1976582/5516353/34d2856c-884d-11e4-86f3-382eabfb70d2.gif)
## After

![vim-after](https://cloud.githubusercontent.com/assets/1976582/5516355/3761b5c8-884d-11e4-8096-1516a2bf291e.gif)

I've sent a CLA as well -- please let me know if there's anything else you need.

Thanks!
