### PR TITLE
Fit what metadata we can into autocompletes

### DIFF
--- a/lib/ace/autocomplete/popup.js
+++ b/lib/ace/autocomplete/popup.js
@@ -197,8 +197,12 @@ var AcePopup = function(parentNode) {
 
         if (data.meta) {
             var maxW = popup.renderer.$size.scrollerWidth / popup.renderer.layerConfig.characterWidth;
-            if (data.meta.length + data.caption.length < maxW - 2)
-                tokens.push({type: "rightAlignedText", value: data.meta});
+            var metaData = data.meta;
+            if (metaData.length + data.caption.length > maxW - 2) {
+                // trim meta to fit this popup and add ellipsis
+                metaData = metaData.substr(0, maxW - data.caption.length - 5) + '...'
+            }
+            tokens.push({type: "rightAlignedText", value: metaData});
         }
         return tokens;
     };


### PR DESCRIPTION
The whole meta string currently gets dropped from the autocompletes popup if it doesn't fit.  This leads to confusing autocompletes where the meta for some entries are missing for no apparent reason.

So, instead of dropping the entire meta string when it doesn't fit, insert what we can and append "..." to communicate that we clipped it.