### PR TITLE
Fix autocomplete prefix for custom identifierRegexes

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -220,27 +220,34 @@ var Autocomplete = function() {
         "PageDown": function(editor) { editor.completer.popup.gotoPageDown(); }
     };
 
-    this.gatherCompletions = function(editor, callback) {
-        var session = editor.getSession();
-        var pos = editor.getCursorPosition();
-
+    /**
+     * Computes auto-complete prefix and updates completer state based on it.
+     */
+    this.getPrefix = function(session, pos, prefixRegex) {
         var line = session.getLine(pos.row);
-        var prefix = util.retrievePrecedingIdentifier(line, pos.column);
+        var prefix = util.retrievePrecedingIdentifier(line, pos.column, prefixRegex);
 
         this.base = session.doc.createAnchor(pos.row, pos.column - prefix.length);
         this.base.$insertRight = true;
+        return prefix;
+    };
+
+    this.gatherCompletions = function(editor, callback) {
+        var session = editor.getSession();
+        var pos = editor.getCursorPosition();
+        var prefix = this.getPrefix(session, pos);
 
         var matches = [];
         var total = editor.completers.length;
+        var self = this;
         editor.completers.forEach(function(completer, i) {
             completer.getCompletions(editor, session, pos, prefix, function(err, results) {
                 if (!err)
                     matches = matches.concat(results);
                 // Fetch prefix again, because they may have changed by now
-                var pos = editor.getCursorPosition();
-                var line = session.getLine(pos.row);
+                var prefix = self.getPrefix(session, pos, results[0] && results[0].identifierRegex);
                 callback(null, {
-                    prefix: util.retrievePrecedingIdentifier(line, pos.column, results[0] && results[0].identifierRegex),
+                    prefix: prefix,
                     matches: matches,
                     finished: (--total === 0)
                 });


### PR DESCRIPTION
Autocomplete prefix can be wrong for completions with a custom identifierRegex because `Autocompleter.base` is computed relative to a prefix defined by the default identifierRegex.

Steps to reproduce the issue this pull request solves:
- create a completer whose completions provide more permissive `identifierRegex` than the default (say one that matches `$` and `{` in addition to the defaults)
- trigger auto-completes after typing `${`, and note how the prefix is respected:
    ![screen shot 2015-02-10 at 1 35 15 pm](https://cloud.githubusercontent.com/assets/711001/6139387/0a47cc82-b140-11e4-8a9f-5ee9caea0c30.png)

- continue typing, and note how the `${` part of the prefix is lost and we only match against `test`:
    ![screen shot 2015-02-10 at 1 36 10 pm](https://cloud.githubusercontent.com/assets/711001/6139388/0c488166-b140-11e4-8cd1-a736a468da94.png)

With this patch, we instead get the expected prefix of `${test`:

![screen shot 2015-02-10 at 2 46 17 pm](https://cloud.githubusercontent.com/assets/711001/6139396/13d9f8a6-b140-11e4-97ba-13f117a0aa3b.png)



