### PR TITLE
Remove 0 height selection highlight

### DIFF
--- a/lib/ace/layer/marker.js
+++ b/lib/ace/layer/marker.js
@@ -155,7 +155,7 @@ var Marker = function(parentEl) {
 
         // all the complete lines
         height = (range.end.row - range.start.row - 1) * config.lineHeight;
-        if (height < 0)
+        if (height <= 0)
             return;
         top = this.$getTop(range.start.row + 1, config);
 


### PR DESCRIPTION
I can't recall how this bug shows up, but I'll report back. Merge if it makes sense to you.