### PR TITLE
Provide an API for throttling completion popups

### DIFF
--- a/lib/ace/ext/language_tools.js
+++ b/lib/ace/ext/language_tools.js
@@ -153,12 +153,39 @@ function getCompletionPrefix(editor) {
     return prefix;
 }
 
+var $characterThreshold = 3;
+var $completionDelay = 250;
+var completionTimer;
+
+var showCompletionPopupDelayed = function(editor) {
+    clearTimeout(completionTimer);
+    completionTimer = setTimeout(function() {
+        
+        var cursor = editor.getCursorPosition();
+        var row = cursor.row;
+        var column = cursor.column;
+        
+        if (column < $characterThreshold)
+            return;
+        
+        var line = editor.getSession().getLine(row);
+        for (var i = 0; i < $characterThreshold; i++)
+        {
+            var idx = column - i - 1;
+            if (line[idx] == null || " \t\n\r\v".indexOf(line[idx]) !== -1)
+                return;
+        }
+        editor.completer.showPopup(editor);
+    }, $completionDelay);
+}
+
 var doLiveAutocomplete = function(e) {
+
+    clearTimeout(completionTimer);
+    
     var editor = e.editor;
     var text = e.args || "";
     var hasCompleter = editor.completer && editor.completer.activated;
-
-
 
     // We don't want to autocomplete with no prefix
     if (e.command.name === "backspace") {
@@ -168,7 +195,7 @@ var doLiveAutocomplete = function(e) {
     else if (e.command.name === "insertstring") {
         var prefix = getCompletionPrefix(editor);
         // Only autocomplete if there's a prefix that can be matched
-        if (prefix && !hasCompleter) {
+        if (prefix && prefix.length >= $characterThreshold && !hasCompleter) {
             if (!editor.completer) {
                 // Create new autocompleter
                 editor.completer = new Autocomplete();
@@ -176,7 +203,7 @@ var doLiveAutocomplete = function(e) {
             // Disable autoInsert
             editor.completer.autoSelect = false;
             editor.completer.autoInsert = false;
-            editor.completer.showPopup(editor);
+            showCompletionPopupDelayed(editor);
         }
     }
 };
@@ -224,6 +251,22 @@ require("../config").defineOptions(Editor.prototype, "editor", {
             }
         },
         value: false
+    },
+    completionDelay: {
+        set: function(val) {
+            $completionDelay = val;
+        },
+        get: function() {
+            return $completionDelay;
+        }
+    },
+    completionCharacterThreshold: {
+        set: function(val) {
+            $characterThreshold = val;
+        },
+        get: function() {
+            return $characterThreshold;
+        }
     }
 });
 });


### PR DESCRIPTION
This PR adds a simple API for throttling completions based on:
- the number of characters previous to the cursor, and
- the keyboard idle time.

Users can adjust these using the `EditSession` options; e.g.

```
editor.getSession().setOptions({
    completionCharacterThreshold: 3,
    completionDelay: 250
});
```
