### PR TITLE
Fix getVScrollBarAlwaysVisible

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -750,7 +750,7 @@ var VirtualRenderer = function(container, theme) {
      * @returns {Boolean}
      **/
     this.getVScrollBarAlwaysVisible = function() {
-        return this.$hScrollBarAlwaysVisible;
+        return this.$vScrollBarAlwaysVisible;
     };
 
     /**


### PR DESCRIPTION
By accident it is returning `$hScrollBarAlwaysVisible`.
