### PR TITLE
Live autocomplete delay

### DIFF
--- a/lib/ace/ext/language_tools.js
+++ b/lib/ace/ext/language_tools.js
@@ -166,7 +166,7 @@ var doLiveAutocomplete = function(e) {
     else if (e.command.name === "insertstring") {
         var prefix = getCompletionPrefix(editor);
         // Only autocomplete if there's a prefix that can be matched
-        if (prefix && !hasCompleter) {
+        if (prefix && prefix.length >= editor.$liveAutocompletionThreshold && !hasCompleter) {
             if (!editor.completer) {
                 // Create new autocompleter
                 editor.completer = new Autocomplete();
@@ -177,6 +177,15 @@ var doLiveAutocomplete = function(e) {
         }
     }
 };
+
+var lastExec_e;
+var liveAutocompleteTimer = lang.delayedCall(function () { doLiveAutocomplete(lastExec_e); }, 0);
+
+var scheduleAutocomplete = function(e)
+{
+    lastExec_e = e;
+    liveAutocompleteTimer.delay(e.editor.$liveAutocompletionDelay);
+}
 
 var Editor = require("../editor").Editor;
 require("../config").defineOptions(Editor.prototype, "editor", {
@@ -202,12 +211,18 @@ require("../config").defineOptions(Editor.prototype, "editor", {
                 if (!this.completers)
                     this.completers = Array.isArray(val)? val: completers;
                 // On each change automatically trigger the autocomplete
-                this.commands.on('afterExec', doLiveAutocomplete);
+                this.commands.on('afterExec', scheduleAutocomplete);
             } else {
-                this.commands.removeListener('afterExec', doLiveAutocomplete);
+                this.commands.removeListener('afterExec', scheduleAutocomplete);
             }
         },
         value: false
+    },
+    liveAutocompletionDelay: {
+        value: 100
+    },
+    liveAutocompletionThreshold: {
+        value: 0
     },
     enableSnippets: {
         set: function(val) {

--- a/lib/ace/ext/modelist.js
+++ b/lib/ace/ext/modelist.js
@@ -48,7 +48,7 @@ var supportedModes = {
     ADA:         ["ada|adb"],
     Apache_Conf: ["^htaccess|^htgroups|^htpasswd|^conf|htaccess|htgroups|htpasswd"],
     AsciiDoc:    ["asciidoc"],
-    Assembly_x86:["asm"],
+    Assembly_x86:["asm|s"],
     AutoHotKey:  ["ahk"],
     BatchFile:   ["bat|cmd"],
     C9Search:    ["c9search_results"],


### PR DESCRIPTION
Added delay and threshold editor-wide settings for making the live
autocomplete popup less erratic when typing short words quickly in large
files. Uses `lang.delayedCall` for timing, suppresses calls to
`doLiveAutocomplete` until the popup is allowed to be shown.

Use alongside normal editor options:

```
editor.setOptions({
            enableLiveAutocompletion: true,
            liveAutocompletionDelay: 100,
            liveAutocompletionThreshold: 3
        });
```

Also added an extension (.s) to `modelist`, which is fairly trivial, but can be separated/changed as needed.
