### PR TITLE
Conform with upstream change for Vim Visual Block + move to EOL behaviour

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -2118,11 +2118,9 @@ dom.importCssString(".normal-mode .ace_cursor{\
             newHead = copyCursor(origHead);
           }
           if (vim.visualMode) {
-
-            if (!(vim.visualBlock && motion === "moveToEol")) {
+            if (!(vim.visualBlock && newHead.ch === Infinity)) {
               newHead = clipCursorToContent(cm, newHead, vim.visualBlock);
             }
-            
             if (newAnchor) {
               newAnchor = clipCursorToContent(cm, newAnchor, true);
             }


### PR DESCRIPTION
Ref:
https://github.com/codemirror/CodeMirror/commit/1e5ae06ba46ab8c7c41d295ebf25b1bfc6cf6c39

This PR changes the earlier modified move to EOL behaviour to match what was entered into CodeMirror after @mightyguava's changes.