### PR TITLE
correct snippet for 'sapply'

### DIFF
--- a/lib/ace/snippets/r.snippets
+++ b/lib/ace/snippets/r.snippets
@@ -47,7 +47,7 @@ snippet apply
 snippet lapply
 	lapply(${1:list}, ${2:function})
 snippet sapply
-	lapply(${1:list}, ${2:function})
+	sapply(${1:list}, ${2:function})
 snippet vapply
 	vapply(${1:list}, ${2:function}, ${3:type})
 snippet mapply


### PR DESCRIPTION
A very minor fix: swap out `lapply` for `sapply` in the `sapply` snippet.