### PR TITLE
Add the missing mode "Django" to ext-modelist

### DIFF
--- a/lib/ace/ext/modelist.js
+++ b/lib/ace/ext/modelist.js
@@ -161,7 +161,9 @@ var supportedModes = {
     VHDL:        ["vhd|vhdl"],
     XML:         ["xml|rdf|rss|wsdl|xslt|atom|mathml|mml|xul|xbl"],
     XQuery:      ["xq"],
-    YAML:        ["yaml|yml"]
+    YAML:        ["yaml|yml"],
+    // Add the missing mode "Django" to ext-modelist
+    Django:      ["html"]
 };
 
 var nameOverrides = {


### PR DESCRIPTION
This is to add Django as an alternative mode for HTML files. The placement of the entry is to ensure that Django syntax highlighter does not override HTML syntax highlighter.