### PR TITLE
Prevent vim ex commandline from obscuring search results

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -489,8 +489,12 @@ define(function(require, exports, module) {
   };
   this.scrollInfo = function() { return 0; };
   this.scrollIntoView = function(pos, margin) {
-    if (pos)
-      this.ace.renderer.scrollCursorIntoView(toAcePos(pos), null, margin);
+    if (pos) {
+      var renderer = this.ace.renderer;
+      var viewMargin = { "top": 0, "bottom": margin };
+      renderer.scrollCursorIntoView(toAcePos(pos),
+        (renderer.lineHeight * 2) / renderer.$size.scrollerHeight, viewMargin);
+    }
   };
   this.getLine = function(row) { return this.ace.session.getLine(row) };
   this.getRange = function(s, e) {


### PR DESCRIPTION
This change addresses an issue in which Vim search results may be obscured by the ex commandline UI:

- a scroll offset equal to two lines of text is added to account for the lines obscured by the ex commandline; and
- the view margin is supplied in the format `scrollCursorIntoView` appears to expect (i.e. an object rather than a scalar)

