### PR TITLE
Fix spacing in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,8 +196,7 @@ console.log(addResult);
                             <p><span class="expand_arrow">&gt;</span> <a href="https://github.com/ajaxorg/ace/tree/master/lib/ace/theme" target="_blank">See all themes</a></p>
                             <h2>Setting the Programming Language Mode</h2>
                             <p>By default, the editor supports plain text mode. All other language modes are available as separate modules, loaded on demand like this:</p>
-                            <pre><code class="javascript">editor.getSession().setMode("ace/mode/javascript");
-                            </code></pre>
+                            <pre><code class="javascript">editor.getSession().setMode("ace/mode/javascript");</code></pre>
                             <!--h2>One Editor, Multiple Sessions</h2>
                                 <p>Ace keeps everything about the state of the editor (selection, scroll position, etc.)
                                     in <code class="javascript">editor.session</code>. This means you can grab the


### PR DESCRIPTION
In the [How-To Guide on the homepage](http://ace.c9.io/#nav=howto) under Setting the Programming Language, there is an extra blank line in the code snippet:

![Screenshot](https://monosnap.com/image/1zbO9MrZMrm0COrh1PT0A1MvrI7xt8.png)

This PR should fix this problem.