### PR TITLE
add Gherkin worker leveraging offical gherkin parser

### DIFF
--- a/lib/ace/mode/gherkin.js
+++ b/lib/ace/mode/gherkin.js
@@ -33,6 +33,7 @@ define(function(require, exports, module) {
 var oop = require("../lib/oop");
 var TextMode = require("./text").Mode;
 var GherkinHighlightRules = require("./gherkin_highlight_rules").GherkinHighlightRules;
+var WorkerClient = require("../worker/worker_client").WorkerClient;
 
 var Mode = function() {
     this.HighlightRules = GherkinHighlightRules;
@@ -74,6 +75,22 @@ oop.inherits(Mode, TextMode);
 
         return indent;
     };
+
+    this.createWorker = function(session) {
+        var worker = new WorkerClient(["ace"], "ace/mode/gherkin_worker", "GherkinWorker");
+        worker.attachToDocument(session.getDocument());
+
+        worker.on("annotate", function(results) {
+            session.setAnnotations(results.data);
+        });
+
+        worker.on("terminate", function() {
+            session.clearAnnotations();
+        });
+
+        return worker;
+    };
+
 }).call(Mode.prototype);
 
 exports.Mode = Mode;

--- a/lib/ace/mode/gherkin/LICENSE.gherkin
+++ b/lib/ace/mode/gherkin/LICENSE.gherkin
@@ -1,4 +1,5 @@
-/*
+This license pertains to the file worker-gherkin.js.
+
 The MIT License (MIT)
 
 Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
@@ -20,42 +21,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-*/
-define(function(require,exports,module){
-
-module.exports = function TokenFormatterBuilder() {
-  var tokensText = '';
-
-  this.startRule = function(ruleType) {};
-
-  this.endRule = function(ruleType) {};
-
-  this.build = function(token) {
-    tokensText += formatToken(token) + '\n';
-  };
-
-  this.getResult = function() {
-    return tokensText;
-  }
-
-  function formatToken(token) {
-    if(token.isEof) return 'EOF';
-
-    return "(" +
-    token.location.line +
-    ":" +
-    token.location.column +
-    ")" +
-    token.matchedType +
-    ":" +
-    (typeof token.matchedKeyword === 'string' ? token.matchedKeyword : '') +
-    "/" +
-    (typeof token.matchedText === 'string' ? token.matchedText : '') +
-    "/" +
-    token.matchedItems.map(function (i) { return i.column + ':' + i.text; }).join(',');
-  }
-};
-
-return module.exports;
-
-});

--- a/lib/ace/mode/gherkin/ast_builder.js
+++ b/lib/ace/mode/gherkin/ast_builder.js
@@ -1,3 +1,26 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 define(function(require,exports,module){
 
 var AstNode = require('./ast_node');

--- a/lib/ace/mode/gherkin/ast_builder.js
+++ b/lib/ace/mode/gherkin/ast_builder.js
@@ -1,0 +1,236 @@
+define(function(require,exports,module){
+
+var AstNode = require('./ast_node');
+var Errors = require('./errors');
+
+module.exports = function AstBuilder () {
+
+  var stack = [new AstNode('None')];
+
+  this.startRule = function (ruleType) {
+    stack.push(new AstNode(ruleType));
+  };
+
+  this.endRule = function (ruleType) {
+    var node = stack.pop();
+    var transformedNode = transformNode(node);
+    currentNode().add(node.ruleType, transformedNode);
+  };
+
+  this.build = function (token) {
+    currentNode().add(token.matchedType, token);
+  };
+
+  this.getResult = function () {
+    return currentNode().getSingle('Feature');
+  };
+
+  function currentNode () {
+    return stack[stack.length - 1];
+  }
+
+  function getLocation (token, column) {
+    return !column ? token.location : {line: token.location.line, column: column};
+  }
+
+  function getTags (node) {
+    var tags = [];
+    var tagsNode = node.getSingle('Tags');
+    if (!tagsNode) return tags;
+    tagsNode.getTokens('TagLine').forEach(function (token) {
+      token.matchedItems.forEach(function (tagItem) {
+        tags.push({
+          type: 'Tag',
+          location: getLocation(token, tagItem.column),
+          name: tagItem.text
+        });
+      });
+
+    });
+    return tags;
+  }
+
+  function getCells(tableRowToken) {
+    return tableRowToken.matchedItems.map(function (cellItem) {
+      return {
+        type: 'TableCell',
+        location: getLocation(tableRowToken, cellItem.column),
+        value: cellItem.text
+      }
+    });
+  }
+
+  function getDescription (node) {
+    return node.getSingle('Description');
+  }
+
+  function getSteps (node) {
+    return node.getItems('Step');
+  }
+
+  function getTableRows(node) {
+    var rows = node.getTokens('TableRow').map(function (token) {
+      return {
+        type: 'TableRow',
+        location: getLocation(token),
+        cells: getCells(token)
+      };
+    });
+    ensureCellCount(rows);
+    return rows;
+  }
+
+  function ensureCellCount(rows) {
+    if(rows.length == 0) return;
+    var cellCount = rows[0].cells.length;
+
+    rows.forEach(function (row) {
+      if (row.cells.length != cellCount) {
+        throw Errors.AstBuilderException.create("inconsistent cell count within the table", row.location);
+      }
+    });
+  }
+
+  function transformNode(node) {
+    switch(node.ruleType) {
+      case 'Step':
+        var stepLine = node.getToken('StepLine');
+        var stepArgument = node.getSingle('DataTable') || node.getSingle('DocString') || undefined;
+
+        return {
+          type: node.ruleType,
+          location: getLocation(stepLine),
+          keyword: stepLine.matchedKeyword,
+          name: stepLine.matchedText,
+          argument: stepArgument
+        }
+      case 'DocString':
+        var separatorToken = node.getTokens('DocStringSeparator')[0];
+        var contentType = separatorToken.matchedText;
+        var lineTokens = node.getTokens('Other');
+        var content = lineTokens.map(function (t) {return t.matchedText}).join("\n");
+
+        return {
+          type: node.ruleType,
+          location: getLocation(separatorToken),
+          contentType: contentType,
+          content: content
+        };
+      case 'DataTable':
+        var rows = getTableRows(node);
+        return {
+          type: node.ruleType,
+          location: rows[0].location,
+          rows: rows,
+        }
+      case 'Background':
+        var backgroundLine = node.getToken('BackgroundLine');
+        var description = getDescription(node);
+        var steps = getSteps(node);
+
+        return {
+          type: node.ruleType,
+          location: getLocation(backgroundLine),
+          keyword: backgroundLine.matchedKeyword,
+          name: backgroundLine.matchedText,
+          description: description,
+          steps: steps
+        };
+      case 'Scenario_Definition':
+        var tags = getTags(node);
+        var scenarioNode = node.getSingle('Scenario');
+        if(scenarioNode) {
+          var scenarioLine = scenarioNode.getToken('ScenarioLine');
+          var description = getDescription(scenarioNode);
+          var steps = getSteps(scenarioNode);
+
+          return {
+            type: scenarioNode.ruleType,
+            tags: tags,
+            location: getLocation(scenarioLine),
+            keyword: scenarioLine.matchedKeyword,
+            name: scenarioLine.matchedText,
+            description: description,
+            steps: steps
+          };
+        } else {
+          var scenarioOutlineNode = node.getSingle('ScenarioOutline');
+          if(!scenarioOutlineNode) throw new Error('Internal grammar error');
+
+          var scenarioOutlineLine = scenarioOutlineNode.getToken('ScenarioOutlineLine');
+          var description = getDescription(scenarioOutlineNode);
+          var steps = getSteps(scenarioOutlineNode);
+          var examples = scenarioOutlineNode.getItems('Examples');
+
+          return {
+            type: scenarioOutlineNode.ruleType,
+            tags: tags,
+            location: getLocation(scenarioOutlineLine),
+            keyword: scenarioOutlineLine.matchedKeyword,
+            name: scenarioOutlineLine.matchedText,
+            description: description,
+            steps: steps,
+            examples: examples
+          };
+        }
+      case 'Examples':
+        var tags = getTags(node);
+        var examplesLine = node.getToken('ExamplesLine');
+        var description = getDescription(node);
+
+        var allRows = getTableRows(node);
+        var header = allRows[0];
+        var rows = allRows.slice(1);
+
+        return {
+          type: node.ruleType,
+          tags: tags,
+          location: getLocation(examplesLine),
+          keyword: examplesLine.matchedKeyword,
+          name: examplesLine.matchedText,
+          description: description,
+          header: header,
+          rows: rows
+        };
+      case 'Description':
+        var lineTokens = node.getTokens('Other');
+        // Trim trailing empty lines
+        var end = lineTokens.length;
+        while (end > 0 && lineTokens[end-1].line.trimmedLineText === '') {
+            end--;
+        }
+        lineTokens = lineTokens.slice(0, end);
+
+        var description = lineTokens.map(function (token) { return token.matchedText}).join("\n");
+        return description;
+
+      case 'Feature':
+        var header = node.getSingle('Feature_Header');
+        var tags = getTags(header);
+        var featureLine = header.getToken('FeatureLine');
+        var background = node.getSingle('Background');
+        var scenariodefinitions = node.getItems('Scenario_Definition');
+        var description = getDescription(header);
+        var language = featureLine.matchedGherkinDialect;
+
+        return {
+          type: node.ruleType,
+          tags: tags,
+          location: getLocation(featureLine),
+          language: language,
+          keyword: featureLine.matchedKeyword,
+          name: featureLine.matchedText,
+          description: description,
+          background: background,
+          scenarioDefinitions: scenariodefinitions
+        };
+      default:
+        return node;
+    }
+  }
+
+};
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/ast_node.js
+++ b/lib/ace/mode/gherkin/ast_node.js
@@ -1,3 +1,26 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 define(function(require,exports,module){
 
 function AstNode (ruleType) {

--- a/lib/ace/mode/gherkin/ast_node.js
+++ b/lib/ace/mode/gherkin/ast_node.js
@@ -1,0 +1,34 @@
+define(function(require,exports,module){
+
+function AstNode (ruleType) {
+  this.ruleType = ruleType;
+  this._subItems = {};
+}
+
+AstNode.prototype.add = function (ruleType, obj) {
+  var items = this._subItems[ruleType];
+  if(items === undefined) this._subItems[ruleType] = items = [];
+  items.push(obj);
+}
+
+AstNode.prototype.getSingle = function (ruleType) {
+  return (this._subItems[ruleType] || [])[0];
+}
+
+AstNode.prototype.getItems = function (ruleType) {
+  return this._subItems[ruleType] || [];
+}
+
+AstNode.prototype.getToken = function (tokenType) {
+  return this.getSingle(tokenType);
+}
+
+AstNode.prototype.getTokens = function (tokenType) {
+  return this._subItems[tokenType] || [];
+}
+
+module.exports = AstNode;
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/compiler.js
+++ b/lib/ace/mode/gherkin/compiler.js
@@ -1,3 +1,26 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 define(function(require,exports,module){
 
 var EventEmitter = require('events').EventEmitter;

--- a/lib/ace/mode/gherkin/compiler.js
+++ b/lib/ace/mode/gherkin/compiler.js
@@ -1,0 +1,57 @@
+define(function(require,exports,module){
+
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+
+function Compiler() {
+  EventEmitter.call(this);
+
+  var self = this;
+
+  this.compile = function (feature) {
+    var backgroundSteps = feature.background ? feature.background.steps : [];
+
+    feature.scenarioDefinitions.forEach(function (scenarioDefinition) {
+      if(scenarioDefinition.type === 'Scenario') {
+        compileScenario(backgroundSteps, scenarioDefinition);
+      } else {
+        compileScenarioOutline(backgroundSteps, scenarioDefinition);
+      }
+    });
+  };
+
+  function compileScenario(backgroundSteps, scenario) {
+    var testCase = {
+      name: scenario.keyword + ": " + scenario.name,
+      location: scenario.location
+    };
+    self.emit('test-case', testCase);
+
+    var steps = [].concat(backgroundSteps).concat(scenario.steps);
+    steps.forEach(function (step) {
+      var testStep = {
+        name: step.keyword + step.name,
+        location: step.location
+      };
+      self.emit('test-step', testStep);
+    });
+  }
+
+  function compileScenarioOutline(backgroundSteps, scenarioOutline) {
+    scenarioOutline.examples.forEach(function (example) {
+      example.rows.forEach(function (row) {
+        var i = 0;
+        row.cells.forEach(function (cell) {
+
+        });
+      });
+    });
+  }
+}
+
+util.inherits(Compiler, EventEmitter);
+module.exports = Compiler;
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/errors.js
+++ b/lib/ace/mode/gherkin/errors.js
@@ -1,3 +1,26 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 define(function(require,exports,module){
 
 var error = require('./tea/error');

--- a/lib/ace/mode/gherkin/errors.js
+++ b/lib/ace/mode/gherkin/errors.js
@@ -1,0 +1,51 @@
+define(function(require,exports,module){
+
+var error = require('./tea/error');
+
+var Errors = {
+  ParserException: error('ParserException'),
+  CompositeParserException: error('CompositeParserException'),
+  UnexpectedTokenException: error('UnexpectedTokenException'),
+  UnexpectedEOFException: error('UnexpectedEOFException'),
+  AstBuilderException: error('AstBuilderException'),
+  NoSuchLanguageException: error('NoSuchLanguageException')
+};
+
+Errors.CompositeParserException.create = function(errors) {
+  var message = "Parser errors:\n" + errors.map(function (e) { return e.message; }).join("\n");
+  var err = new Errors.CompositeParserException(message);
+  err.errors = errors;
+  return err;
+};
+
+Errors.UnexpectedTokenException.create = function(token, expectedTokenTypes, stateComment) {
+  var message = "expected: " + expectedTokenTypes.join(', ') + ", got '" + token.getTokenValue().trim() + "'";
+  return createError(Errors.UnexpectedEOFException, message, token.location);
+};
+
+Errors.UnexpectedEOFException.create = function(token, expectedTokenTypes, stateComment) {
+  var message = "unexpected end of file, expected: " + expectedTokenTypes.join(', ');
+  return createError(Errors.UnexpectedTokenException, message, token.location);
+};
+
+Errors.AstBuilderException.create = function(message, location) {
+  return createError(Errors.AstBuilderException, message, location);
+};
+
+Errors.NoSuchLanguageException.create = function(language, location) {
+  var message = "Language not supported: " + language;
+  return createError(Errors.NoSuchLanguageException, message, location);
+};
+
+function createError(Ctor, message, location) {
+  var fullMessage = "(" + location.line + ":" + location.column + "): " + message;
+  var error = new Ctor(fullMessage);
+  error.location = location;
+  return error;
+}
+
+module.exports = Errors;
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/gherkin_line.js
+++ b/lib/ace/mode/gherkin/gherkin_line.js
@@ -1,3 +1,26 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 define(function(require,exports,module){
 
 function GherkinLine(lineText, lineNumber) {

--- a/lib/ace/mode/gherkin/gherkin_line.js
+++ b/lib/ace/mode/gherkin/gherkin_line.js
@@ -1,0 +1,60 @@
+define(function(require,exports,module){
+
+function GherkinLine(lineText, lineNumber) {
+  this.lineText = lineText;
+  this.lineNumber = lineNumber;
+  this.trimmedLineText = lineText.replace(/^\s+/g, ''); // ltrim
+  this.isEmpty = this.trimmedLineText.length == 0;
+  this.indent = lineText.length - this.trimmedLineText.length;
+};
+
+GherkinLine.prototype.startsWith = function startsWith(prefix) {
+  return this.trimmedLineText.indexOf(prefix) == 0;
+};
+
+GherkinLine.prototype.startsWithTitleKeyword = function startsWithTitleKeyword(keyword) {
+  return this.startsWith(keyword+':'); // The C# impl is more complicated. Find out why.
+};
+
+GherkinLine.prototype.getLineText = function getLineText(indentToRemove) {
+  if (indentToRemove < 0 || indentToRemove > this.indent) {
+    return this.trimmedLineText;
+  } else {
+    return this.lineText.substring(indentToRemove);
+  }
+};
+
+GherkinLine.prototype.getRestTrimmed = function getRestTrimmed(length) {
+  return this.trimmedLineText.substring(length).trim();
+};
+
+GherkinLine.prototype.getTableCells = function getTableCells() {
+  var column = this.indent + 1;
+  var items = this.trimmedLineText.split('|');
+  items.shift(); // Skip the beginning of the line
+  items.pop(); // Skip the one after the last pipe
+  return items.map(function (item) {
+    var cellIndent = item.length - item.replace(/^\s+/g, '').length + 1;
+    var span = {column: column + cellIndent, text: item.trim()};
+    column += item.length + 1;
+    return span;
+  });
+};
+
+GherkinLine.prototype.getTags = function getTags() {
+  var column = this.indent + 1;
+  var items = this.trimmedLineText.trim().split('@');
+  items.shift();
+  return items.map(function (item) {
+    var length = item.length;
+    var span = {column: column, text: '@' + item.trim()};
+    column += length + 1;
+    return span;
+  });
+};
+
+module.exports = GherkinLine;
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/parser.js
+++ b/lib/ace/mode/gherkin/parser.js
@@ -1,0 +1,2004 @@
+define(function(require,exports,module){
+
+// This file is generated. Do not edit! Edit gherkin-javascript.razor instead.
+var Errors = require('./errors');
+
+module.exports = function Parser() {
+
+  var RULE_TYPES = [
+    'None',
+    '_EOF', // #EOF
+    '_Empty', // #Empty
+    '_Comment', // #Comment
+    '_TagLine', // #TagLine
+    '_FeatureLine', // #FeatureLine
+    '_BackgroundLine', // #BackgroundLine
+    '_ScenarioLine', // #ScenarioLine
+    '_ScenarioOutlineLine', // #ScenarioOutlineLine
+    '_ExamplesLine', // #ExamplesLine
+    '_StepLine', // #StepLine
+    '_DocStringSeparator', // #DocStringSeparator
+    '_TableRow', // #TableRow
+    '_Language', // #Language
+    '_Other', // #Other
+    'Feature', // Feature! := Feature_Header Background? Scenario_Definition*
+    'Feature_Header', // Feature_Header! := #Language? Tags? #FeatureLine Feature_Description
+    'Background', // Background! := #BackgroundLine Background_Description Scenario_Step*
+    'Scenario_Definition', // Scenario_Definition! := Tags? (Scenario | ScenarioOutline)
+    'Scenario', // Scenario! := #ScenarioLine Scenario_Description Scenario_Step*
+    'ScenarioOutline', // ScenarioOutline! := #ScenarioOutlineLine ScenarioOutline_Description ScenarioOutline_Step* Examples+
+    'Examples', // Examples! [#Empty|#Comment|#TagLine-&gt;#ExamplesLine] := Tags? #ExamplesLine Examples_Description #TableRow #TableRow+
+    'Scenario_Step', // Scenario_Step := Step
+    'ScenarioOutline_Step', // ScenarioOutline_Step := Step
+    'Step', // Step! := #StepLine Step_Arg?
+    'Step_Arg', // Step_Arg := (DataTable | DocString)
+    'DataTable', // DataTable! := #TableRow+
+    'DocString', // DocString! := #DocStringSeparator #Other* #DocStringSeparator
+    'Tags', // Tags! := #TagLine+
+    'Feature_Description', // Feature_Description := Description_Helper
+    'Background_Description', // Background_Description := Description_Helper
+    'Scenario_Description', // Scenario_Description := Description_Helper
+    'ScenarioOutline_Description', // ScenarioOutline_Description := Description_Helper
+    'Examples_Description', // Examples_Description := Description_Helper
+    'Description_Helper', // Description_Helper := #Empty* Description? #Comment*
+    'Description', // Description! := #Other+
+  ]
+
+  var context = {};
+
+  this.parse = function(tokenScanner, astBuilder, tokenMatcher) {
+    context.tokenScanner = tokenScanner;
+    context.astBuilder = astBuilder;
+    context.tokenMatcher = tokenMatcher;
+    context.tokenQueue = [];
+    context.errors = [];
+
+    startRule(context, 'Feature');
+    var state = 0;
+    var token = null;
+    while(true) {
+      token = readToken(context);
+      state = matchToken(state, token, context);
+      if(token.isEof) break;
+    }
+
+    endRule(context, 'Feature');
+
+    if(context.errors.length > 0) {
+      throw Errors.CompositeParserException.create(context.errors);
+    }
+
+    return getResult(context);
+  };
+
+  function addError(context, error) {
+    context.errors.push(error);
+    if (context.errors.length > 10)
+      throw Errors.CompositeParserException.create(context.errors);
+  }
+
+  function startRule(context, ruleType) {
+    handleAstError(context, function () {
+      context.astBuilder.startRule(ruleType);
+    });
+  }
+
+  function endRule(context, ruleType) {
+    handleAstError(context, function () {
+      context.astBuilder.endRule(ruleType);
+    });
+  }
+
+  function build(context, token) {
+    handleAstError(context, function () {
+      context.astBuilder.build(token);
+    });
+  }
+
+  function getResult(context) {
+    return context.astBuilder.getResult();
+  }
+
+  function handleAstError(context, action) {
+    handleExternalError(context, true, action)
+  }
+
+  function handleExternalError(context, defaultValue, action) {
+    if(this.stopAtFirstError) return action();
+    try {
+      return action();
+    } catch (e) {
+      if(e instanceof Errors.CompositeParserException) {
+        e.errors.forEach(function (error) {
+          addError(context, error);
+        });
+      } else if(
+        e instanceof Errors.ParserException ||
+        e instanceof Errors.AstBuilderException ||
+        e instanceof Errors.UnexpectedTokenException ||
+        e instanceof Errors.NoSuchLanguageException
+      ) {
+        addError(context, e);
+      } else {
+        throw e;
+      }
+    }
+    return defaultValue;
+  }
+
+  function readToken(context) {
+    return context.tokenQueue.length > 0 ?
+      context.tokenQueue.shift() :
+      context.tokenScanner.read();
+  }
+
+  function matchToken(state, token, context) {
+    switch(state) {
+    case 0:
+      return matchTokenAt_0(token, context);
+    case 1:
+      return matchTokenAt_1(token, context);
+    case 2:
+      return matchTokenAt_2(token, context);
+    case 3:
+      return matchTokenAt_3(token, context);
+    case 4:
+      return matchTokenAt_4(token, context);
+    case 5:
+      return matchTokenAt_5(token, context);
+    case 6:
+      return matchTokenAt_6(token, context);
+    case 7:
+      return matchTokenAt_7(token, context);
+    case 8:
+      return matchTokenAt_8(token, context);
+    case 9:
+      return matchTokenAt_9(token, context);
+    case 10:
+      return matchTokenAt_10(token, context);
+    case 11:
+      return matchTokenAt_11(token, context);
+    case 12:
+      return matchTokenAt_12(token, context);
+    case 13:
+      return matchTokenAt_13(token, context);
+    case 14:
+      return matchTokenAt_14(token, context);
+    case 15:
+      return matchTokenAt_15(token, context);
+    case 16:
+      return matchTokenAt_16(token, context);
+    case 17:
+      return matchTokenAt_17(token, context);
+    case 18:
+      return matchTokenAt_18(token, context);
+    case 19:
+      return matchTokenAt_19(token, context);
+    case 20:
+      return matchTokenAt_20(token, context);
+    case 21:
+      return matchTokenAt_21(token, context);
+    case 22:
+      return matchTokenAt_22(token, context);
+    case 23:
+      return matchTokenAt_23(token, context);
+    case 24:
+      return matchTokenAt_24(token, context);
+    case 25:
+      return matchTokenAt_25(token, context);
+    case 26:
+      return matchTokenAt_26(token, context);
+    case 27:
+      return matchTokenAt_27(token, context);
+    case 29:
+      return matchTokenAt_29(token, context);
+    case 30:
+      return matchTokenAt_30(token, context);
+    case 31:
+      return matchTokenAt_31(token, context);
+    case 32:
+      return matchTokenAt_32(token, context);
+    case 33:
+      return matchTokenAt_33(token, context);
+    case 34:
+      return matchTokenAt_34(token, context);
+    default:
+      throw new Error("Unknown state: " + state);
+    }
+  }
+
+
+  // Start
+  function matchTokenAt_0(token, context) {
+    if(match_Language(context, token)) {
+      startRule(context, 'Feature_Header');
+      build(context, token);
+      return 1;
+    }
+    if(match_TagLine(context, token)) {
+      startRule(context, 'Feature_Header');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 2;
+    }
+    if(match_FeatureLine(context, token)) {
+      startRule(context, 'Feature_Header');
+      build(context, token);
+      return 3;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 0;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 0;
+    }
+    
+    var stateComment = "State: 0 - Start";
+    token.detach();
+    var expectedTokens = ["#Language", "#TagLine", "#FeatureLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 0;
+  }
+
+
+  // Feature:0>Feature_Header:0>#Language:0
+  function matchTokenAt_1(token, context) {
+    if(match_TagLine(context, token)) {
+      startRule(context, 'Tags');
+      build(context, token);
+      return 2;
+    }
+    if(match_FeatureLine(context, token)) {
+      build(context, token);
+      return 3;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 1;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 1;
+    }
+    
+    var stateComment = "State: 1 - Feature:0>Feature_Header:0>#Language:0";
+    token.detach();
+    var expectedTokens = ["#TagLine", "#FeatureLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 1;
+  }
+
+
+  // Feature:0>Feature_Header:1>Tags:0>#TagLine:0
+  function matchTokenAt_2(token, context) {
+    if(match_TagLine(context, token)) {
+      build(context, token);
+      return 2;
+    }
+    if(match_FeatureLine(context, token)) {
+      endRule(context, 'Tags');
+      build(context, token);
+      return 3;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 2;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 2;
+    }
+    
+    var stateComment = "State: 2 - Feature:0>Feature_Header:1>Tags:0>#TagLine:0";
+    token.detach();
+    var expectedTokens = ["#TagLine", "#FeatureLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 2;
+  }
+
+
+  // Feature:0>Feature_Header:2>#FeatureLine:0
+  function matchTokenAt_3(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Feature_Header');
+      build(context, token);
+      return 28;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 3;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 5;
+    }
+    if(match_BackgroundLine(context, token)) {
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Background');
+      build(context, token);
+      return 6;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Other(context, token)) {
+      startRule(context, 'Description');
+      build(context, token);
+      return 4;
+    }
+    
+    var stateComment = "State: 3 - Feature:0>Feature_Header:2>#FeatureLine:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Empty", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 3;
+  }
+
+
+  // Feature:0>Feature_Header:3>Feature_Description:0>Description_Helper:1>Description:0>#Other:0
+  function matchTokenAt_4(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Feature_Header');
+      build(context, token);
+      return 28;
+    }
+    if(match_Comment(context, token)) {
+      endRule(context, 'Description');
+      build(context, token);
+      return 5;
+    }
+    if(match_BackgroundLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Background');
+      build(context, token);
+      return 6;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Other(context, token)) {
+      build(context, token);
+      return 4;
+    }
+    
+    var stateComment = "State: 4 - Feature:0>Feature_Header:3>Feature_Description:0>Description_Helper:1>Description:0>#Other:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 4;
+  }
+
+
+  // Feature:0>Feature_Header:3>Feature_Description:0>Description_Helper:2>#Comment:0
+  function matchTokenAt_5(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Feature_Header');
+      build(context, token);
+      return 28;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 5;
+    }
+    if(match_BackgroundLine(context, token)) {
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Background');
+      build(context, token);
+      return 6;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Feature_Header');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 5;
+    }
+    
+    var stateComment = "State: 5 - Feature:0>Feature_Header:3>Feature_Description:0>Description_Helper:2>#Comment:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 5;
+  }
+
+
+  // Feature:1>Background:0>#BackgroundLine:0
+  function matchTokenAt_6(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Background');
+      build(context, token);
+      return 28;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 6;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 8;
+    }
+    if(match_StepLine(context, token)) {
+      startRule(context, 'Step');
+      build(context, token);
+      return 9;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Other(context, token)) {
+      startRule(context, 'Description');
+      build(context, token);
+      return 7;
+    }
+    
+    var stateComment = "State: 6 - Feature:1>Background:0>#BackgroundLine:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 6;
+  }
+
+
+  // Feature:1>Background:1>Background_Description:0>Description_Helper:1>Description:0>#Other:0
+  function matchTokenAt_7(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Background');
+      build(context, token);
+      return 28;
+    }
+    if(match_Comment(context, token)) {
+      endRule(context, 'Description');
+      build(context, token);
+      return 8;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'Description');
+      startRule(context, 'Step');
+      build(context, token);
+      return 9;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Other(context, token)) {
+      build(context, token);
+      return 7;
+    }
+    
+    var stateComment = "State: 7 - Feature:1>Background:1>Background_Description:0>Description_Helper:1>Description:0>#Other:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 7;
+  }
+
+
+  // Feature:1>Background:1>Background_Description:0>Description_Helper:2>#Comment:0
+  function matchTokenAt_8(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Background');
+      build(context, token);
+      return 28;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 8;
+    }
+    if(match_StepLine(context, token)) {
+      startRule(context, 'Step');
+      build(context, token);
+      return 9;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 8;
+    }
+    
+    var stateComment = "State: 8 - Feature:1>Background:1>Background_Description:0>Description_Helper:2>#Comment:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 8;
+  }
+
+
+  // Feature:1>Background:2>Scenario_Step:0>Step:0>#StepLine:0
+  function matchTokenAt_9(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      build(context, token);
+      return 28;
+    }
+    if(match_TableRow(context, token)) {
+      startRule(context, 'DataTable');
+      build(context, token);
+      return 10;
+    }
+    if(match_DocStringSeparator(context, token)) {
+      startRule(context, 'DocString');
+      build(context, token);
+      return 33;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 9;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 9;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 9;
+    }
+    
+    var stateComment = "State: 9 - Feature:1>Background:2>Scenario_Step:0>Step:0>#StepLine:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 9;
+  }
+
+
+  // Feature:1>Background:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0
+  function matchTokenAt_10(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      build(context, token);
+      return 28;
+    }
+    if(match_TableRow(context, token)) {
+      build(context, token);
+      return 10;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 9;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 10;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 10;
+    }
+    
+    var stateComment = "State: 10 - Feature:1>Background:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 10;
+  }
+
+
+  // Feature:2>Scenario_Definition:0>Tags:0>#TagLine:0
+  function matchTokenAt_11(token, context) {
+    if(match_TagLine(context, token)) {
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Tags');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Tags');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 11;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 11;
+    }
+    
+    var stateComment = "State: 11 - Feature:2>Scenario_Definition:0>Tags:0>#TagLine:0";
+    token.detach();
+    var expectedTokens = ["#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 11;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:0>Scenario:0>#ScenarioLine:0
+  function matchTokenAt_12(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      build(context, token);
+      return 28;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 12;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 14;
+    }
+    if(match_StepLine(context, token)) {
+      startRule(context, 'Step');
+      build(context, token);
+      return 15;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Other(context, token)) {
+      startRule(context, 'Description');
+      build(context, token);
+      return 13;
+    }
+    
+    var stateComment = "State: 12 - Feature:2>Scenario_Definition:1>__alt0:0>Scenario:0>#ScenarioLine:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 12;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:0>Scenario:1>Scenario_Description:0>Description_Helper:1>Description:0>#Other:0
+  function matchTokenAt_13(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      build(context, token);
+      return 28;
+    }
+    if(match_Comment(context, token)) {
+      endRule(context, 'Description');
+      build(context, token);
+      return 14;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'Description');
+      startRule(context, 'Step');
+      build(context, token);
+      return 15;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Description');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Other(context, token)) {
+      build(context, token);
+      return 13;
+    }
+    
+    var stateComment = "State: 13 - Feature:2>Scenario_Definition:1>__alt0:0>Scenario:1>Scenario_Description:0>Description_Helper:1>Description:0>#Other:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 13;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:0>Scenario:1>Scenario_Description:0>Description_Helper:2>#Comment:0
+  function matchTokenAt_14(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      build(context, token);
+      return 28;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 14;
+    }
+    if(match_StepLine(context, token)) {
+      startRule(context, 'Step');
+      build(context, token);
+      return 15;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 14;
+    }
+    
+    var stateComment = "State: 14 - Feature:2>Scenario_Definition:1>__alt0:0>Scenario:1>Scenario_Description:0>Description_Helper:2>#Comment:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 14;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Scenario_Step:0>Step:0>#StepLine:0
+  function matchTokenAt_15(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      build(context, token);
+      return 28;
+    }
+    if(match_TableRow(context, token)) {
+      startRule(context, 'DataTable');
+      build(context, token);
+      return 16;
+    }
+    if(match_DocStringSeparator(context, token)) {
+      startRule(context, 'DocString');
+      build(context, token);
+      return 31;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 15;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 15;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 15;
+    }
+    
+    var stateComment = "State: 15 - Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Scenario_Step:0>Step:0>#StepLine:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 15;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0
+  function matchTokenAt_16(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      build(context, token);
+      return 28;
+    }
+    if(match_TableRow(context, token)) {
+      build(context, token);
+      return 16;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 15;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 16;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 16;
+    }
+    
+    var stateComment = "State: 16 - Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 16;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:0>#ScenarioOutlineLine:0
+  function matchTokenAt_17(token, context) {
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 19;
+    }
+    if(match_StepLine(context, token)) {
+      startRule(context, 'Step');
+      build(context, token);
+      return 20;
+    }
+    if(match_TagLine(context, token)) {
+      startRule(context, 'Examples');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 22;
+    }
+    if(match_ExamplesLine(context, token)) {
+      startRule(context, 'Examples');
+      build(context, token);
+      return 23;
+    }
+    if(match_Other(context, token)) {
+      startRule(context, 'Description');
+      build(context, token);
+      return 18;
+    }
+    
+    var stateComment = "State: 17 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:0>#ScenarioOutlineLine:0";
+    token.detach();
+    var expectedTokens = ["#Empty", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 17;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:1>ScenarioOutline_Description:0>Description_Helper:1>Description:0>#Other:0
+  function matchTokenAt_18(token, context) {
+    if(match_Comment(context, token)) {
+      endRule(context, 'Description');
+      build(context, token);
+      return 19;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'Description');
+      startRule(context, 'Step');
+      build(context, token);
+      return 20;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Description');
+      startRule(context, 'Examples');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 22;
+    }
+    if(match_ExamplesLine(context, token)) {
+      endRule(context, 'Description');
+      startRule(context, 'Examples');
+      build(context, token);
+      return 23;
+    }
+    if(match_Other(context, token)) {
+      build(context, token);
+      return 18;
+    }
+    
+    var stateComment = "State: 18 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:1>ScenarioOutline_Description:0>Description_Helper:1>Description:0>#Other:0";
+    token.detach();
+    var expectedTokens = ["#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 18;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:1>ScenarioOutline_Description:0>Description_Helper:2>#Comment:0
+  function matchTokenAt_19(token, context) {
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 19;
+    }
+    if(match_StepLine(context, token)) {
+      startRule(context, 'Step');
+      build(context, token);
+      return 20;
+    }
+    if(match_TagLine(context, token)) {
+      startRule(context, 'Examples');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 22;
+    }
+    if(match_ExamplesLine(context, token)) {
+      startRule(context, 'Examples');
+      build(context, token);
+      return 23;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 19;
+    }
+    
+    var stateComment = "State: 19 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:1>ScenarioOutline_Description:0>Description_Helper:2>#Comment:0";
+    token.detach();
+    var expectedTokens = ["#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 19;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>ScenarioOutline_Step:0>Step:0>#StepLine:0
+  function matchTokenAt_20(token, context) {
+    if(match_TableRow(context, token)) {
+      startRule(context, 'DataTable');
+      build(context, token);
+      return 21;
+    }
+    if(match_DocStringSeparator(context, token)) {
+      startRule(context, 'DocString');
+      build(context, token);
+      return 29;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 20;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Step');
+      startRule(context, 'Examples');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 22;
+    }
+    if(match_ExamplesLine(context, token)) {
+      endRule(context, 'Step');
+      startRule(context, 'Examples');
+      build(context, token);
+      return 23;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 20;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 20;
+    }
+    
+    var stateComment = "State: 20 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>ScenarioOutline_Step:0>Step:0>#StepLine:0";
+    token.detach();
+    var expectedTokens = ["#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ExamplesLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 20;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>ScenarioOutline_Step:0>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0
+  function matchTokenAt_21(token, context) {
+    if(match_TableRow(context, token)) {
+      build(context, token);
+      return 21;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 20;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      startRule(context, 'Examples');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 22;
+    }
+    if(match_ExamplesLine(context, token)) {
+      endRule(context, 'DataTable');
+      endRule(context, 'Step');
+      startRule(context, 'Examples');
+      build(context, token);
+      return 23;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 21;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 21;
+    }
+    
+    var stateComment = "State: 21 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>ScenarioOutline_Step:0>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
+    token.detach();
+    var expectedTokens = ["#TableRow", "#StepLine", "#TagLine", "#ExamplesLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 21;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:0>Tags:0>#TagLine:0
+  function matchTokenAt_22(token, context) {
+    if(match_TagLine(context, token)) {
+      build(context, token);
+      return 22;
+    }
+    if(match_ExamplesLine(context, token)) {
+      endRule(context, 'Tags');
+      build(context, token);
+      return 23;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 22;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 22;
+    }
+    
+    var stateComment = "State: 22 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:0>Tags:0>#TagLine:0";
+    token.detach();
+    var expectedTokens = ["#TagLine", "#ExamplesLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 22;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:1>#ExamplesLine:0
+  function matchTokenAt_23(token, context) {
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 23;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 25;
+    }
+    if(match_TableRow(context, token)) {
+      build(context, token);
+      return 26;
+    }
+    if(match_Other(context, token)) {
+      startRule(context, 'Description');
+      build(context, token);
+      return 24;
+    }
+    
+    var stateComment = "State: 23 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:1>#ExamplesLine:0";
+    token.detach();
+    var expectedTokens = ["#Empty", "#Comment", "#TableRow", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 23;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:2>Examples_Description:0>Description_Helper:1>Description:0>#Other:0
+  function matchTokenAt_24(token, context) {
+    if(match_Comment(context, token)) {
+      endRule(context, 'Description');
+      build(context, token);
+      return 25;
+    }
+    if(match_TableRow(context, token)) {
+      endRule(context, 'Description');
+      build(context, token);
+      return 26;
+    }
+    if(match_Other(context, token)) {
+      build(context, token);
+      return 24;
+    }
+    
+    var stateComment = "State: 24 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:2>Examples_Description:0>Description_Helper:1>Description:0>#Other:0";
+    token.detach();
+    var expectedTokens = ["#Comment", "#TableRow", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 24;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:2>Examples_Description:0>Description_Helper:2>#Comment:0
+  function matchTokenAt_25(token, context) {
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 25;
+    }
+    if(match_TableRow(context, token)) {
+      build(context, token);
+      return 26;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 25;
+    }
+    
+    var stateComment = "State: 25 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:2>Examples_Description:0>Description_Helper:2>#Comment:0";
+    token.detach();
+    var expectedTokens = ["#Comment", "#TableRow", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 25;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:3>#TableRow:0
+  function matchTokenAt_26(token, context) {
+    if(match_TableRow(context, token)) {
+      build(context, token);
+      return 27;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 26;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 26;
+    }
+    
+    var stateComment = "State: 26 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:3>#TableRow:0";
+    token.detach();
+    var expectedTokens = ["#TableRow", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 26;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:4>#TableRow:0
+  function matchTokenAt_27(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'Examples');
+      endRule(context, 'ScenarioOutline');
+      endRule(context, 'Scenario_Definition');
+      build(context, token);
+      return 28;
+    }
+    if(match_TableRow(context, token)) {
+      build(context, token);
+      return 27;
+    }
+    if(match_TagLine(context, token)) {
+      if(lookahead_0(context, token)) {
+      endRule(context, 'Examples');
+      startRule(context, 'Examples');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 22;
+      }
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'Examples');
+      endRule(context, 'ScenarioOutline');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ExamplesLine(context, token)) {
+      endRule(context, 'Examples');
+      startRule(context, 'Examples');
+      build(context, token);
+      return 23;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'Examples');
+      endRule(context, 'ScenarioOutline');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'Examples');
+      endRule(context, 'ScenarioOutline');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 27;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 27;
+    }
+    
+    var stateComment = "State: 27 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples:4>#TableRow:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 27;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>ScenarioOutline_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0
+  function matchTokenAt_29(token, context) {
+    if(match_DocStringSeparator(context, token)) {
+      build(context, token);
+      return 30;
+    }
+    if(match_Other(context, token)) {
+      build(context, token);
+      return 29;
+    }
+    
+    var stateComment = "State: 29 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>ScenarioOutline_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
+    token.detach();
+    var expectedTokens = ["#DocStringSeparator", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 29;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>ScenarioOutline_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0
+  function matchTokenAt_30(token, context) {
+    if(match_StepLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 20;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      startRule(context, 'Examples');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 22;
+    }
+    if(match_ExamplesLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      startRule(context, 'Examples');
+      build(context, token);
+      return 23;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 30;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 30;
+    }
+    
+    var stateComment = "State: 30 - Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>ScenarioOutline_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
+    token.detach();
+    var expectedTokens = ["#StepLine", "#TagLine", "#ExamplesLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 30;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0
+  function matchTokenAt_31(token, context) {
+    if(match_DocStringSeparator(context, token)) {
+      build(context, token);
+      return 32;
+    }
+    if(match_Other(context, token)) {
+      build(context, token);
+      return 31;
+    }
+    
+    var stateComment = "State: 31 - Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
+    token.detach();
+    var expectedTokens = ["#DocStringSeparator", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 31;
+  }
+
+
+  // Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0
+  function matchTokenAt_32(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      build(context, token);
+      return 28;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 15;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      endRule(context, 'Scenario');
+      endRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 32;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 32;
+    }
+    
+    var stateComment = "State: 32 - Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 32;
+  }
+
+
+  // Feature:1>Background:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0
+  function matchTokenAt_33(token, context) {
+    if(match_DocStringSeparator(context, token)) {
+      build(context, token);
+      return 34;
+    }
+    if(match_Other(context, token)) {
+      build(context, token);
+      return 33;
+    }
+    
+    var stateComment = "State: 33 - Feature:1>Background:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
+    token.detach();
+    var expectedTokens = ["#DocStringSeparator", "#Other"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 33;
+  }
+
+
+  // Feature:1>Background:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0
+  function matchTokenAt_34(token, context) {
+    if(match_EOF(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      build(context, token);
+      return 28;
+    }
+    if(match_StepLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      startRule(context, 'Step');
+      build(context, token);
+      return 9;
+    }
+    if(match_TagLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Tags');
+      build(context, token);
+      return 11;
+    }
+    if(match_ScenarioLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'Scenario');
+      build(context, token);
+      return 12;
+    }
+    if(match_ScenarioOutlineLine(context, token)) {
+      endRule(context, 'DocString');
+      endRule(context, 'Step');
+      endRule(context, 'Background');
+      startRule(context, 'Scenario_Definition');
+      startRule(context, 'ScenarioOutline');
+      build(context, token);
+      return 17;
+    }
+    if(match_Comment(context, token)) {
+      build(context, token);
+      return 34;
+    }
+    if(match_Empty(context, token)) {
+      build(context, token);
+      return 34;
+    }
+    
+    var stateComment = "State: 34 - Feature:1>Background:2>Scenario_Step:0>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
+    token.detach();
+    var expectedTokens = ["#EOF", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
+    var error = token.isEof ?
+      Errors.UnexpectedEOFException.create(token, expectedTokens, stateComment) :
+      Errors.UnexpectedTokenException.create(token, expectedTokens, stateComment);
+    if (this.stopAtFirstError) throw error;
+    addError(context, error);
+    return 34;
+  }
+
+
+
+  function match_EOF(context, token) {
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_EOF(token);
+    });
+  }
+
+
+  function match_Empty(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_Empty(token);
+    });
+  }
+
+
+  function match_Comment(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_Comment(token);
+    });
+  }
+
+
+  function match_TagLine(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_TagLine(token);
+    });
+  }
+
+
+  function match_FeatureLine(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_FeatureLine(token);
+    });
+  }
+
+
+  function match_BackgroundLine(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_BackgroundLine(token);
+    });
+  }
+
+
+  function match_ScenarioLine(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_ScenarioLine(token);
+    });
+  }
+
+
+  function match_ScenarioOutlineLine(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_ScenarioOutlineLine(token);
+    });
+  }
+
+
+  function match_ExamplesLine(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_ExamplesLine(token);
+    });
+  }
+
+
+  function match_StepLine(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_StepLine(token);
+    });
+  }
+
+
+  function match_DocStringSeparator(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_DocStringSeparator(token);
+    });
+  }
+
+
+  function match_TableRow(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_TableRow(token);
+    });
+  }
+
+
+  function match_Language(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_Language(token);
+    });
+  }
+
+
+  function match_Other(context, token) {
+    if(token.isEof) return false;
+    return handleExternalError(context, false, function () {
+      return context.tokenMatcher.match_Other(token);
+    });
+  }
+
+
+
+  function lookahead_0(context, currentToken) {
+    currentToken.detach();
+    var token;
+    var queue = [];
+    var match = false;
+    do {
+      token = readToken(context);
+      token.detach();
+      queue.push(token);
+
+      if (false  || match_ExamplesLine(context, token)) {
+        match = true;
+        break;
+      }
+    } while(false  || match_Empty(context, token) || match_Comment(context, token) || match_TagLine(context, token));
+
+    context.tokenQueue = context.tokenQueue.concat(queue);
+
+    return match;
+  }
+
+
+}
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/parser.js
+++ b/lib/ace/mode/gherkin/parser.js
@@ -1,3 +1,26 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 define(function(require,exports,module){
 
 // This file is generated. Do not edit! Edit gherkin-javascript.razor instead.

--- a/lib/ace/mode/gherkin/tea/error.js
+++ b/lib/ace/mode/gherkin/tea/error.js
@@ -1,0 +1,230 @@
+define(function(require,exports,module){
+
+/*!
+ * tea-error
+ * Copyright(c) 2012 Jake Luer <jake@qualiancy.com>
+ * MIT Licensed
+ */
+
+/*!
+ * Module dependencies
+ */
+
+var extend = require('./extend');
+
+/**
+ * ### error (name)
+ *
+ * The primary export for this module is a factory
+ * that will return a constructor for a custom error
+ * of the type/name that is specified.
+ *
+ * ```js
+ * var error = require('tea-error')
+ *   , TestError = error('TestError')
+ *   , err = new TestError('My error message.');
+ *
+ * throw err;
+ * ```
+ *
+ * An error created/thrown from the custom constructor
+ * observes all of the expected Javascript behaviors of
+ * `Error`.
+ *
+ * ##### instanceof
+ *
+ * The constructed error is an instanceof an Error.
+ *
+ * ```js
+ * var err = new Error();
+ *   , myerr = new TestError()
+ *
+ * err.should.be.instanceof(Error);
+ * myerr.should.be.instanceof(Error);
+ * myerr.should.be.isntanceof(TestError);
+ * ```
+ *
+ * ##### name
+ *
+ * The `name` property is defined like other "native" errors.
+ *
+ * ```js
+ * var err = new ReferenceError()
+ *   , myerr = new TestError();
+ *
+ * err.should.have.property('name', 'ReferenceError');
+ * myerr.should.have.property('name', 'TestError');
+ * ```
+ *
+ * ##### message
+ *
+ * The `message` property is defined like all error and specified
+ * as the first argument during construction.
+ *
+ * ```js
+ * var err = new Error('Javascript error occurred')
+ *   , myerr = new TestError('Test error occurred');
+ *
+ * err.should.have.property('message', 'Javascript error occurred');
+ * myerr.should.have.property('message', 'Test Error occurred');
+ * ```
+ *
+ * ##### stack
+ *
+ * If the environment provides the ability to capture a stack trace,
+ * it will be provided as the `stack` property. Please view your environments
+ * documentation to see if this is supported.
+ *
+ * ```js
+ * var err = new Error()
+ *   , myerr = new TestError();
+ *
+ * if (Error.captureStackTrace) {
+ *   err.should.have.property('stack');
+ *   myerr.should.have.property('stack');
+ * }
+ * ```
+ *
+ * @param {String} name
+ * @return {Function} custom error constructor
+ * @api public
+ */
+
+module.exports = function (name) {
+
+  /**
+   * #### new CustomError (message[, properties[, startStackFunction]])
+   *
+   * Once the new constructor for an error has been created
+   * it can be used to construct errors just as normal javascript
+   * errors.
+   *
+   * ```js
+   * var TestError = require('tea-errors')('TestError')
+   *   , err = new TestError('that did not work right');
+   *
+   * throw err;
+   * ```
+   *
+   * There are a number of additional arguments that can be
+   * specified upon construction to provide further insight
+   * into the error created.
+   *
+   * ##### properties
+   *
+   * The second argument during construction can be an object
+   * of properties that will be merged onto the newly created error.
+   *
+   * ```js
+   * var err = new TestError('expected field value', { fields: [ 'username' ] });
+   *
+   * err.should.have.property('fields')
+   *   .an('array')
+   *   .that.deep.equals([ 'username' ]);
+   * ```
+   *
+   * Note that if the `name`, `message`, and `stack` properties are defined
+   * in this custom properties object, they will be ignored as those keys
+   * are reserved.
+   *
+   * ##### start stack function
+   *
+   * The start stack function is used by `Error.captureStackTrace`
+   * to indicate where the environment should start the visible
+   * stack trace. Modifying this value might be useful in situations
+   * where the internals of the module issuing the error are irrelevant
+   * to what occured. The most obvious example is providing feedback
+   * for an api method.
+   *
+   * ```js
+   * // api.js
+   * var ApiError = require('tea-error')('ApiError');
+   *
+   * exports.use = function (fn) {
+   *   if ('function' !== typeof fn) {
+   *     throw new ApiError('API .use only accepts functions', null, arguments.callee);
+   *   }
+   *
+   *   // etc.
+   * };
+   *
+   * // user.js
+   * var api = require('./api.js);
+   * api.use('a string?');
+   * ```
+   *
+   * In this scenario the first line of the error stack will reference
+   * `user.js-Ln:2` as opposed to `api.js-Ln:5`. See the `stack` example
+   * for a demonstration.
+   *
+   * @param {String} message
+   * @param {Object} properties
+   * @param {Callee} start stack function for captureStackTrace
+   */
+
+  function ErrorProto (message, props, ssf) {
+    var exclude = extend.exclude('name', 'message', 'stack')
+      , props = exclude(props || {});
+
+    this.message = message || ('Unspecified ' + name);
+    extend(this, props);
+
+    ssf = ssf || arguments.callee;
+    if (ssf && Error.captureStackTrace) {
+      Error.captureStackTrace(this, ssf);
+    }
+  }
+
+  /*!
+   * Build the prototype
+   */
+
+  ErrorProto.prototype = Object.create(Error.prototype);
+  ErrorProto.prototype.name = name;
+  ErrorProto.prototype.constructor = ErrorProto;
+
+  /**
+   * ### .toJSON ()
+   *
+   * Convert this error into a serialized JSON object.
+   *
+   * ```js
+   * var err = new TestError('some message', { hello: 'universe' })
+   *   , json = err.toJSON();
+   *
+   * json.should.deep.equal({
+   *     name: 'TestError'
+   *   , message: 'some message'
+   *   , hello: 'universe'
+   *   , stack: '...'
+   * });
+   * ```
+   *
+   * If this method is called as `err.toJSON(false)` the
+   * `stack` property will not be included.
+   *
+   * @param {Boolean} include stack
+   * @return {Object} JSON
+   * @alias serialize
+   * @api public
+   */
+
+  ErrorProto.prototype.toJSON =
+  ErrorProto.prototype.serialize = function (stack) {
+    var exclude = extend.exclude('constructor', 'serialize', 'toJSON', 'stack')
+      , props = exclude({ name: this.name }, this);
+
+    if (false !== stack && this.stack) {
+      props.stack = this.stack;
+    }
+
+    return props;
+  };
+
+  // return constructor
+  return ErrorProto;
+};
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/tea/extend.js
+++ b/lib/ace/mode/gherkin/tea/extend.js
@@ -1,0 +1,173 @@
+define(function(require,exports,module){
+
+/*!
+ * tea-extend
+ * Copyright(c) 2012 Jake Luer <jake@qualiancy.com>
+ * MIT Licensed
+ */
+
+/**
+ * ### extend (destination, source, ...)
+ *
+ * For each source, shallow merge its key/values to the
+ * destinatino. Sources are read in order, meaning the same
+ * key in a later source will overwrite the key's value earlier
+ * set.
+ *
+ * ```js
+ * var extend = require('tea-extend');
+ *
+ * // sample objects
+ * var a = { hello: 'universe' }
+ *   , b = { speak: 'loudly' };
+ *
+ * // change a
+ * extend(a, b);
+ * a.should.deep.equal({ hello: 'universe', speak: 'loudly' });
+ *
+ * // shallow clone to c
+ * var c = extend({}, a);
+ * a.language = 'en';
+ *
+ * a.should.deep.equal({ hello: 'universe', speak: 'loudly', language: 'en' });
+ * c.should.deep.equal({ hello: 'universe', speak: 'loudly' });
+ * ```
+ *
+ * @param {Object} destination
+ * @param {Object} sources ...
+ * @return {Object} destination extended
+ * @api public
+ */
+
+var exports = module.exports = function () {
+  var args = [].slice.call(arguments, 0)
+    , i = 1
+    , res = args[0];
+
+  for (; i < args.length; i++) {
+    extend(res, args[i]);
+  }
+
+  return res;
+};
+
+/*!
+ * Actually extend
+ */
+
+function extend (a, b) {
+  if (a && b) {
+    for (var key in b) {
+      a[key] = b[key];
+    }
+  }
+  return a;
+};
+
+/**
+ * ### extend.include (props, ...)
+ *
+ * Create a new object that only includes the properties
+ * specified. Unlike `extend()`, the original objects
+ * will not be modified.
+ *
+ * This method will return a function that can be
+ * reused for the specified properties. Like `extend()`,
+ * this function accepts an unlimited number of objects
+ * as parameters to draw from. Also, the same key in later
+ * specified objects will overwrite earlier specified values.
+ *
+ * ```js
+ * var extend = require('tea-extend')
+ *   , include = extend.include('one', 'two');
+ *
+ * var a = { one: 1, three: 3 }
+ *   , b = { zero: 0, two: 2 };
+ *
+ * var c = include(a, b);
+ *
+ * c.should.deep.equal({ one: 1, two: 2 });
+ * ```
+ *
+ * @param {String} each property to include as an argument
+ * @return {Function} reusable include function
+ * @api public
+ */
+
+exports.include = function () {
+  var includes = [].slice.call(arguments, 0);
+
+  function include (res, obj) {
+    Object.keys(obj).forEach(function (key) {
+      if (~includes.indexOf(key)) res[key] = obj[key];
+    });
+  }
+
+  return function extendInclude () {
+    var args = [].slice.call(arguments, 0)
+      , i = 0
+      , res = {};
+
+    for (; i < args.length; i++) {
+      include(res, args[i]);
+    }
+
+    return res;
+  };
+};
+
+/**
+ * ### extend.exclude (props, ...)
+ *
+ * Create a new object that include all but the properties
+ * specified. Unlike `extend()`, the original objects
+ * will not be modified.
+ *
+ * This method will return a function that can be
+ * reused for the specified properties. Like `extend()`,
+ * this function accepts an unlimited number of objects
+ * as parameters to draw from. Also, the same key in later
+ * specified objects will overwrite earlier specified values.
+ *
+ * ```js
+ * var extend = require('tea-extend')
+ *   , exclude = extend.exclude('one', 'two');
+ *
+ * var a = { one: 1, three: 3 }
+ *   , b = { zero: 0, two: 2 };
+ *
+ * var c = exclude(a, b);
+ *
+ * c.should.deep.equal({ three: 3, zero: 0 });
+ * ```
+ *
+ * @param {String} each property to exclude as an argument
+ * @return {Function} reusable exclude function
+ * @api public
+ */
+
+exports.exclude = function () {
+  var excludes = [].slice.call(arguments, 0);
+
+  function exclude (res, obj) {
+    Object.keys(obj).forEach(function (key) {
+      if (!~excludes.indexOf(key)) res[key] = obj[key];
+    });
+  }
+
+  return function extendExclude () {
+    var args = [].slice.call(arguments, 0)
+      , i = 0
+      , res = {};
+
+    for (; i < args.length; i++) {
+      exclude(res, args[i]);
+    }
+
+    return res;
+  };
+};
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/tea/extend.js
+++ b/lib/ace/mode/gherkin/tea/extend.js
@@ -15,7 +15,7 @@ define(function(require,exports,module){
  * set.
  *
  * ```js
- * var extend = require('tea-extend');
+ * var extend = require('./extend');
  *
  * // sample objects
  * var a = { hello: 'universe' }
@@ -78,7 +78,7 @@ function extend (a, b) {
  * specified objects will overwrite earlier specified values.
  *
  * ```js
- * var extend = require('tea-extend')
+ * var extend = require('./extend')
  *   , include = extend.include('one', 'two');
  *
  * var a = { one: 1, three: 3 }
@@ -130,7 +130,7 @@ exports.include = function () {
  * specified objects will overwrite earlier specified values.
  *
  * ```js
- * var extend = require('tea-extend')
+ * var extend = require('./extend')
  *   , exclude = extend.exclude('one', 'two');
  *
  * var a = { one: 1, three: 3 }

--- a/lib/ace/mode/gherkin/token.js
+++ b/lib/ace/mode/gherkin/token.js
@@ -1,3 +1,26 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 define(function(require,exports,module){
 
 function Token(line, location) {

--- a/lib/ace/mode/gherkin/token.js
+++ b/lib/ace/mode/gherkin/token.js
@@ -1,0 +1,21 @@
+define(function(require,exports,module){
+
+function Token(line, location) {
+  this.line = line;
+  this.location = location;
+  this.isEof = line == null;
+};
+
+Token.prototype.getTokenValue = function () {
+  return this.isEof ? "EOF" : this.line.getLineText(-1);
+};
+
+Token.prototype.detach = function () {
+  // TODO: Detach line, but is this really needed?
+};
+
+module.exports = Token;
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/token_formatter_builder.js
+++ b/lib/ace/mode/gherkin/token_formatter_builder.js
@@ -1,0 +1,38 @@
+define(function(require,exports,module){
+
+module.exports = function TokenFormatterBuilder() {
+  var tokensText = '';
+
+  this.startRule = function(ruleType) {};
+
+  this.endRule = function(ruleType) {};
+
+  this.build = function(token) {
+    tokensText += formatToken(token) + '\n';
+  };
+
+  this.getResult = function() {
+    return tokensText;
+  }
+
+  function formatToken(token) {
+    if(token.isEof) return 'EOF';
+
+    return "(" +
+    token.location.line +
+    ":" +
+    token.location.column +
+    ")" +
+    token.matchedType +
+    ":" +
+    (typeof token.matchedKeyword === 'string' ? token.matchedKeyword : '') +
+    "/" +
+    (typeof token.matchedText === 'string' ? token.matchedText : '') +
+    "/" +
+    token.matchedItems.map(function (i) { return i.column + ':' + i.text; }).join(',');
+  }
+};
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/token_matcher.js
+++ b/lib/ace/mode/gherkin/token_matcher.js
@@ -1,0 +1,2877 @@
+define(function (require, exports, module) {
+
+  // from dialects.json
+  var dialects = {
+    "en": {
+      "name": "English",
+      "native": "English",
+      "feature": [
+        "Feature",
+        "Business Need",
+        "Ability"
+      ],
+      "background": [
+        "Background"
+      ],
+      "scenario": [
+        "Scenario"
+      ],
+      "scenarioOutline": [
+        "Scenario Outline",
+        "Scenario Template"
+      ],
+      "examples": [
+        "Examples",
+        "Scenarios"
+      ],
+      "given": [
+        "* ",
+        "Given "
+      ],
+      "when": [
+        "* ",
+        "When "
+      ],
+      "then": [
+        "* ",
+        "Then "
+      ],
+      "and": [
+        "* ",
+        "And "
+      ],
+      "but": [
+        "* ",
+        "But "
+      ]
+    },
+    "af": {
+      "name": "Afrikaans",
+      "native": "Afrikaans",
+      "feature": [
+        "Funksie",
+        "Besigheid Behoefte",
+        "Vermoë"
+      ],
+      "background": [
+        "Agtergrond"
+      ],
+      "scenario": [
+        "Situasie"
+      ],
+      "scenarioOutline": [
+        "Situasie Uiteensetting"
+      ],
+      "examples": [
+        "Voorbeelde"
+      ],
+      "given": [
+        "* ",
+        "Gegewe "
+      ],
+      "when": [
+        "* ",
+        "Wanneer "
+      ],
+      "then": [
+        "* ",
+        "Dan "
+      ],
+      "and": [
+        "* ",
+        "En "
+      ],
+      "but": [
+        "* ",
+        "Maar "
+      ]
+    },
+    "ar": {
+      "name": "Arabic",
+      "native": "العربية",
+      "feature": [
+        "خاصية"
+      ],
+      "background": [
+        "الخلفية"
+      ],
+      "scenario": [
+        "سيناريو"
+      ],
+      "scenarioOutline": [
+        "سيناريو مخطط"
+      ],
+      "examples": [
+        "امثلة"
+      ],
+      "given": [
+        "* ",
+        "بفرض "
+      ],
+      "when": [
+        "* ",
+        "متى ",
+        "عندما "
+      ],
+      "then": [
+        "* ",
+        "اذاً ",
+        "ثم "
+      ],
+      "and": [
+        "* ",
+        "و "
+      ],
+      "but": [
+        "* ",
+        "لكن "
+      ]
+    },
+    "bm": {
+      "name": "Malay",
+      "native": "Bahasa Melayu",
+      "feature": [
+        "Fungsi"
+      ],
+      "background": [
+        "Latar Belakang"
+      ],
+      "scenario": [
+        "Senario",
+        "Situai",
+        "Keadaan"
+      ],
+      "scenarioOutline": [
+        "Template Senario",
+        "Template Situai",
+        "Template Keadaan",
+        "Menggariskan Senario"
+      ],
+      "examples": [
+        "Contoh"
+      ],
+      "given": [
+        "* ",
+        "Diberi ",
+        "Bagi "
+      ],
+      "when": [
+        "* ",
+        "Apabila "
+      ],
+      "then": [
+        "* ",
+        "Maka ",
+        "Kemudian "
+      ],
+      "and": [
+        "* ",
+        "Dan "
+      ],
+      "but": [
+        "* ",
+        "Tetapi ",
+        "Tapi "
+      ]
+    },
+    "bg": {
+      "name": "Bulgarian",
+      "native": "български",
+      "feature": [
+        "Функционалност"
+      ],
+      "background": [
+        "Предистория"
+      ],
+      "scenario": [
+        "Сценарий"
+      ],
+      "scenarioOutline": [
+        "Рамка на сценарий"
+      ],
+      "examples": [
+        "Примери"
+      ],
+      "given": [
+        "* ",
+        "Дадено "
+      ],
+      "when": [
+        "* ",
+        "Когато "
+      ],
+      "then": [
+        "* ",
+        "То "
+      ],
+      "and": [
+        "* ",
+        "И "
+      ],
+      "but": [
+        "* ",
+        "Но "
+      ]
+    },
+    "ca": {
+      "name": "Catalan",
+      "native": "català",
+      "feature": [
+        "Característica",
+        "Funcionalitat"
+      ],
+      "background": [
+        "Rerefons",
+        "Antecedents"
+      ],
+      "scenario": [
+        "Escenari"
+      ],
+      "scenarioOutline": [
+        "Esquema de l'escenari"
+      ],
+      "examples": [
+        "Exemples"
+      ],
+      "given": [
+        "* ",
+        "Donat ",
+        "Donada ",
+        "Atès ",
+        "Atesa "
+      ],
+      "when": [
+        "* ",
+        "Quan "
+      ],
+      "then": [
+        "* ",
+        "Aleshores ",
+        "Cal "
+      ],
+      "and": [
+        "* ",
+        "I "
+      ],
+      "but": [
+        "* ",
+        "Però "
+      ]
+    },
+    "cy-GB": {
+      "name": "Welsh",
+      "native": "Cymraeg",
+      "feature": [
+        "Arwedd"
+      ],
+      "background": [
+        "Cefndir"
+      ],
+      "scenario": [
+        "Scenario"
+      ],
+      "scenarioOutline": [
+        "Scenario Amlinellol"
+      ],
+      "examples": [
+        "Enghreifftiau"
+      ],
+      "given": [
+        "* ",
+        "Anrhegedig a "
+      ],
+      "when": [
+        "* ",
+        "Pryd "
+      ],
+      "then": [
+        "* ",
+        "Yna "
+      ],
+      "and": [
+        "* ",
+        "A "
+      ],
+      "but": [
+        "* ",
+        "Ond "
+      ]
+    },
+    "cs": {
+      "name": "Czech",
+      "native": "Česky",
+      "feature": [
+        "Požadavek"
+      ],
+      "background": [
+        "Pozadí",
+        "Kontext"
+      ],
+      "scenario": [
+        "Scénář"
+      ],
+      "scenarioOutline": [
+        "Náčrt Scénáře",
+        "Osnova scénáře"
+      ],
+      "examples": [
+        "Příklady"
+      ],
+      "given": [
+        "* ",
+        "Pokud ",
+        "Za předpokladu "
+      ],
+      "when": [
+        "* ",
+        "Když "
+      ],
+      "then": [
+        "* ",
+        "Pak "
+      ],
+      "and": [
+        "* ",
+        "A také ",
+        "A "
+      ],
+      "but": [
+        "* ",
+        "Ale "
+      ]
+    },
+    "da": {
+      "name": "Danish",
+      "native": "dansk",
+      "feature": [
+        "Egenskab"
+      ],
+      "background": [
+        "Baggrund"
+      ],
+      "scenario": [
+        "Scenarie"
+      ],
+      "scenarioOutline": [
+        "Abstrakt Scenario"
+      ],
+      "examples": [
+        "Eksempler"
+      ],
+      "given": [
+        "* ",
+        "Givet "
+      ],
+      "when": [
+        "* ",
+        "Når "
+      ],
+      "then": [
+        "* ",
+        "Så "
+      ],
+      "and": [
+        "* ",
+        "Og "
+      ],
+      "but": [
+        "* ",
+        "Men "
+      ]
+    },
+    "de": {
+      "name": "German",
+      "native": "Deutsch",
+      "feature": [
+        "Funktionalität"
+      ],
+      "background": [
+        "Grundlage"
+      ],
+      "scenario": [
+        "Szenario"
+      ],
+      "scenarioOutline": [
+        "Szenariogrundriss"
+      ],
+      "examples": [
+        "Beispiele"
+      ],
+      "given": [
+        "* ",
+        "Angenommen ",
+        "Gegeben sei ",
+        "Gegeben seien "
+      ],
+      "when": [
+        "* ",
+        "Wenn "
+      ],
+      "then": [
+        "* ",
+        "Dann "
+      ],
+      "and": [
+        "* ",
+        "Und "
+      ],
+      "but": [
+        "* ",
+        "Aber "
+      ]
+    },
+    "el": {
+      "name": "Greek",
+      "native": "Ελληνικά",
+      "feature": [
+        "Δυνατότητα",
+        "Λειτουργία"
+      ],
+      "background": [
+        "Υπόβαθρο"
+      ],
+      "scenario": [
+        "Σενάριο"
+      ],
+      "scenarioOutline": [
+        "Περιγραφή Σεναρίου"
+      ],
+      "examples": [
+        "Παραδείγματα",
+        "Σενάρια"
+      ],
+      "given": [
+        "* ",
+        "Δεδομένου "
+      ],
+      "when": [
+        "* ",
+        "Όταν "
+      ],
+      "then": [
+        "* ",
+        "Τότε "
+      ],
+      "and": [
+        "* ",
+        "Και "
+      ],
+      "but": [
+        "* ",
+        "Αλλά "
+      ]
+    },
+    "en-au": {
+      "name": "Australian",
+      "native": "Australian",
+      "feature": [
+        "Pretty much"
+      ],
+      "background": [
+        "First off"
+      ],
+      "scenario": [
+        "Awww, look mate"
+      ],
+      "scenarioOutline": [
+        "Reckon it's like"
+      ],
+      "examples": [
+        "You'll wanna"
+      ],
+      "given": [
+        "* ",
+        "Y'know "
+      ],
+      "when": [
+        "* ",
+        "It's just unbelievable "
+      ],
+      "then": [
+        "* ",
+        "But at the end of the day I reckon "
+      ],
+      "and": [
+        "* ",
+        "Too right "
+      ],
+      "but": [
+        "* ",
+        "Yeah nah "
+      ]
+    },
+    "en-lol": {
+      "name": "LOLCAT",
+      "native": "LOLCAT",
+      "feature": [
+        "OH HAI"
+      ],
+      "background": [
+        "B4"
+      ],
+      "scenario": [
+        "MISHUN"
+      ],
+      "scenarioOutline": [
+        "MISHUN SRSLY"
+      ],
+      "examples": [
+        "EXAMPLZ"
+      ],
+      "given": [
+        "* ",
+        "I CAN HAZ "
+      ],
+      "when": [
+        "* ",
+        "WEN "
+      ],
+      "then": [
+        "* ",
+        "DEN "
+      ],
+      "and": [
+        "* ",
+        "AN "
+      ],
+      "but": [
+        "* ",
+        "BUT "
+      ]
+    },
+    "en-old": {
+      "name": "Old English",
+      "native": "Englisc",
+      "feature": [
+        "Hwaet",
+        "Hwæt"
+      ],
+      "background": [
+        "Aer",
+        "Ær"
+      ],
+      "scenario": [
+        "Swa"
+      ],
+      "scenarioOutline": [
+        "Swa hwaer swa",
+        "Swa hwær swa"
+      ],
+      "examples": [
+        "Se the",
+        "Se þe",
+        "Se ðe"
+      ],
+      "given": [
+        "* ",
+        "Thurh ",
+        "Þurh ",
+        "Ðurh "
+      ],
+      "when": [
+        "* ",
+        "Tha ",
+        "Þa ",
+        "Ða "
+      ],
+      "then": [
+        "* ",
+        "Tha ",
+        "Þa ",
+        "Ða ",
+        "Tha the ",
+        "Þa þe ",
+        "Ða ðe "
+      ],
+      "and": [
+        "* ",
+        "Ond ",
+        "7 "
+      ],
+      "but": [
+        "* ",
+        "Ac "
+      ]
+    },
+    "en-pirate": {
+      "name": "Pirate",
+      "native": "Pirate",
+      "feature": [
+        "Ahoy matey!"
+      ],
+      "background": [
+        "Yo-ho-ho"
+      ],
+      "scenario": [
+        "Heave to"
+      ],
+      "scenarioOutline": [
+        "Shiver me timbers"
+      ],
+      "examples": [
+        "Dead men tell no tales"
+      ],
+      "given": [
+        "* ",
+        "Gangway! "
+      ],
+      "when": [
+        "* ",
+        "Blimey! "
+      ],
+      "then": [
+        "* ",
+        "Let go and haul "
+      ],
+      "and": [
+        "* ",
+        "Aye "
+      ],
+      "but": [
+        "* ",
+        "Avast! "
+      ]
+    },
+    "en-Scouse": {
+      "name": "Scouse",
+      "native": "Scouse",
+      "feature": [
+        "Feature"
+      ],
+      "background": [
+        "Dis is what went down"
+      ],
+      "scenario": [
+        "The thing of it is"
+      ],
+      "scenarioOutline": [
+        "Wharrimean is"
+      ],
+      "examples": [
+        "Examples"
+      ],
+      "given": [
+        "* ",
+        "Givun ",
+        "Youse know when youse got "
+      ],
+      "when": [
+        "* ",
+        "Wun ",
+        "Youse know like when "
+      ],
+      "then": [
+        "* ",
+        "Dun ",
+        "Den youse gotta "
+      ],
+      "and": [
+        "* ",
+        "An "
+      ],
+      "but": [
+        "* ",
+        "Buh "
+      ]
+    },
+    "en-tx": {
+      "name": "Texan",
+      "native": "Texan",
+      "feature": [
+        "Feature"
+      ],
+      "background": [
+        "Background"
+      ],
+      "scenario": [
+        "Scenario"
+      ],
+      "scenarioOutline": [
+        "All y'all"
+      ],
+      "examples": [
+        "Examples"
+      ],
+      "given": [
+        "* ",
+        "Given y'all "
+      ],
+      "when": [
+        "* ",
+        "When y'all "
+      ],
+      "then": [
+        "* ",
+        "Then y'all "
+      ],
+      "and": [
+        "* ",
+        "And y'all "
+      ],
+      "but": [
+        "* ",
+        "But y'all "
+      ]
+    },
+    "eo": {
+      "name": "Esperanto",
+      "native": "Esperanto",
+      "feature": [
+        "Trajto"
+      ],
+      "background": [
+        "Fono"
+      ],
+      "scenario": [
+        "Scenaro"
+      ],
+      "scenarioOutline": [
+        "Konturo de la scenaro"
+      ],
+      "examples": [
+        "Ekzemploj"
+      ],
+      "given": [
+        "* ",
+        "Donitaĵo "
+      ],
+      "when": [
+        "* ",
+        "Se "
+      ],
+      "then": [
+        "* ",
+        "Do "
+      ],
+      "and": [
+        "* ",
+        "Kaj "
+      ],
+      "but": [
+        "* ",
+        "Sed "
+      ]
+    },
+    "es": {
+      "name": "Spanish",
+      "native": "español",
+      "feature": [
+        "Característica"
+      ],
+      "background": [
+        "Antecedentes"
+      ],
+      "scenario": [
+        "Escenario"
+      ],
+      "scenarioOutline": [
+        "Esquema del escenario"
+      ],
+      "examples": [
+        "Ejemplos"
+      ],
+      "given": [
+        "* ",
+        "Dado ",
+        "Dada ",
+        "Dados ",
+        "Dadas "
+      ],
+      "when": [
+        "* ",
+        "Cuando "
+      ],
+      "then": [
+        "* ",
+        "Entonces "
+      ],
+      "and": [
+        "* ",
+        "Y "
+      ],
+      "but": [
+        "* ",
+        "Pero "
+      ]
+    },
+    "et": {
+      "name": "Estonian",
+      "native": "eesti keel",
+      "feature": [
+        "Omadus"
+      ],
+      "background": [
+        "Taust"
+      ],
+      "scenario": [
+        "Stsenaarium"
+      ],
+      "scenarioOutline": [
+        "Raamstsenaarium"
+      ],
+      "examples": [
+        "Juhtumid"
+      ],
+      "given": [
+        "* ",
+        "Eeldades "
+      ],
+      "when": [
+        "* ",
+        "Kui "
+      ],
+      "then": [
+        "* ",
+        "Siis "
+      ],
+      "and": [
+        "* ",
+        "Ja "
+      ],
+      "but": [
+        "* ",
+        "Kuid "
+      ]
+    },
+    "fa": {
+      "name": "Persian",
+      "native": "فارسی",
+      "feature": [
+        "وِیژگی"
+      ],
+      "background": [
+        "زمینه"
+      ],
+      "scenario": [
+        "سناریو"
+      ],
+      "scenarioOutline": [
+        "الگوی سناریو"
+      ],
+      "examples": [
+        "نمونه ها"
+      ],
+      "given": [
+        "* ",
+        "با فرض "
+      ],
+      "when": [
+        "* ",
+        "هنگامی "
+      ],
+      "then": [
+        "* ",
+        "آنگاه "
+      ],
+      "and": [
+        "* ",
+        "و "
+      ],
+      "but": [
+        "* ",
+        "اما "
+      ]
+    },
+    "fi": {
+      "name": "Finnish",
+      "native": "suomi",
+      "feature": [
+        "Ominaisuus"
+      ],
+      "background": [
+        "Tausta"
+      ],
+      "scenario": [
+        "Tapaus"
+      ],
+      "scenarioOutline": [
+        "Tapausaihio"
+      ],
+      "examples": [
+        "Tapaukset"
+      ],
+      "given": [
+        "* ",
+        "Oletetaan "
+      ],
+      "when": [
+        "* ",
+        "Kun "
+      ],
+      "then": [
+        "* ",
+        "Niin "
+      ],
+      "and": [
+        "* ",
+        "Ja "
+      ],
+      "but": [
+        "* ",
+        "Mutta "
+      ]
+    },
+    "fr": {
+      "name": "French",
+      "native": "français",
+      "feature": [
+        "Fonctionnalité"
+      ],
+      "background": [
+        "Contexte"
+      ],
+      "scenario": [
+        "Scénario"
+      ],
+      "scenarioOutline": [
+        "Plan du scénario",
+        "Plan du Scénario"
+      ],
+      "examples": [
+        "Exemples"
+      ],
+      "given": [
+        "* ",
+        "Soit ",
+        "Etant donné ",
+        "Etant donnée ",
+        "Etant donnés ",
+        "Etant données ",
+        "Étant donné ",
+        "Étant donnée ",
+        "Étant donnés ",
+        "Étant données "
+      ],
+      "when": [
+        "* ",
+        "Quand ",
+        "Lorsque ",
+        "Lorsqu'"
+      ],
+      "then": [
+        "* ",
+        "Alors "
+      ],
+      "and": [
+        "* ",
+        "Et "
+      ],
+      "but": [
+        "* ",
+        "Mais "
+      ]
+    },
+    "gl": {
+      "name": "Galician",
+      "native": "galego",
+      "feature": [
+        "Característica"
+      ],
+      "background": [
+        "Contexto"
+      ],
+      "scenario": [
+        "Escenario"
+      ],
+      "scenarioOutline": [
+        "Esbozo do escenario"
+      ],
+      "examples": [
+        "Exemplos"
+      ],
+      "given": [
+        "* ",
+        "Dado ",
+        "Dada ",
+        "Dados ",
+        "Dadas "
+      ],
+      "when": [
+        "* ",
+        "Cando "
+      ],
+      "then": [
+        "* ",
+        "Entón ",
+        "Logo "
+      ],
+      "and": [
+        "* ",
+        "E "
+      ],
+      "but": [
+        "* ",
+        "Mais ",
+        "Pero "
+      ]
+    },
+    "he": {
+      "name": "Hebrew",
+      "native": "עברית",
+      "feature": [
+        "תכונה"
+      ],
+      "background": [
+        "רקע"
+      ],
+      "scenario": [
+        "תרחיש"
+      ],
+      "scenarioOutline": [
+        "תבנית תרחיש"
+      ],
+      "examples": [
+        "דוגמאות"
+      ],
+      "given": [
+        "* ",
+        "בהינתן "
+      ],
+      "when": [
+        "* ",
+        "כאשר "
+      ],
+      "then": [
+        "* ",
+        "אז ",
+        "אזי "
+      ],
+      "and": [
+        "* ",
+        "וגם "
+      ],
+      "but": [
+        "* ",
+        "אבל "
+      ]
+    },
+    "hi": {
+      "name": "Hindi",
+      "native": "हिंदी",
+      "feature": [
+        "रूप लेख"
+      ],
+      "background": [
+        "पृष्ठभूमि"
+      ],
+      "scenario": [
+        "परिदृश्य"
+      ],
+      "scenarioOutline": [
+        "परिदृश्य रूपरेखा"
+      ],
+      "examples": [
+        "उदाहरण"
+      ],
+      "given": [
+        "* ",
+        "अगर ",
+        "यदि ",
+        "चूंकि "
+      ],
+      "when": [
+        "* ",
+        "जब ",
+        "कदा "
+      ],
+      "then": [
+        "* ",
+        "तब ",
+        "तदा "
+      ],
+      "and": [
+        "* ",
+        "और ",
+        "तथा "
+      ],
+      "but": [
+        "* ",
+        "पर ",
+        "परन्तु ",
+        "किन्तु "
+      ]
+    },
+    "hr": {
+      "name": "Croatian",
+      "native": "hrvatski",
+      "feature": [
+        "Osobina",
+        "Mogućnost",
+        "Mogucnost"
+      ],
+      "background": [
+        "Pozadina"
+      ],
+      "scenario": [
+        "Scenarij"
+      ],
+      "scenarioOutline": [
+        "Skica",
+        "Koncept"
+      ],
+      "examples": [
+        "Primjeri",
+        "Scenariji"
+      ],
+      "given": [
+        "* ",
+        "Zadan ",
+        "Zadani ",
+        "Zadano "
+      ],
+      "when": [
+        "* ",
+        "Kada ",
+        "Kad "
+      ],
+      "then": [
+        "* ",
+        "Onda "
+      ],
+      "and": [
+        "* ",
+        "I "
+      ],
+      "but": [
+        "* ",
+        "Ali "
+      ]
+    },
+    "ht": {
+      "name": "Creole",
+      "native": "kreyòl",
+      "feature": [
+        "Karakteristik",
+        "Mak",
+        "Fonksyonalite"
+      ],
+      "background": [
+        "Kontèks",
+        "Istorik"
+      ],
+      "scenario": [
+        "Senaryo"
+      ],
+      "scenarioOutline": [
+        "Plan senaryo",
+        "Plan Senaryo",
+        "Senaryo deskripsyon",
+        "Senaryo Deskripsyon",
+        "Dyagram senaryo",
+        "Dyagram Senaryo"
+      ],
+      "examples": [
+        "Egzanp"
+      ],
+      "given": [
+        "* ",
+        "Sipoze ",
+        "Sipoze ke ",
+        "Sipoze Ke "
+      ],
+      "when": [
+        "* ",
+        "Lè ",
+        "Le "
+      ],
+      "then": [
+        "* ",
+        "Lè sa a ",
+        "Le sa a "
+      ],
+      "and": [
+        "* ",
+        "Ak ",
+        "Epi ",
+        "E "
+      ],
+      "but": [
+        "* ",
+        "Men "
+      ]
+    },
+    "hu": {
+      "name": "Hungarian",
+      "native": "magyar",
+      "feature": [
+        "Jellemző"
+      ],
+      "background": [
+        "Háttér"
+      ],
+      "scenario": [
+        "Forgatókönyv"
+      ],
+      "scenarioOutline": [
+        "Forgatókönyv vázlat"
+      ],
+      "examples": [
+        "Példák"
+      ],
+      "given": [
+        "* ",
+        "Amennyiben ",
+        "Adott "
+      ],
+      "when": [
+        "* ",
+        "Majd ",
+        "Ha ",
+        "Amikor "
+      ],
+      "then": [
+        "* ",
+        "Akkor "
+      ],
+      "and": [
+        "* ",
+        "És "
+      ],
+      "but": [
+        "* ",
+        "De "
+      ]
+    },
+    "id": {
+      "name": "Indonesian",
+      "native": "Bahasa Indonesia",
+      "feature": [
+        "Fitur"
+      ],
+      "background": [
+        "Dasar"
+      ],
+      "scenario": [
+        "Skenario"
+      ],
+      "scenarioOutline": [
+        "Skenario konsep"
+      ],
+      "examples": [
+        "Contoh"
+      ],
+      "given": [
+        "* ",
+        "Dengan "
+      ],
+      "when": [
+        "* ",
+        "Ketika "
+      ],
+      "then": [
+        "* ",
+        "Maka "
+      ],
+      "and": [
+        "* ",
+        "Dan "
+      ],
+      "but": [
+        "* ",
+        "Tapi "
+      ]
+    },
+    "is": {
+      "name": "Icelandic",
+      "native": "Íslenska",
+      "feature": [
+        "Eiginleiki"
+      ],
+      "background": [
+        "Bakgrunnur"
+      ],
+      "scenario": [
+        "Atburðarás"
+      ],
+      "scenarioOutline": [
+        "Lýsing Atburðarásar",
+        "Lýsing Dæma"
+      ],
+      "examples": [
+        "Dæmi",
+        "Atburðarásir"
+      ],
+      "given": [
+        "* ",
+        "Ef "
+      ],
+      "when": [
+        "* ",
+        "Þegar "
+      ],
+      "then": [
+        "* ",
+        "Þá "
+      ],
+      "and": [
+        "* ",
+        "Og "
+      ],
+      "but": [
+        "* ",
+        "En "
+      ]
+    },
+    "it": {
+      "name": "Italian",
+      "native": "italiano",
+      "feature": [
+        "Funzionalità"
+      ],
+      "background": [
+        "Contesto"
+      ],
+      "scenario": [
+        "Scenario"
+      ],
+      "scenarioOutline": [
+        "Schema dello scenario"
+      ],
+      "examples": [
+        "Esempi"
+      ],
+      "given": [
+        "* ",
+        "Dato ",
+        "Data ",
+        "Dati ",
+        "Date "
+      ],
+      "when": [
+        "* ",
+        "Quando "
+      ],
+      "then": [
+        "* ",
+        "Allora "
+      ],
+      "and": [
+        "* ",
+        "E "
+      ],
+      "but": [
+        "* ",
+        "Ma "
+      ]
+    },
+    "ja": {
+      "name": "Japanese",
+      "native": "日本語",
+      "feature": [
+        "フィーチャ",
+        "機能"
+      ],
+      "background": [
+        "背景"
+      ],
+      "scenario": [
+        "シナリオ"
+      ],
+      "scenarioOutline": [
+        "シナリオアウトライン",
+        "シナリオテンプレート",
+        "テンプレ",
+        "シナリオテンプレ"
+      ],
+      "examples": [
+        "例",
+        "サンプル"
+      ],
+      "given": [
+        "* ",
+        "前提"
+      ],
+      "when": [
+        "* ",
+        "もし"
+      ],
+      "then": [
+        "* ",
+        "ならば"
+      ],
+      "and": [
+        "* ",
+        "かつ"
+      ],
+      "but": [
+        "* ",
+        "しかし",
+        "但し",
+        "ただし"
+      ]
+    },
+    "jv": {
+      "name": "Javanese",
+      "native": "Basa Jawa",
+      "feature": [
+        "Fitur"
+      ],
+      "background": [
+        "Dasar"
+      ],
+      "scenario": [
+        "Skenario"
+      ],
+      "scenarioOutline": [
+        "Konsep skenario"
+      ],
+      "examples": [
+        "Conto",
+        "Contone"
+      ],
+      "given": [
+        "* ",
+        "Nalika ",
+        "Nalikaning "
+      ],
+      "when": [
+        "* ",
+        "Manawa ",
+        "Menawa "
+      ],
+      "then": [
+        "* ",
+        "Njuk ",
+        "Banjur "
+      ],
+      "and": [
+        "* ",
+        "Lan "
+      ],
+      "but": [
+        "* ",
+        "Tapi ",
+        "Nanging ",
+        "Ananging "
+      ]
+    },
+    "kn": {
+      "name": "Kannada",
+      "native": "ಕನ್ನಡ",
+      "feature": [
+        "ಹೆಚ್ಚಳ"
+      ],
+      "background": [
+        "ಹಿನ್ನೆಲೆ"
+      ],
+      "scenario": [
+        "ಕಥಾಸಾರಾಂಶ"
+      ],
+      "scenarioOutline": [
+        "ವಿವರಣೆ"
+      ],
+      "examples": [
+        "ಉದಾಹರಣೆಗಳು"
+      ],
+      "given": [
+        "* ",
+        "ನೀಡಿದ "
+      ],
+      "when": [
+        "* ",
+        "ಸ್ಥಿತಿಯನ್ನು "
+      ],
+      "then": [
+        "* ",
+        "ನಂತರ "
+      ],
+      "and": [
+        "* ",
+        "ಮತ್ತು "
+      ],
+      "but": [
+        "* ",
+        "ಆದರೆ "
+      ]
+    },
+    "ko": {
+      "name": "Korean",
+      "native": "한국어",
+      "feature": [
+        "기능"
+      ],
+      "background": [
+        "배경"
+      ],
+      "scenario": [
+        "시나리오"
+      ],
+      "scenarioOutline": [
+        "시나리오 개요"
+      ],
+      "examples": [
+        "예"
+      ],
+      "given": [
+        "* ",
+        "조건",
+        "먼저"
+      ],
+      "when": [
+        "* ",
+        "만일",
+        "만약"
+      ],
+      "then": [
+        "* ",
+        "그러면"
+      ],
+      "and": [
+        "* ",
+        "그리고"
+      ],
+      "but": [
+        "* ",
+        "하지만",
+        "단"
+      ]
+    },
+    "lt": {
+      "name": "Lithuanian",
+      "native": "lietuvių kalba",
+      "feature": [
+        "Savybė"
+      ],
+      "background": [
+        "Kontekstas"
+      ],
+      "scenario": [
+        "Scenarijus"
+      ],
+      "scenarioOutline": [
+        "Scenarijaus šablonas"
+      ],
+      "examples": [
+        "Pavyzdžiai",
+        "Scenarijai",
+        "Variantai"
+      ],
+      "given": [
+        "* ",
+        "Duota "
+      ],
+      "when": [
+        "* ",
+        "Kai "
+      ],
+      "then": [
+        "* ",
+        "Tada "
+      ],
+      "and": [
+        "* ",
+        "Ir "
+      ],
+      "but": [
+        "* ",
+        "Bet "
+      ]
+    },
+    "lu": {
+      "name": "Luxemburgish",
+      "native": "Lëtzebuergesch",
+      "feature": [
+        "Funktionalitéit"
+      ],
+      "background": [
+        "Hannergrond"
+      ],
+      "scenario": [
+        "Szenario"
+      ],
+      "scenarioOutline": [
+        "Plang vum Szenario"
+      ],
+      "examples": [
+        "Beispiller"
+      ],
+      "given": [
+        "* ",
+        "ugeholl "
+      ],
+      "when": [
+        "* ",
+        "wann "
+      ],
+      "then": [
+        "* ",
+        "dann "
+      ],
+      "and": [
+        "* ",
+        "an ",
+        "a "
+      ],
+      "but": [
+        "* ",
+        "awer ",
+        "mä "
+      ]
+    },
+    "lv": {
+      "name": "Latvian",
+      "native": "latviešu",
+      "feature": [
+        "Funkcionalitāte",
+        "Fīča"
+      ],
+      "background": [
+        "Konteksts",
+        "Situācija"
+      ],
+      "scenario": [
+        "Scenārijs"
+      ],
+      "scenarioOutline": [
+        "Scenārijs pēc parauga"
+      ],
+      "examples": [
+        "Piemēri",
+        "Paraugs"
+      ],
+      "given": [
+        "* ",
+        "Kad "
+      ],
+      "when": [
+        "* ",
+        "Ja "
+      ],
+      "then": [
+        "* ",
+        "Tad "
+      ],
+      "and": [
+        "* ",
+        "Un "
+      ],
+      "but": [
+        "* ",
+        "Bet "
+      ]
+    },
+    "nl": {
+      "name": "Dutch",
+      "native": "Nederlands",
+      "feature": [
+        "Functionaliteit"
+      ],
+      "background": [
+        "Achtergrond"
+      ],
+      "scenario": [
+        "Scenario"
+      ],
+      "scenarioOutline": [
+        "Abstract Scenario"
+      ],
+      "examples": [
+        "Voorbeelden"
+      ],
+      "given": [
+        "* ",
+        "Gegeven ",
+        "Stel "
+      ],
+      "when": [
+        "* ",
+        "Als "
+      ],
+      "then": [
+        "* ",
+        "Dan "
+      ],
+      "and": [
+        "* ",
+        "En "
+      ],
+      "but": [
+        "* ",
+        "Maar "
+      ]
+    },
+    "no": {
+      "name": "Norwegian",
+      "native": "norsk",
+      "feature": [
+        "Egenskap"
+      ],
+      "background": [
+        "Bakgrunn"
+      ],
+      "scenario": [
+        "Scenario"
+      ],
+      "scenarioOutline": [
+        "Scenariomal",
+        "Abstrakt Scenario"
+      ],
+      "examples": [
+        "Eksempler"
+      ],
+      "given": [
+        "* ",
+        "Gitt "
+      ],
+      "when": [
+        "* ",
+        "Når "
+      ],
+      "then": [
+        "* ",
+        "Så "
+      ],
+      "and": [
+        "* ",
+        "Og "
+      ],
+      "but": [
+        "* ",
+        "Men "
+      ]
+    },
+    "pa": {
+      "name": "Panjabi",
+      "native": "ਪੰਜਾਬੀ",
+      "feature": [
+        "ਖਾਸੀਅਤ",
+        "ਮੁਹਾਂਦਰਾ",
+        "ਨਕਸ਼ ਨੁਹਾਰ"
+      ],
+      "background": [
+        "ਪਿਛੋਕੜ"
+      ],
+      "scenario": [
+        "ਪਟਕਥਾ"
+      ],
+      "scenarioOutline": [
+        "ਪਟਕਥਾ ਢਾਂਚਾ",
+        "ਪਟਕਥਾ ਰੂਪ ਰੇਖਾ"
+      ],
+      "examples": [
+        "ਉਦਾਹਰਨਾਂ"
+      ],
+      "given": [
+        "* ",
+        "ਜੇਕਰ ",
+        "ਜਿਵੇਂ ਕਿ "
+      ],
+      "when": [
+        "* ",
+        "ਜਦੋਂ "
+      ],
+      "then": [
+        "* ",
+        "ਤਦ "
+      ],
+      "and": [
+        "* ",
+        "ਅਤੇ "
+      ],
+      "but": [
+        "* ",
+        "ਪਰ "
+      ]
+    },
+    "pl": {
+      "name": "Polish",
+      "native": "polski",
+      "feature": [
+        "Właściwość",
+        "Funkcja",
+        "Aspekt",
+        "Potrzeba biznesowa"
+      ],
+      "background": [
+        "Założenia"
+      ],
+      "scenario": [
+        "Scenariusz"
+      ],
+      "scenarioOutline": [
+        "Szablon scenariusza"
+      ],
+      "examples": [
+        "Przykłady"
+      ],
+      "given": [
+        "* ",
+        "Zakładając ",
+        "Mając "
+      ],
+      "when": [
+        "* ",
+        "Jeżeli ",
+        "Jeśli ",
+        "Gdy ",
+        "Kiedy "
+      ],
+      "then": [
+        "* ",
+        "Wtedy "
+      ],
+      "and": [
+        "* ",
+        "Oraz ",
+        "I "
+      ],
+      "but": [
+        "* ",
+        "Ale "
+      ]
+    },
+    "pt": {
+      "name": "Portuguese",
+      "native": "português",
+      "feature": [
+        "Funcionalidade",
+        "Característica",
+        "Caracteristica"
+      ],
+      "background": [
+        "Contexto",
+        "Cenário de Fundo",
+        "Cenario de Fundo",
+        "Fundo"
+      ],
+      "scenario": [
+        "Cenário",
+        "Cenario"
+      ],
+      "scenarioOutline": [
+        "Esquema do Cenário",
+        "Esquema do Cenario",
+        "Delineação do Cenário",
+        "Delineacao do Cenario"
+      ],
+      "examples": [
+        "Exemplos",
+        "Cenários",
+        "Cenarios"
+      ],
+      "given": [
+        "* ",
+        "Dado ",
+        "Dada ",
+        "Dados ",
+        "Dadas "
+      ],
+      "when": [
+        "* ",
+        "Quando "
+      ],
+      "then": [
+        "* ",
+        "Então ",
+        "Entao "
+      ],
+      "and": [
+        "* ",
+        "E "
+      ],
+      "but": [
+        "* ",
+        "Mas "
+      ]
+    },
+    "ro": {
+      "name": "Romanian",
+      "native": "română",
+      "feature": [
+        "Functionalitate",
+        "Funcționalitate",
+        "Funcţionalitate"
+      ],
+      "background": [
+        "Context"
+      ],
+      "scenario": [
+        "Scenariu"
+      ],
+      "scenarioOutline": [
+        "Structura scenariu",
+        "Structură scenariu"
+      ],
+      "examples": [
+        "Exemple"
+      ],
+      "given": [
+        "* ",
+        "Date fiind ",
+        "Dat fiind ",
+        "Dati fiind ",
+        "Dați fiind ",
+        "Daţi fiind "
+      ],
+      "when": [
+        "* ",
+        "Cand ",
+        "Când "
+      ],
+      "then": [
+        "* ",
+        "Atunci "
+      ],
+      "and": [
+        "* ",
+        "Si ",
+        "Și ",
+        "Şi "
+      ],
+      "but": [
+        "* ",
+        "Dar "
+      ]
+    },
+    "ru": {
+      "name": "Russian",
+      "native": "русский",
+      "feature": [
+        "Функция",
+        "Функционал",
+        "Свойство"
+      ],
+      "background": [
+        "Предыстория",
+        "Контекст"
+      ],
+      "scenario": [
+        "Сценарий"
+      ],
+      "scenarioOutline": [
+        "Структура сценария"
+      ],
+      "examples": [
+        "Примеры"
+      ],
+      "given": [
+        "* ",
+        "Допустим ",
+        "Дано ",
+        "Пусть "
+      ],
+      "when": [
+        "* ",
+        "Если ",
+        "Когда "
+      ],
+      "then": [
+        "* ",
+        "То ",
+        "Тогда "
+      ],
+      "and": [
+        "* ",
+        "И ",
+        "К тому же ",
+        "Также "
+      ],
+      "but": [
+        "* ",
+        "Но ",
+        "А "
+      ]
+    },
+    "sv": {
+      "name": "Swedish",
+      "native": "Svenska",
+      "feature": [
+        "Egenskap"
+      ],
+      "background": [
+        "Bakgrund"
+      ],
+      "scenario": [
+        "Scenario"
+      ],
+      "scenarioOutline": [
+        "Abstrakt Scenario",
+        "Scenariomall"
+      ],
+      "examples": [
+        "Exempel"
+      ],
+      "given": [
+        "* ",
+        "Givet "
+      ],
+      "when": [
+        "* ",
+        "När "
+      ],
+      "then": [
+        "* ",
+        "Så "
+      ],
+      "and": [
+        "* ",
+        "Och "
+      ],
+      "but": [
+        "* ",
+        "Men "
+      ]
+    },
+    "sk": {
+      "name": "Slovak",
+      "native": "Slovensky",
+      "feature": [
+        "Požiadavka",
+        "Funkcia",
+        "Vlastnosť"
+      ],
+      "background": [
+        "Pozadie"
+      ],
+      "scenario": [
+        "Scenár"
+      ],
+      "scenarioOutline": [
+        "Náčrt Scenáru",
+        "Náčrt Scenára",
+        "Osnova Scenára"
+      ],
+      "examples": [
+        "Príklady"
+      ],
+      "given": [
+        "* ",
+        "Pokiaľ ",
+        "Za predpokladu "
+      ],
+      "when": [
+        "* ",
+        "Keď ",
+        "Ak "
+      ],
+      "then": [
+        "* ",
+        "Tak ",
+        "Potom "
+      ],
+      "and": [
+        "* ",
+        "A ",
+        "A tiež ",
+        "A taktiež ",
+        "A zároveň "
+      ],
+      "but": [
+        "* ",
+        "Ale "
+      ]
+    },
+    "sl": {
+      "name": "Slovenian",
+      "native": "Slovenski",
+      "feature": [
+        "Funkcionalnost",
+        "Funkcija",
+        "Možnosti",
+        "Moznosti",
+        "Lastnost",
+        "Značilnost"
+      ],
+      "background": [
+        "Kontekst",
+        "Osnova",
+        "Ozadje"
+      ],
+      "scenario": [
+        "Scenarij",
+        "Primer"
+      ],
+      "scenarioOutline": [
+        "Struktura scenarija",
+        "Skica",
+        "Koncept",
+        "Oris scenarija",
+        "Osnutek"
+      ],
+      "examples": [
+        "Primeri",
+        "Scenariji"
+      ],
+      "given": [
+        "Dano ",
+        "Podano ",
+        "Zaradi ",
+        "Privzeto "
+      ],
+      "when": [
+        "Ko ",
+        "Ce ",
+        "Če ",
+        "Kadar "
+      ],
+      "then": [
+        "Nato ",
+        "Potem ",
+        "Takrat "
+      ],
+      "and": [
+        "In ",
+        "Ter "
+      ],
+      "but": [
+        "Toda ",
+        "Ampak ",
+        "Vendar "
+      ]
+    },
+    "sr-Latn": {
+      "name": "Serbian (Latin)",
+      "native": "Srpski (Latinica)",
+      "feature": [
+        "Funkcionalnost",
+        "Mogućnost",
+        "Mogucnost",
+        "Osobina"
+      ],
+      "background": [
+        "Kontekst",
+        "Osnova",
+        "Pozadina"
+      ],
+      "scenario": [
+        "Scenario",
+        "Primer"
+      ],
+      "scenarioOutline": [
+        "Struktura scenarija",
+        "Skica",
+        "Koncept"
+      ],
+      "examples": [
+        "Primeri",
+        "Scenariji"
+      ],
+      "given": [
+        "* ",
+        "Zadato ",
+        "Zadate ",
+        "Zatati "
+      ],
+      "when": [
+        "* ",
+        "Kada ",
+        "Kad "
+      ],
+      "then": [
+        "* ",
+        "Onda "
+      ],
+      "and": [
+        "* ",
+        "I "
+      ],
+      "but": [
+        "* ",
+        "Ali "
+      ]
+    },
+    "sr-Cyrl": {
+      "name": "Serbian",
+      "native": "Српски",
+      "feature": [
+        "Функционалност",
+        "Могућност",
+        "Особина"
+      ],
+      "background": [
+        "Контекст",
+        "Основа",
+        "Позадина"
+      ],
+      "scenario": [
+        "Сценарио",
+        "Пример"
+      ],
+      "scenarioOutline": [
+        "Структура сценарија",
+        "Скица",
+        "Концепт"
+      ],
+      "examples": [
+        "Примери",
+        "Сценарији"
+      ],
+      "given": [
+        "* ",
+        "Задато ",
+        "Задате ",
+        "Задати "
+      ],
+      "when": [
+        "* ",
+        "Када ",
+        "Кад "
+      ],
+      "then": [
+        "* ",
+        "Онда "
+      ],
+      "and": [
+        "* ",
+        "И "
+      ],
+      "but": [
+        "* ",
+        "Али "
+      ]
+    },
+    "tl": {
+      "name": "Telugu",
+      "native": "తెలుగు",
+      "feature": [
+        "గుణము"
+      ],
+      "background": [
+        "నేపథ్యం"
+      ],
+      "scenario": [
+        "సన్నివేశం"
+      ],
+      "scenarioOutline": [
+        "కథనం"
+      ],
+      "examples": [
+        "ఉదాహరణలు"
+      ],
+      "given": [
+        "* ",
+        "చెప్పబడినది "
+      ],
+      "when": [
+        "* ",
+        "ఈ పరిస్థితిలో "
+      ],
+      "then": [
+        "* ",
+        "అప్పుడు "
+      ],
+      "and": [
+        "* ",
+        "మరియు "
+      ],
+      "but": [
+        "* ",
+        "కాని "
+      ]
+    },
+    "th": {
+      "name": "Thai",
+      "native": "ไทย",
+      "feature": [
+        "โครงหลัก",
+        "ความต้องการทางธุรกิจ",
+        "ความสามารถ"
+      ],
+      "background": [
+        "แนวคิด"
+      ],
+      "scenario": [
+        "เหตุการณ์"
+      ],
+      "scenarioOutline": [
+        "สรุปเหตุการณ์",
+        "โครงสร้างของเหตุการณ์"
+      ],
+      "examples": [
+        "ชุดของตัวอย่าง",
+        "ชุดของเหตุการณ์"
+      ],
+      "given": [
+        "* ",
+        "กำหนดให้ "
+      ],
+      "when": [
+        "* ",
+        "เมื่อ "
+      ],
+      "then": [
+        "* ",
+        "ดังนั้น "
+      ],
+      "and": [
+        "* ",
+        "และ "
+      ],
+      "but": [
+        "* ",
+        "แต่ "
+      ]
+    },
+    "tlh": {
+      "name": "Klingon",
+      "native": "tlhIngan",
+      "feature": [
+        "Qap",
+        "Qu'meH 'ut",
+        "perbogh",
+        "poQbogh malja'",
+        "laH"
+      ],
+      "background": [
+        "mo'"
+      ],
+      "scenario": [
+        "lut"
+      ],
+      "scenarioOutline": [
+        "lut chovnatlh"
+      ],
+      "examples": [
+        "ghantoH",
+        "lutmey"
+      ],
+      "given": [
+        "* ",
+        "ghu' noblu' ",
+        "DaH ghu' bejlu' "
+      ],
+      "when": [
+        "* ",
+        "qaSDI' "
+      ],
+      "then": [
+        "* ",
+        "vaj "
+      ],
+      "and": [
+        "* ",
+        "'ej ",
+        "latlh "
+      ],
+      "but": [
+        "* ",
+        "'ach ",
+        "'a "
+      ]
+    },
+    "tr": {
+      "name": "Turkish",
+      "native": "Türkçe",
+      "feature": [
+        "Özellik"
+      ],
+      "background": [
+        "Geçmiş"
+      ],
+      "scenario": [
+        "Senaryo"
+      ],
+      "scenarioOutline": [
+        "Senaryo taslağı"
+      ],
+      "examples": [
+        "Örnekler"
+      ],
+      "given": [
+        "* ",
+        "Diyelim ki "
+      ],
+      "when": [
+        "* ",
+        "Eğer ki "
+      ],
+      "then": [
+        "* ",
+        "O zaman "
+      ],
+      "and": [
+        "* ",
+        "Ve "
+      ],
+      "but": [
+        "* ",
+        "Fakat ",
+        "Ama "
+      ]
+    },
+    "tt": {
+      "name": "Tatar",
+      "native": "Татарча",
+      "feature": [
+        "Мөмкинлек",
+        "Үзенчәлеклелек"
+      ],
+      "background": [
+        "Кереш"
+      ],
+      "scenario": [
+        "Сценарий"
+      ],
+      "scenarioOutline": [
+        "Сценарийның төзелеше"
+      ],
+      "examples": [
+        "Үрнәкләр",
+        "Мисаллар"
+      ],
+      "given": [
+        "* ",
+        "Әйтик "
+      ],
+      "when": [
+        "* ",
+        "Әгәр "
+      ],
+      "then": [
+        "* ",
+        "Нәтиҗәдә "
+      ],
+      "and": [
+        "* ",
+        "Һәм ",
+        "Вә "
+      ],
+      "but": [
+        "* ",
+        "Ләкин ",
+        "Әмма "
+      ]
+    },
+    "uk": {
+      "name": "Ukrainian",
+      "native": "Українська",
+      "feature": [
+        "Функціонал"
+      ],
+      "background": [
+        "Передумова"
+      ],
+      "scenario": [
+        "Сценарій"
+      ],
+      "scenarioOutline": [
+        "Структура сценарію"
+      ],
+      "examples": [
+        "Приклади"
+      ],
+      "given": [
+        "* ",
+        "Припустимо ",
+        "Припустимо, що ",
+        "Нехай ",
+        "Дано "
+      ],
+      "when": [
+        "* ",
+        "Якщо ",
+        "Коли "
+      ],
+      "then": [
+        "* ",
+        "То ",
+        "Тоді "
+      ],
+      "and": [
+        "* ",
+        "І ",
+        "А також ",
+        "Та "
+      ],
+      "but": [
+        "* ",
+        "Але "
+      ]
+    },
+    "uz": {
+      "name": "Uzbek",
+      "native": "Узбекча",
+      "feature": [
+        "Функционал"
+      ],
+      "background": [
+        "Тарих"
+      ],
+      "scenario": [
+        "Сценарий"
+      ],
+      "scenarioOutline": [
+        "Сценарий структураси"
+      ],
+      "examples": [
+        "Мисоллар"
+      ],
+      "given": [
+        "* ",
+        "Агар "
+      ],
+      "when": [
+        "* ",
+        "Агар "
+      ],
+      "then": [
+        "* ",
+        "Унда "
+      ],
+      "and": [
+        "* ",
+        "Ва "
+      ],
+      "but": [
+        "* ",
+        "Лекин ",
+        "Бирок ",
+        "Аммо "
+      ]
+    },
+    "vi": {
+      "name": "Vietnamese",
+      "native": "Tiếng Việt",
+      "feature": [
+        "Tính năng"
+      ],
+      "background": [
+        "Bối cảnh"
+      ],
+      "scenario": [
+        "Tình huống",
+        "Kịch bản"
+      ],
+      "scenarioOutline": [
+        "Khung tình huống",
+        "Khung kịch bản"
+      ],
+      "examples": [
+        "Dữ liệu"
+      ],
+      "given": [
+        "* ",
+        "Biết ",
+        "Cho "
+      ],
+      "when": [
+        "* ",
+        "Khi "
+      ],
+      "then": [
+        "* ",
+        "Thì "
+      ],
+      "and": [
+        "* ",
+        "Và "
+      ],
+      "but": [
+        "* ",
+        "Nhưng "
+      ]
+    },
+    "zh-CN": {
+      "name": "Chinese simplified",
+      "native": "简体中文",
+      "feature": [
+        "功能"
+      ],
+      "background": [
+        "背景"
+      ],
+      "scenario": [
+        "场景",
+        "剧本"
+      ],
+      "scenarioOutline": [
+        "场景大纲",
+        "剧本大纲"
+      ],
+      "examples": [
+        "例子"
+      ],
+      "given": [
+        "* ",
+        "假如",
+        "假设",
+        "假定"
+      ],
+      "when": [
+        "* ",
+        "当"
+      ],
+      "then": [
+        "* ",
+        "那么"
+      ],
+      "and": [
+        "* ",
+        "而且",
+        "并且",
+        "同时"
+      ],
+      "but": [
+        "* ",
+        "但是"
+      ]
+    },
+    "zh-TW": {
+      "name": "Chinese traditional",
+      "native": "繁體中文",
+      "feature": [
+        "功能"
+      ],
+      "background": [
+        "背景"
+      ],
+      "scenario": [
+        "場景",
+        "劇本"
+      ],
+      "scenarioOutline": [
+        "場景大綱",
+        "劇本大綱"
+      ],
+      "examples": [
+        "例子"
+      ],
+      "given": [
+        "* ",
+        "假如",
+        "假設",
+        "假定"
+      ],
+      "when": [
+        "* ",
+        "當"
+      ],
+      "then": [
+        "* ",
+        "那麼"
+      ],
+      "and": [
+        "* ",
+        "而且",
+        "並且",
+        "同時"
+      ],
+      "but": [
+        "* ",
+        "但是"
+      ]
+    },
+    "ur": {
+      "name": "Urdu",
+      "native": "اردو",
+      "feature": [
+        "صلاحیت",
+        "کاروبار کی ضرورت",
+        "خصوصیت"
+      ],
+      "background": [
+        "پس منظر"
+      ],
+      "scenario": [
+        "منظرنامہ"
+      ],
+      "scenarioOutline": [
+        "منظر نامے کا خاکہ"
+      ],
+      "examples": [
+        "مثالیں"
+      ],
+      "given": [
+        "* ",
+        "اگر ",
+        "بالفرض ",
+        "فرض کیا "
+      ],
+      "when": [
+        "* ",
+        "جب "
+      ],
+      "then": [
+        "* ",
+        "پھر ",
+        "تب "
+      ],
+      "and": [
+        "* ",
+        "اور "
+      ],
+      "but": [
+        "* ",
+        "لیکن "
+      ]
+    }
+  };
+
+  var Errors = require('./errors');
+
+  module.exports = function TokenMatcher() {
+    var LANGUAGE_PATTERN = /^\s*#\s*language\s*:\s*([a-zA-Z\-_]+)\s*$/;
+    changeDialect('en');
+
+    this.match_TagLine = function match_TagLine(token) {
+      if (token.line.startsWith('@')) {
+        setTokenMatched(token, 'TagLine', null, null, null, token.line.getTags());
+        return true;
+      }
+      return false;
+    };
+
+    this.match_FeatureLine = function match_FeatureLine(token) {
+      return matchTitleLine(token, 'FeatureLine', dialect.feature);
+    };
+
+    this.match_ScenarioLine = function match_ScenarioLine(token) {
+      return matchTitleLine(token, 'ScenarioLine', dialect.scenario);
+    };
+
+    this.match_ScenarioOutlineLine = function match_ScenarioOutlineLine(token) {
+      return matchTitleLine(token, 'ScenarioOutlineLine', dialect.scenarioOutline);
+    };
+
+    this.match_BackgroundLine = function match_BackgroundLine(token) {
+      return matchTitleLine(token, 'BackgroundLine', dialect.background);
+    };
+
+    this.match_ExamplesLine = function match_ExamplesLine(token) {
+      return matchTitleLine(token, 'ExamplesLine', dialect.examples);
+    };
+
+    this.match_TableRow = function match_TableRow(token) {
+      if (token.line.startsWith('|')) {
+        // TODO: indent
+        setTokenMatched(token, 'TableRow', null, null, null, token.line.getTableCells());
+        return true;
+      }
+      return false;
+    };
+
+    this.match_Empty = function match_Empty(token) {
+      if (token.line.isEmpty) {
+        setTokenMatched(token, 'Empty', null, null, 0);
+        return true;
+      }
+      return false;
+    };
+
+    this.match_Comment = function match_Comment(token) {
+      if (token.line.startsWith('#')) {
+        var text = token.line.getLineText(0); //take the entire line, including leading space
+        setTokenMatched(token, 'Comment', text, null, 0);
+        return true;
+      }
+      return false;
+    };
+
+    this.match_Language = function match_Language(token) {
+      var match;
+      if (match = token.line.trimmedLineText.match(LANGUAGE_PATTERN)) {
+        newDialectName = match[1];
+        setTokenMatched(token, 'Language', newDialectName);
+
+        changeDialect(newDialectName, token.location);
+        return true;
+      }
+      return false;
+    };
+
+    function changeDialect(newDialectName, location) {
+      newDialect = dialects[newDialectName];
+      if (!newDialect) {
+        throw Errors.NoSuchLanguageException.create(newDialectName, location);
+      }
+
+      dialectName = newDialectName;
+      dialect = newDialect;
+    }
+
+    var activeDocStringSeparator = null;
+    var indentToRemove = null;
+
+    this.match_DocStringSeparator = function match_DocStringSeparator(token) {
+      return activeDocStringSeparator == null
+        ?
+        // open
+      _match_DocStringSeparator(token, '"""', true) ||
+      _match_DocStringSeparator(token, '```', true)
+        :
+        // close
+        _match_DocStringSeparator(token, activeDocStringSeparator, false);
+    };
+
+    function _match_DocStringSeparator(token, separator, isOpen) {
+      if (token.line.startsWith(separator)) {
+        var contentType = null;
+        if (isOpen) {
+          contentType = token.line.getRestTrimmed(separator.length);
+          activeDocStringSeparator = separator;
+          indentToRemove = token.line.indent;
+        } else {
+          activeDocStringSeparator = null;
+          indentToRemove = 0;
+        }
+
+        // TODO: Use the separator as keyword. That's needed for pretty printing.
+        setTokenMatched(token, 'DocStringSeparator', contentType);
+        return true;
+      }
+      return false;
+    }
+
+    this.match_EOF = function match_EOF(token) {
+      if (token.isEof) {
+        setTokenMatched(token, 'EOF');
+        return true;
+      }
+      return false;
+    };
+
+    this.match_StepLine = function match_StepLine(token) {
+      var keywords = []
+        .concat(dialect.given)
+        .concat(dialect.when)
+        .concat(dialect.then)
+        .concat(dialect.and)
+        .concat(dialect.but);
+      var length = keywords.length;
+      for (var i = 0, keyword; i < length; i++) {
+        var keyword = keywords[i];
+
+        if (token.line.startsWith(keyword)) {
+          var title = token.line.getRestTrimmed(keyword.length);
+          setTokenMatched(token, 'StepLine', title, keyword);
+          return true;
+        }
+      }
+      return false;
+    };
+
+    this.match_Other = function match_Other(token) {
+      var text = token.line.getLineText(indentToRemove); //take the entire line, except removing DocString indents
+      setTokenMatched(token, 'Other', text, null, 0);
+      return true;
+    };
+
+    function matchTitleLine(token, tokenType, keywords) {
+      var length = keywords.length;
+      for (var i = 0, keyword; i < length; i++) {
+        var keyword = keywords[i];
+
+        if (token.line.startsWithTitleKeyword(keyword)) {
+          var title = token.line.getRestTrimmed(keyword.length + ':'.length);
+          setTokenMatched(token, tokenType, title, keyword);
+          return true;
+        }
+      }
+      return false;
+    }
+
+    function setTokenMatched(token, matchedType, text, keyword, indent, items) {
+      token.matchedType = matchedType;
+      token.matchedText = text;
+      token.matchedKeyword = keyword;
+      token.matchedIndent = (typeof indent === 'number') ? indent : (token.line == null ? 0 : token.line.indent);
+      token.matchedItems = items || [];
+
+      token.location.column = token.matchedIndent + 1;
+      token.matchedGherkinDialect = dialectName;
+    }
+  };
+
+  return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/token_matcher.js
+++ b/lib/ace/mode/gherkin/token_matcher.js
@@ -1,2877 +1,2898 @@
-define(function (require, exports, module) {
+/*
+The MIT License (MIT)
 
-  // from dialects.json
-  var dialects = {
-    "en": {
-      "name": "English",
-      "native": "English",
-      "feature": [
-        "Feature",
-        "Business Need",
-        "Ability"
-      ],
-      "background": [
-        "Background"
-      ],
-      "scenario": [
-        "Scenario"
-      ],
-      "scenarioOutline": [
-        "Scenario Outline",
-        "Scenario Template"
-      ],
-      "examples": [
-        "Examples",
-        "Scenarios"
-      ],
-      "given": [
-        "* ",
-        "Given "
-      ],
-      "when": [
-        "* ",
-        "When "
-      ],
-      "then": [
-        "* ",
-        "Then "
-      ],
-      "and": [
-        "* ",
-        "And "
-      ],
-      "but": [
-        "* ",
-        "But "
-      ]
-    },
-    "af": {
-      "name": "Afrikaans",
-      "native": "Afrikaans",
-      "feature": [
-        "Funksie",
-        "Besigheid Behoefte",
-        "Vermoë"
-      ],
-      "background": [
-        "Agtergrond"
-      ],
-      "scenario": [
-        "Situasie"
-      ],
-      "scenarioOutline": [
-        "Situasie Uiteensetting"
-      ],
-      "examples": [
-        "Voorbeelde"
-      ],
-      "given": [
-        "* ",
-        "Gegewe "
-      ],
-      "when": [
-        "* ",
-        "Wanneer "
-      ],
-      "then": [
-        "* ",
-        "Dan "
-      ],
-      "and": [
-        "* ",
-        "En "
-      ],
-      "but": [
-        "* ",
-        "Maar "
-      ]
-    },
-    "ar": {
-      "name": "Arabic",
-      "native": "العربية",
-      "feature": [
-        "خاصية"
-      ],
-      "background": [
-        "الخلفية"
-      ],
-      "scenario": [
-        "سيناريو"
-      ],
-      "scenarioOutline": [
-        "سيناريو مخطط"
-      ],
-      "examples": [
-        "امثلة"
-      ],
-      "given": [
-        "* ",
-        "بفرض "
-      ],
-      "when": [
-        "* ",
-        "متى ",
-        "عندما "
-      ],
-      "then": [
-        "* ",
-        "اذاً ",
-        "ثم "
-      ],
-      "and": [
-        "* ",
-        "و "
-      ],
-      "but": [
-        "* ",
-        "لكن "
-      ]
-    },
-    "bm": {
-      "name": "Malay",
-      "native": "Bahasa Melayu",
-      "feature": [
-        "Fungsi"
-      ],
-      "background": [
-        "Latar Belakang"
-      ],
-      "scenario": [
-        "Senario",
-        "Situai",
-        "Keadaan"
-      ],
-      "scenarioOutline": [
-        "Template Senario",
-        "Template Situai",
-        "Template Keadaan",
-        "Menggariskan Senario"
-      ],
-      "examples": [
-        "Contoh"
-      ],
-      "given": [
-        "* ",
-        "Diberi ",
-        "Bagi "
-      ],
-      "when": [
-        "* ",
-        "Apabila "
-      ],
-      "then": [
-        "* ",
-        "Maka ",
-        "Kemudian "
-      ],
-      "and": [
-        "* ",
-        "Dan "
-      ],
-      "but": [
-        "* ",
-        "Tetapi ",
-        "Tapi "
-      ]
-    },
-    "bg": {
-      "name": "Bulgarian",
-      "native": "български",
-      "feature": [
-        "Функционалност"
-      ],
-      "background": [
-        "Предистория"
-      ],
-      "scenario": [
-        "Сценарий"
-      ],
-      "scenarioOutline": [
-        "Рамка на сценарий"
-      ],
-      "examples": [
-        "Примери"
-      ],
-      "given": [
-        "* ",
-        "Дадено "
-      ],
-      "when": [
-        "* ",
-        "Когато "
-      ],
-      "then": [
-        "* ",
-        "То "
-      ],
-      "and": [
-        "* ",
-        "И "
-      ],
-      "but": [
-        "* ",
-        "Но "
-      ]
-    },
-    "ca": {
-      "name": "Catalan",
-      "native": "català",
-      "feature": [
-        "Característica",
-        "Funcionalitat"
-      ],
-      "background": [
-        "Rerefons",
-        "Antecedents"
-      ],
-      "scenario": [
-        "Escenari"
-      ],
-      "scenarioOutline": [
-        "Esquema de l'escenari"
-      ],
-      "examples": [
-        "Exemples"
-      ],
-      "given": [
-        "* ",
-        "Donat ",
-        "Donada ",
-        "Atès ",
-        "Atesa "
-      ],
-      "when": [
-        "* ",
-        "Quan "
-      ],
-      "then": [
-        "* ",
-        "Aleshores ",
-        "Cal "
-      ],
-      "and": [
-        "* ",
-        "I "
-      ],
-      "but": [
-        "* ",
-        "Però "
-      ]
-    },
-    "cy-GB": {
-      "name": "Welsh",
-      "native": "Cymraeg",
-      "feature": [
-        "Arwedd"
-      ],
-      "background": [
-        "Cefndir"
-      ],
-      "scenario": [
-        "Scenario"
-      ],
-      "scenarioOutline": [
-        "Scenario Amlinellol"
-      ],
-      "examples": [
-        "Enghreifftiau"
-      ],
-      "given": [
-        "* ",
-        "Anrhegedig a "
-      ],
-      "when": [
-        "* ",
-        "Pryd "
-      ],
-      "then": [
-        "* ",
-        "Yna "
-      ],
-      "and": [
-        "* ",
-        "A "
-      ],
-      "but": [
-        "* ",
-        "Ond "
-      ]
-    },
-    "cs": {
-      "name": "Czech",
-      "native": "Česky",
-      "feature": [
-        "Požadavek"
-      ],
-      "background": [
-        "Pozadí",
-        "Kontext"
-      ],
-      "scenario": [
-        "Scénář"
-      ],
-      "scenarioOutline": [
-        "Náčrt Scénáře",
-        "Osnova scénáře"
-      ],
-      "examples": [
-        "Příklady"
-      ],
-      "given": [
-        "* ",
-        "Pokud ",
-        "Za předpokladu "
-      ],
-      "when": [
-        "* ",
-        "Když "
-      ],
-      "then": [
-        "* ",
-        "Pak "
-      ],
-      "and": [
-        "* ",
-        "A také ",
-        "A "
-      ],
-      "but": [
-        "* ",
-        "Ale "
-      ]
-    },
-    "da": {
-      "name": "Danish",
-      "native": "dansk",
-      "feature": [
-        "Egenskab"
-      ],
-      "background": [
-        "Baggrund"
-      ],
-      "scenario": [
-        "Scenarie"
-      ],
-      "scenarioOutline": [
-        "Abstrakt Scenario"
-      ],
-      "examples": [
-        "Eksempler"
-      ],
-      "given": [
-        "* ",
-        "Givet "
-      ],
-      "when": [
-        "* ",
-        "Når "
-      ],
-      "then": [
-        "* ",
-        "Så "
-      ],
-      "and": [
-        "* ",
-        "Og "
-      ],
-      "but": [
-        "* ",
-        "Men "
-      ]
-    },
-    "de": {
-      "name": "German",
-      "native": "Deutsch",
-      "feature": [
-        "Funktionalität"
-      ],
-      "background": [
-        "Grundlage"
-      ],
-      "scenario": [
-        "Szenario"
-      ],
-      "scenarioOutline": [
-        "Szenariogrundriss"
-      ],
-      "examples": [
-        "Beispiele"
-      ],
-      "given": [
-        "* ",
-        "Angenommen ",
-        "Gegeben sei ",
-        "Gegeben seien "
-      ],
-      "when": [
-        "* ",
-        "Wenn "
-      ],
-      "then": [
-        "* ",
-        "Dann "
-      ],
-      "and": [
-        "* ",
-        "Und "
-      ],
-      "but": [
-        "* ",
-        "Aber "
-      ]
-    },
-    "el": {
-      "name": "Greek",
-      "native": "Ελληνικά",
-      "feature": [
-        "Δυνατότητα",
-        "Λειτουργία"
-      ],
-      "background": [
-        "Υπόβαθρο"
-      ],
-      "scenario": [
-        "Σενάριο"
-      ],
-      "scenarioOutline": [
-        "Περιγραφή Σεναρίου"
-      ],
-      "examples": [
-        "Παραδείγματα",
-        "Σενάρια"
-      ],
-      "given": [
-        "* ",
-        "Δεδομένου "
-      ],
-      "when": [
-        "* ",
-        "Όταν "
-      ],
-      "then": [
-        "* ",
-        "Τότε "
-      ],
-      "and": [
-        "* ",
-        "Και "
-      ],
-      "but": [
-        "* ",
-        "Αλλά "
-      ]
-    },
-    "en-au": {
-      "name": "Australian",
-      "native": "Australian",
-      "feature": [
-        "Pretty much"
-      ],
-      "background": [
-        "First off"
-      ],
-      "scenario": [
-        "Awww, look mate"
-      ],
-      "scenarioOutline": [
-        "Reckon it's like"
-      ],
-      "examples": [
-        "You'll wanna"
-      ],
-      "given": [
-        "* ",
-        "Y'know "
-      ],
-      "when": [
-        "* ",
-        "It's just unbelievable "
-      ],
-      "then": [
-        "* ",
-        "But at the end of the day I reckon "
-      ],
-      "and": [
-        "* ",
-        "Too right "
-      ],
-      "but": [
-        "* ",
-        "Yeah nah "
-      ]
-    },
-    "en-lol": {
-      "name": "LOLCAT",
-      "native": "LOLCAT",
-      "feature": [
-        "OH HAI"
-      ],
-      "background": [
-        "B4"
-      ],
-      "scenario": [
-        "MISHUN"
-      ],
-      "scenarioOutline": [
-        "MISHUN SRSLY"
-      ],
-      "examples": [
-        "EXAMPLZ"
-      ],
-      "given": [
-        "* ",
-        "I CAN HAZ "
-      ],
-      "when": [
-        "* ",
-        "WEN "
-      ],
-      "then": [
-        "* ",
-        "DEN "
-      ],
-      "and": [
-        "* ",
-        "AN "
-      ],
-      "but": [
-        "* ",
-        "BUT "
-      ]
-    },
-    "en-old": {
-      "name": "Old English",
-      "native": "Englisc",
-      "feature": [
-        "Hwaet",
-        "Hwæt"
-      ],
-      "background": [
-        "Aer",
-        "Ær"
-      ],
-      "scenario": [
-        "Swa"
-      ],
-      "scenarioOutline": [
-        "Swa hwaer swa",
-        "Swa hwær swa"
-      ],
-      "examples": [
-        "Se the",
-        "Se þe",
-        "Se ðe"
-      ],
-      "given": [
-        "* ",
-        "Thurh ",
-        "Þurh ",
-        "Ðurh "
-      ],
-      "when": [
-        "* ",
-        "Tha ",
-        "Þa ",
-        "Ða "
-      ],
-      "then": [
-        "* ",
-        "Tha ",
-        "Þa ",
-        "Ða ",
-        "Tha the ",
-        "Þa þe ",
-        "Ða ðe "
-      ],
-      "and": [
-        "* ",
-        "Ond ",
-        "7 "
-      ],
-      "but": [
-        "* ",
-        "Ac "
-      ]
-    },
-    "en-pirate": {
-      "name": "Pirate",
-      "native": "Pirate",
-      "feature": [
-        "Ahoy matey!"
-      ],
-      "background": [
-        "Yo-ho-ho"
-      ],
-      "scenario": [
-        "Heave to"
-      ],
-      "scenarioOutline": [
-        "Shiver me timbers"
-      ],
-      "examples": [
-        "Dead men tell no tales"
-      ],
-      "given": [
-        "* ",
-        "Gangway! "
-      ],
-      "when": [
-        "* ",
-        "Blimey! "
-      ],
-      "then": [
-        "* ",
-        "Let go and haul "
-      ],
-      "and": [
-        "* ",
-        "Aye "
-      ],
-      "but": [
-        "* ",
-        "Avast! "
-      ]
-    },
-    "en-Scouse": {
-      "name": "Scouse",
-      "native": "Scouse",
-      "feature": [
-        "Feature"
-      ],
-      "background": [
-        "Dis is what went down"
-      ],
-      "scenario": [
-        "The thing of it is"
-      ],
-      "scenarioOutline": [
-        "Wharrimean is"
-      ],
-      "examples": [
-        "Examples"
-      ],
-      "given": [
-        "* ",
-        "Givun ",
-        "Youse know when youse got "
-      ],
-      "when": [
-        "* ",
-        "Wun ",
-        "Youse know like when "
-      ],
-      "then": [
-        "* ",
-        "Dun ",
-        "Den youse gotta "
-      ],
-      "and": [
-        "* ",
-        "An "
-      ],
-      "but": [
-        "* ",
-        "Buh "
-      ]
-    },
-    "en-tx": {
-      "name": "Texan",
-      "native": "Texan",
-      "feature": [
-        "Feature"
-      ],
-      "background": [
-        "Background"
-      ],
-      "scenario": [
-        "Scenario"
-      ],
-      "scenarioOutline": [
-        "All y'all"
-      ],
-      "examples": [
-        "Examples"
-      ],
-      "given": [
-        "* ",
-        "Given y'all "
-      ],
-      "when": [
-        "* ",
-        "When y'all "
-      ],
-      "then": [
-        "* ",
-        "Then y'all "
-      ],
-      "and": [
-        "* ",
-        "And y'all "
-      ],
-      "but": [
-        "* ",
-        "But y'all "
-      ]
-    },
-    "eo": {
-      "name": "Esperanto",
-      "native": "Esperanto",
-      "feature": [
-        "Trajto"
-      ],
-      "background": [
-        "Fono"
-      ],
-      "scenario": [
-        "Scenaro"
-      ],
-      "scenarioOutline": [
-        "Konturo de la scenaro"
-      ],
-      "examples": [
-        "Ekzemploj"
-      ],
-      "given": [
-        "* ",
-        "Donitaĵo "
-      ],
-      "when": [
-        "* ",
-        "Se "
-      ],
-      "then": [
-        "* ",
-        "Do "
-      ],
-      "and": [
-        "* ",
-        "Kaj "
-      ],
-      "but": [
-        "* ",
-        "Sed "
-      ]
-    },
-    "es": {
-      "name": "Spanish",
-      "native": "español",
-      "feature": [
-        "Característica"
-      ],
-      "background": [
-        "Antecedentes"
-      ],
-      "scenario": [
-        "Escenario"
-      ],
-      "scenarioOutline": [
-        "Esquema del escenario"
-      ],
-      "examples": [
-        "Ejemplos"
-      ],
-      "given": [
-        "* ",
-        "Dado ",
-        "Dada ",
-        "Dados ",
-        "Dadas "
-      ],
-      "when": [
-        "* ",
-        "Cuando "
-      ],
-      "then": [
-        "* ",
-        "Entonces "
-      ],
-      "and": [
-        "* ",
-        "Y "
-      ],
-      "but": [
-        "* ",
-        "Pero "
-      ]
-    },
-    "et": {
-      "name": "Estonian",
-      "native": "eesti keel",
-      "feature": [
-        "Omadus"
-      ],
-      "background": [
-        "Taust"
-      ],
-      "scenario": [
-        "Stsenaarium"
-      ],
-      "scenarioOutline": [
-        "Raamstsenaarium"
-      ],
-      "examples": [
-        "Juhtumid"
-      ],
-      "given": [
-        "* ",
-        "Eeldades "
-      ],
-      "when": [
-        "* ",
-        "Kui "
-      ],
-      "then": [
-        "* ",
-        "Siis "
-      ],
-      "and": [
-        "* ",
-        "Ja "
-      ],
-      "but": [
-        "* ",
-        "Kuid "
-      ]
-    },
-    "fa": {
-      "name": "Persian",
-      "native": "فارسی",
-      "feature": [
-        "وِیژگی"
-      ],
-      "background": [
-        "زمینه"
-      ],
-      "scenario": [
-        "سناریو"
-      ],
-      "scenarioOutline": [
-        "الگوی سناریو"
-      ],
-      "examples": [
-        "نمونه ها"
-      ],
-      "given": [
-        "* ",
-        "با فرض "
-      ],
-      "when": [
-        "* ",
-        "هنگامی "
-      ],
-      "then": [
-        "* ",
-        "آنگاه "
-      ],
-      "and": [
-        "* ",
-        "و "
-      ],
-      "but": [
-        "* ",
-        "اما "
-      ]
-    },
-    "fi": {
-      "name": "Finnish",
-      "native": "suomi",
-      "feature": [
-        "Ominaisuus"
-      ],
-      "background": [
-        "Tausta"
-      ],
-      "scenario": [
-        "Tapaus"
-      ],
-      "scenarioOutline": [
-        "Tapausaihio"
-      ],
-      "examples": [
-        "Tapaukset"
-      ],
-      "given": [
-        "* ",
-        "Oletetaan "
-      ],
-      "when": [
-        "* ",
-        "Kun "
-      ],
-      "then": [
-        "* ",
-        "Niin "
-      ],
-      "and": [
-        "* ",
-        "Ja "
-      ],
-      "but": [
-        "* ",
-        "Mutta "
-      ]
-    },
-    "fr": {
-      "name": "French",
-      "native": "français",
-      "feature": [
-        "Fonctionnalité"
-      ],
-      "background": [
-        "Contexte"
-      ],
-      "scenario": [
-        "Scénario"
-      ],
-      "scenarioOutline": [
-        "Plan du scénario",
-        "Plan du Scénario"
-      ],
-      "examples": [
-        "Exemples"
-      ],
-      "given": [
-        "* ",
-        "Soit ",
-        "Etant donné ",
-        "Etant donnée ",
-        "Etant donnés ",
-        "Etant données ",
-        "Étant donné ",
-        "Étant donnée ",
-        "Étant donnés ",
-        "Étant données "
-      ],
-      "when": [
-        "* ",
-        "Quand ",
-        "Lorsque ",
-        "Lorsqu'"
-      ],
-      "then": [
-        "* ",
-        "Alors "
-      ],
-      "and": [
-        "* ",
-        "Et "
-      ],
-      "but": [
-        "* ",
-        "Mais "
-      ]
-    },
-    "gl": {
-      "name": "Galician",
-      "native": "galego",
-      "feature": [
-        "Característica"
-      ],
-      "background": [
-        "Contexto"
-      ],
-      "scenario": [
-        "Escenario"
-      ],
-      "scenarioOutline": [
-        "Esbozo do escenario"
-      ],
-      "examples": [
-        "Exemplos"
-      ],
-      "given": [
-        "* ",
-        "Dado ",
-        "Dada ",
-        "Dados ",
-        "Dadas "
-      ],
-      "when": [
-        "* ",
-        "Cando "
-      ],
-      "then": [
-        "* ",
-        "Entón ",
-        "Logo "
-      ],
-      "and": [
-        "* ",
-        "E "
-      ],
-      "but": [
-        "* ",
-        "Mais ",
-        "Pero "
-      ]
-    },
-    "he": {
-      "name": "Hebrew",
-      "native": "עברית",
-      "feature": [
-        "תכונה"
-      ],
-      "background": [
-        "רקע"
-      ],
-      "scenario": [
-        "תרחיש"
-      ],
-      "scenarioOutline": [
-        "תבנית תרחיש"
-      ],
-      "examples": [
-        "דוגמאות"
-      ],
-      "given": [
-        "* ",
-        "בהינתן "
-      ],
-      "when": [
-        "* ",
-        "כאשר "
-      ],
-      "then": [
-        "* ",
-        "אז ",
-        "אזי "
-      ],
-      "and": [
-        "* ",
-        "וגם "
-      ],
-      "but": [
-        "* ",
-        "אבל "
-      ]
-    },
-    "hi": {
-      "name": "Hindi",
-      "native": "हिंदी",
-      "feature": [
-        "रूप लेख"
-      ],
-      "background": [
-        "पृष्ठभूमि"
-      ],
-      "scenario": [
-        "परिदृश्य"
-      ],
-      "scenarioOutline": [
-        "परिदृश्य रूपरेखा"
-      ],
-      "examples": [
-        "उदाहरण"
-      ],
-      "given": [
-        "* ",
-        "अगर ",
-        "यदि ",
-        "चूंकि "
-      ],
-      "when": [
-        "* ",
-        "जब ",
-        "कदा "
-      ],
-      "then": [
-        "* ",
-        "तब ",
-        "तदा "
-      ],
-      "and": [
-        "* ",
-        "और ",
-        "तथा "
-      ],
-      "but": [
-        "* ",
-        "पर ",
-        "परन्तु ",
-        "किन्तु "
-      ]
-    },
-    "hr": {
-      "name": "Croatian",
-      "native": "hrvatski",
-      "feature": [
-        "Osobina",
-        "Mogućnost",
-        "Mogucnost"
-      ],
-      "background": [
-        "Pozadina"
-      ],
-      "scenario": [
-        "Scenarij"
-      ],
-      "scenarioOutline": [
-        "Skica",
-        "Koncept"
-      ],
-      "examples": [
-        "Primjeri",
-        "Scenariji"
-      ],
-      "given": [
-        "* ",
-        "Zadan ",
-        "Zadani ",
-        "Zadano "
-      ],
-      "when": [
-        "* ",
-        "Kada ",
-        "Kad "
-      ],
-      "then": [
-        "* ",
-        "Onda "
-      ],
-      "and": [
-        "* ",
-        "I "
-      ],
-      "but": [
-        "* ",
-        "Ali "
-      ]
-    },
-    "ht": {
-      "name": "Creole",
-      "native": "kreyòl",
-      "feature": [
-        "Karakteristik",
-        "Mak",
-        "Fonksyonalite"
-      ],
-      "background": [
-        "Kontèks",
-        "Istorik"
-      ],
-      "scenario": [
-        "Senaryo"
-      ],
-      "scenarioOutline": [
-        "Plan senaryo",
-        "Plan Senaryo",
-        "Senaryo deskripsyon",
-        "Senaryo Deskripsyon",
-        "Dyagram senaryo",
-        "Dyagram Senaryo"
-      ],
-      "examples": [
-        "Egzanp"
-      ],
-      "given": [
-        "* ",
-        "Sipoze ",
-        "Sipoze ke ",
-        "Sipoze Ke "
-      ],
-      "when": [
-        "* ",
-        "Lè ",
-        "Le "
-      ],
-      "then": [
-        "* ",
-        "Lè sa a ",
-        "Le sa a "
-      ],
-      "and": [
-        "* ",
-        "Ak ",
-        "Epi ",
-        "E "
-      ],
-      "but": [
-        "* ",
-        "Men "
-      ]
-    },
-    "hu": {
-      "name": "Hungarian",
-      "native": "magyar",
-      "feature": [
-        "Jellemző"
-      ],
-      "background": [
-        "Háttér"
-      ],
-      "scenario": [
-        "Forgatókönyv"
-      ],
-      "scenarioOutline": [
-        "Forgatókönyv vázlat"
-      ],
-      "examples": [
-        "Példák"
-      ],
-      "given": [
-        "* ",
-        "Amennyiben ",
-        "Adott "
-      ],
-      "when": [
-        "* ",
-        "Majd ",
-        "Ha ",
-        "Amikor "
-      ],
-      "then": [
-        "* ",
-        "Akkor "
-      ],
-      "and": [
-        "* ",
-        "És "
-      ],
-      "but": [
-        "* ",
-        "De "
-      ]
-    },
-    "id": {
-      "name": "Indonesian",
-      "native": "Bahasa Indonesia",
-      "feature": [
-        "Fitur"
-      ],
-      "background": [
-        "Dasar"
-      ],
-      "scenario": [
-        "Skenario"
-      ],
-      "scenarioOutline": [
-        "Skenario konsep"
-      ],
-      "examples": [
-        "Contoh"
-      ],
-      "given": [
-        "* ",
-        "Dengan "
-      ],
-      "when": [
-        "* ",
-        "Ketika "
-      ],
-      "then": [
-        "* ",
-        "Maka "
-      ],
-      "and": [
-        "* ",
-        "Dan "
-      ],
-      "but": [
-        "* ",
-        "Tapi "
-      ]
-    },
-    "is": {
-      "name": "Icelandic",
-      "native": "Íslenska",
-      "feature": [
-        "Eiginleiki"
-      ],
-      "background": [
-        "Bakgrunnur"
-      ],
-      "scenario": [
-        "Atburðarás"
-      ],
-      "scenarioOutline": [
-        "Lýsing Atburðarásar",
-        "Lýsing Dæma"
-      ],
-      "examples": [
-        "Dæmi",
-        "Atburðarásir"
-      ],
-      "given": [
-        "* ",
-        "Ef "
-      ],
-      "when": [
-        "* ",
-        "Þegar "
-      ],
-      "then": [
-        "* ",
-        "Þá "
-      ],
-      "and": [
-        "* ",
-        "Og "
-      ],
-      "but": [
-        "* ",
-        "En "
-      ]
-    },
-    "it": {
-      "name": "Italian",
-      "native": "italiano",
-      "feature": [
-        "Funzionalità"
-      ],
-      "background": [
-        "Contesto"
-      ],
-      "scenario": [
-        "Scenario"
-      ],
-      "scenarioOutline": [
-        "Schema dello scenario"
-      ],
-      "examples": [
-        "Esempi"
-      ],
-      "given": [
-        "* ",
-        "Dato ",
-        "Data ",
-        "Dati ",
-        "Date "
-      ],
-      "when": [
-        "* ",
-        "Quando "
-      ],
-      "then": [
-        "* ",
-        "Allora "
-      ],
-      "and": [
-        "* ",
-        "E "
-      ],
-      "but": [
-        "* ",
-        "Ma "
-      ]
-    },
-    "ja": {
-      "name": "Japanese",
-      "native": "日本語",
-      "feature": [
-        "フィーチャ",
-        "機能"
-      ],
-      "background": [
-        "背景"
-      ],
-      "scenario": [
-        "シナリオ"
-      ],
-      "scenarioOutline": [
-        "シナリオアウトライン",
-        "シナリオテンプレート",
-        "テンプレ",
-        "シナリオテンプレ"
-      ],
-      "examples": [
-        "例",
-        "サンプル"
-      ],
-      "given": [
-        "* ",
-        "前提"
-      ],
-      "when": [
-        "* ",
-        "もし"
-      ],
-      "then": [
-        "* ",
-        "ならば"
-      ],
-      "and": [
-        "* ",
-        "かつ"
-      ],
-      "but": [
-        "* ",
-        "しかし",
-        "但し",
-        "ただし"
-      ]
-    },
-    "jv": {
-      "name": "Javanese",
-      "native": "Basa Jawa",
-      "feature": [
-        "Fitur"
-      ],
-      "background": [
-        "Dasar"
-      ],
-      "scenario": [
-        "Skenario"
-      ],
-      "scenarioOutline": [
-        "Konsep skenario"
-      ],
-      "examples": [
-        "Conto",
-        "Contone"
-      ],
-      "given": [
-        "* ",
-        "Nalika ",
-        "Nalikaning "
-      ],
-      "when": [
-        "* ",
-        "Manawa ",
-        "Menawa "
-      ],
-      "then": [
-        "* ",
-        "Njuk ",
-        "Banjur "
-      ],
-      "and": [
-        "* ",
-        "Lan "
-      ],
-      "but": [
-        "* ",
-        "Tapi ",
-        "Nanging ",
-        "Ananging "
-      ]
-    },
-    "kn": {
-      "name": "Kannada",
-      "native": "ಕನ್ನಡ",
-      "feature": [
-        "ಹೆಚ್ಚಳ"
-      ],
-      "background": [
-        "ಹಿನ್ನೆಲೆ"
-      ],
-      "scenario": [
-        "ಕಥಾಸಾರಾಂಶ"
-      ],
-      "scenarioOutline": [
-        "ವಿವರಣೆ"
-      ],
-      "examples": [
-        "ಉದಾಹರಣೆಗಳು"
-      ],
-      "given": [
-        "* ",
-        "ನೀಡಿದ "
-      ],
-      "when": [
-        "* ",
-        "ಸ್ಥಿತಿಯನ್ನು "
-      ],
-      "then": [
-        "* ",
-        "ನಂತರ "
-      ],
-      "and": [
-        "* ",
-        "ಮತ್ತು "
-      ],
-      "but": [
-        "* ",
-        "ಆದರೆ "
-      ]
-    },
-    "ko": {
-      "name": "Korean",
-      "native": "한국어",
-      "feature": [
-        "기능"
-      ],
-      "background": [
-        "배경"
-      ],
-      "scenario": [
-        "시나리오"
-      ],
-      "scenarioOutline": [
-        "시나리오 개요"
-      ],
-      "examples": [
-        "예"
-      ],
-      "given": [
-        "* ",
-        "조건",
-        "먼저"
-      ],
-      "when": [
-        "* ",
-        "만일",
-        "만약"
-      ],
-      "then": [
-        "* ",
-        "그러면"
-      ],
-      "and": [
-        "* ",
-        "그리고"
-      ],
-      "but": [
-        "* ",
-        "하지만",
-        "단"
-      ]
-    },
-    "lt": {
-      "name": "Lithuanian",
-      "native": "lietuvių kalba",
-      "feature": [
-        "Savybė"
-      ],
-      "background": [
-        "Kontekstas"
-      ],
-      "scenario": [
-        "Scenarijus"
-      ],
-      "scenarioOutline": [
-        "Scenarijaus šablonas"
-      ],
-      "examples": [
-        "Pavyzdžiai",
-        "Scenarijai",
-        "Variantai"
-      ],
-      "given": [
-        "* ",
-        "Duota "
-      ],
-      "when": [
-        "* ",
-        "Kai "
-      ],
-      "then": [
-        "* ",
-        "Tada "
-      ],
-      "and": [
-        "* ",
-        "Ir "
-      ],
-      "but": [
-        "* ",
-        "Bet "
-      ]
-    },
-    "lu": {
-      "name": "Luxemburgish",
-      "native": "Lëtzebuergesch",
-      "feature": [
-        "Funktionalitéit"
-      ],
-      "background": [
-        "Hannergrond"
-      ],
-      "scenario": [
-        "Szenario"
-      ],
-      "scenarioOutline": [
-        "Plang vum Szenario"
-      ],
-      "examples": [
-        "Beispiller"
-      ],
-      "given": [
-        "* ",
-        "ugeholl "
-      ],
-      "when": [
-        "* ",
-        "wann "
-      ],
-      "then": [
-        "* ",
-        "dann "
-      ],
-      "and": [
-        "* ",
-        "an ",
-        "a "
-      ],
-      "but": [
-        "* ",
-        "awer ",
-        "mä "
-      ]
-    },
-    "lv": {
-      "name": "Latvian",
-      "native": "latviešu",
-      "feature": [
-        "Funkcionalitāte",
-        "Fīča"
-      ],
-      "background": [
-        "Konteksts",
-        "Situācija"
-      ],
-      "scenario": [
-        "Scenārijs"
-      ],
-      "scenarioOutline": [
-        "Scenārijs pēc parauga"
-      ],
-      "examples": [
-        "Piemēri",
-        "Paraugs"
-      ],
-      "given": [
-        "* ",
-        "Kad "
-      ],
-      "when": [
-        "* ",
-        "Ja "
-      ],
-      "then": [
-        "* ",
-        "Tad "
-      ],
-      "and": [
-        "* ",
-        "Un "
-      ],
-      "but": [
-        "* ",
-        "Bet "
-      ]
-    },
-    "nl": {
-      "name": "Dutch",
-      "native": "Nederlands",
-      "feature": [
-        "Functionaliteit"
-      ],
-      "background": [
-        "Achtergrond"
-      ],
-      "scenario": [
-        "Scenario"
-      ],
-      "scenarioOutline": [
-        "Abstract Scenario"
-      ],
-      "examples": [
-        "Voorbeelden"
-      ],
-      "given": [
-        "* ",
-        "Gegeven ",
-        "Stel "
-      ],
-      "when": [
-        "* ",
-        "Als "
-      ],
-      "then": [
-        "* ",
-        "Dan "
-      ],
-      "and": [
-        "* ",
-        "En "
-      ],
-      "but": [
-        "* ",
-        "Maar "
-      ]
-    },
-    "no": {
-      "name": "Norwegian",
-      "native": "norsk",
-      "feature": [
-        "Egenskap"
-      ],
-      "background": [
-        "Bakgrunn"
-      ],
-      "scenario": [
-        "Scenario"
-      ],
-      "scenarioOutline": [
-        "Scenariomal",
-        "Abstrakt Scenario"
-      ],
-      "examples": [
-        "Eksempler"
-      ],
-      "given": [
-        "* ",
-        "Gitt "
-      ],
-      "when": [
-        "* ",
-        "Når "
-      ],
-      "then": [
-        "* ",
-        "Så "
-      ],
-      "and": [
-        "* ",
-        "Og "
-      ],
-      "but": [
-        "* ",
-        "Men "
-      ]
-    },
-    "pa": {
-      "name": "Panjabi",
-      "native": "ਪੰਜਾਬੀ",
-      "feature": [
-        "ਖਾਸੀਅਤ",
-        "ਮੁਹਾਂਦਰਾ",
-        "ਨਕਸ਼ ਨੁਹਾਰ"
-      ],
-      "background": [
-        "ਪਿਛੋਕੜ"
-      ],
-      "scenario": [
-        "ਪਟਕਥਾ"
-      ],
-      "scenarioOutline": [
-        "ਪਟਕਥਾ ਢਾਂਚਾ",
-        "ਪਟਕਥਾ ਰੂਪ ਰੇਖਾ"
-      ],
-      "examples": [
-        "ਉਦਾਹਰਨਾਂ"
-      ],
-      "given": [
-        "* ",
-        "ਜੇਕਰ ",
-        "ਜਿਵੇਂ ਕਿ "
-      ],
-      "when": [
-        "* ",
-        "ਜਦੋਂ "
-      ],
-      "then": [
-        "* ",
-        "ਤਦ "
-      ],
-      "and": [
-        "* ",
-        "ਅਤੇ "
-      ],
-      "but": [
-        "* ",
-        "ਪਰ "
-      ]
-    },
-    "pl": {
-      "name": "Polish",
-      "native": "polski",
-      "feature": [
-        "Właściwość",
-        "Funkcja",
-        "Aspekt",
-        "Potrzeba biznesowa"
-      ],
-      "background": [
-        "Założenia"
-      ],
-      "scenario": [
-        "Scenariusz"
-      ],
-      "scenarioOutline": [
-        "Szablon scenariusza"
-      ],
-      "examples": [
-        "Przykłady"
-      ],
-      "given": [
-        "* ",
-        "Zakładając ",
-        "Mając "
-      ],
-      "when": [
-        "* ",
-        "Jeżeli ",
-        "Jeśli ",
-        "Gdy ",
-        "Kiedy "
-      ],
-      "then": [
-        "* ",
-        "Wtedy "
-      ],
-      "and": [
-        "* ",
-        "Oraz ",
-        "I "
-      ],
-      "but": [
-        "* ",
-        "Ale "
-      ]
-    },
-    "pt": {
-      "name": "Portuguese",
-      "native": "português",
-      "feature": [
-        "Funcionalidade",
-        "Característica",
-        "Caracteristica"
-      ],
-      "background": [
-        "Contexto",
-        "Cenário de Fundo",
-        "Cenario de Fundo",
-        "Fundo"
-      ],
-      "scenario": [
-        "Cenário",
-        "Cenario"
-      ],
-      "scenarioOutline": [
-        "Esquema do Cenário",
-        "Esquema do Cenario",
-        "Delineação do Cenário",
-        "Delineacao do Cenario"
-      ],
-      "examples": [
-        "Exemplos",
-        "Cenários",
-        "Cenarios"
-      ],
-      "given": [
-        "* ",
-        "Dado ",
-        "Dada ",
-        "Dados ",
-        "Dadas "
-      ],
-      "when": [
-        "* ",
-        "Quando "
-      ],
-      "then": [
-        "* ",
-        "Então ",
-        "Entao "
-      ],
-      "and": [
-        "* ",
-        "E "
-      ],
-      "but": [
-        "* ",
-        "Mas "
-      ]
-    },
-    "ro": {
-      "name": "Romanian",
-      "native": "română",
-      "feature": [
-        "Functionalitate",
-        "Funcționalitate",
-        "Funcţionalitate"
-      ],
-      "background": [
-        "Context"
-      ],
-      "scenario": [
-        "Scenariu"
-      ],
-      "scenarioOutline": [
-        "Structura scenariu",
-        "Structură scenariu"
-      ],
-      "examples": [
-        "Exemple"
-      ],
-      "given": [
-        "* ",
-        "Date fiind ",
-        "Dat fiind ",
-        "Dati fiind ",
-        "Dați fiind ",
-        "Daţi fiind "
-      ],
-      "when": [
-        "* ",
-        "Cand ",
-        "Când "
-      ],
-      "then": [
-        "* ",
-        "Atunci "
-      ],
-      "and": [
-        "* ",
-        "Si ",
-        "Și ",
-        "Şi "
-      ],
-      "but": [
-        "* ",
-        "Dar "
-      ]
-    },
-    "ru": {
-      "name": "Russian",
-      "native": "русский",
-      "feature": [
-        "Функция",
-        "Функционал",
-        "Свойство"
-      ],
-      "background": [
-        "Предыстория",
-        "Контекст"
-      ],
-      "scenario": [
-        "Сценарий"
-      ],
-      "scenarioOutline": [
-        "Структура сценария"
-      ],
-      "examples": [
-        "Примеры"
-      ],
-      "given": [
-        "* ",
-        "Допустим ",
-        "Дано ",
-        "Пусть "
-      ],
-      "when": [
-        "* ",
-        "Если ",
-        "Когда "
-      ],
-      "then": [
-        "* ",
-        "То ",
-        "Тогда "
-      ],
-      "and": [
-        "* ",
-        "И ",
-        "К тому же ",
-        "Также "
-      ],
-      "but": [
-        "* ",
-        "Но ",
-        "А "
-      ]
-    },
-    "sv": {
-      "name": "Swedish",
-      "native": "Svenska",
-      "feature": [
-        "Egenskap"
-      ],
-      "background": [
-        "Bakgrund"
-      ],
-      "scenario": [
-        "Scenario"
-      ],
-      "scenarioOutline": [
-        "Abstrakt Scenario",
-        "Scenariomall"
-      ],
-      "examples": [
-        "Exempel"
-      ],
-      "given": [
-        "* ",
-        "Givet "
-      ],
-      "when": [
-        "* ",
-        "När "
-      ],
-      "then": [
-        "* ",
-        "Så "
-      ],
-      "and": [
-        "* ",
-        "Och "
-      ],
-      "but": [
-        "* ",
-        "Men "
-      ]
-    },
-    "sk": {
-      "name": "Slovak",
-      "native": "Slovensky",
-      "feature": [
-        "Požiadavka",
-        "Funkcia",
-        "Vlastnosť"
-      ],
-      "background": [
-        "Pozadie"
-      ],
-      "scenario": [
-        "Scenár"
-      ],
-      "scenarioOutline": [
-        "Náčrt Scenáru",
-        "Náčrt Scenára",
-        "Osnova Scenára"
-      ],
-      "examples": [
-        "Príklady"
-      ],
-      "given": [
-        "* ",
-        "Pokiaľ ",
-        "Za predpokladu "
-      ],
-      "when": [
-        "* ",
-        "Keď ",
-        "Ak "
-      ],
-      "then": [
-        "* ",
-        "Tak ",
-        "Potom "
-      ],
-      "and": [
-        "* ",
-        "A ",
-        "A tiež ",
-        "A taktiež ",
-        "A zároveň "
-      ],
-      "but": [
-        "* ",
-        "Ale "
-      ]
-    },
-    "sl": {
-      "name": "Slovenian",
-      "native": "Slovenski",
-      "feature": [
-        "Funkcionalnost",
-        "Funkcija",
-        "Možnosti",
-        "Moznosti",
-        "Lastnost",
-        "Značilnost"
-      ],
-      "background": [
-        "Kontekst",
-        "Osnova",
-        "Ozadje"
-      ],
-      "scenario": [
-        "Scenarij",
-        "Primer"
-      ],
-      "scenarioOutline": [
-        "Struktura scenarija",
-        "Skica",
-        "Koncept",
-        "Oris scenarija",
-        "Osnutek"
-      ],
-      "examples": [
-        "Primeri",
-        "Scenariji"
-      ],
-      "given": [
-        "Dano ",
-        "Podano ",
-        "Zaradi ",
-        "Privzeto "
-      ],
-      "when": [
-        "Ko ",
-        "Ce ",
-        "Če ",
-        "Kadar "
-      ],
-      "then": [
-        "Nato ",
-        "Potem ",
-        "Takrat "
-      ],
-      "and": [
-        "In ",
-        "Ter "
-      ],
-      "but": [
-        "Toda ",
-        "Ampak ",
-        "Vendar "
-      ]
-    },
-    "sr-Latn": {
-      "name": "Serbian (Latin)",
-      "native": "Srpski (Latinica)",
-      "feature": [
-        "Funkcionalnost",
-        "Mogućnost",
-        "Mogucnost",
-        "Osobina"
-      ],
-      "background": [
-        "Kontekst",
-        "Osnova",
-        "Pozadina"
-      ],
-      "scenario": [
-        "Scenario",
-        "Primer"
-      ],
-      "scenarioOutline": [
-        "Struktura scenarija",
-        "Skica",
-        "Koncept"
-      ],
-      "examples": [
-        "Primeri",
-        "Scenariji"
-      ],
-      "given": [
-        "* ",
-        "Zadato ",
-        "Zadate ",
-        "Zatati "
-      ],
-      "when": [
-        "* ",
-        "Kada ",
-        "Kad "
-      ],
-      "then": [
-        "* ",
-        "Onda "
-      ],
-      "and": [
-        "* ",
-        "I "
-      ],
-      "but": [
-        "* ",
-        "Ali "
-      ]
-    },
-    "sr-Cyrl": {
-      "name": "Serbian",
-      "native": "Српски",
-      "feature": [
-        "Функционалност",
-        "Могућност",
-        "Особина"
-      ],
-      "background": [
-        "Контекст",
-        "Основа",
-        "Позадина"
-      ],
-      "scenario": [
-        "Сценарио",
-        "Пример"
-      ],
-      "scenarioOutline": [
-        "Структура сценарија",
-        "Скица",
-        "Концепт"
-      ],
-      "examples": [
-        "Примери",
-        "Сценарији"
-      ],
-      "given": [
-        "* ",
-        "Задато ",
-        "Задате ",
-        "Задати "
-      ],
-      "when": [
-        "* ",
-        "Када ",
-        "Кад "
-      ],
-      "then": [
-        "* ",
-        "Онда "
-      ],
-      "and": [
-        "* ",
-        "И "
-      ],
-      "but": [
-        "* ",
-        "Али "
-      ]
-    },
-    "tl": {
-      "name": "Telugu",
-      "native": "తెలుగు",
-      "feature": [
-        "గుణము"
-      ],
-      "background": [
-        "నేపథ్యం"
-      ],
-      "scenario": [
-        "సన్నివేశం"
-      ],
-      "scenarioOutline": [
-        "కథనం"
-      ],
-      "examples": [
-        "ఉదాహరణలు"
-      ],
-      "given": [
-        "* ",
-        "చెప్పబడినది "
-      ],
-      "when": [
-        "* ",
-        "ఈ పరిస్థితిలో "
-      ],
-      "then": [
-        "* ",
-        "అప్పుడు "
-      ],
-      "and": [
-        "* ",
-        "మరియు "
-      ],
-      "but": [
-        "* ",
-        "కాని "
-      ]
-    },
-    "th": {
-      "name": "Thai",
-      "native": "ไทย",
-      "feature": [
-        "โครงหลัก",
-        "ความต้องการทางธุรกิจ",
-        "ความสามารถ"
-      ],
-      "background": [
-        "แนวคิด"
-      ],
-      "scenario": [
-        "เหตุการณ์"
-      ],
-      "scenarioOutline": [
-        "สรุปเหตุการณ์",
-        "โครงสร้างของเหตุการณ์"
-      ],
-      "examples": [
-        "ชุดของตัวอย่าง",
-        "ชุดของเหตุการณ์"
-      ],
-      "given": [
-        "* ",
-        "กำหนดให้ "
-      ],
-      "when": [
-        "* ",
-        "เมื่อ "
-      ],
-      "then": [
-        "* ",
-        "ดังนั้น "
-      ],
-      "and": [
-        "* ",
-        "และ "
-      ],
-      "but": [
-        "* ",
-        "แต่ "
-      ]
-    },
-    "tlh": {
-      "name": "Klingon",
-      "native": "tlhIngan",
-      "feature": [
-        "Qap",
-        "Qu'meH 'ut",
-        "perbogh",
-        "poQbogh malja'",
-        "laH"
-      ],
-      "background": [
-        "mo'"
-      ],
-      "scenario": [
-        "lut"
-      ],
-      "scenarioOutline": [
-        "lut chovnatlh"
-      ],
-      "examples": [
-        "ghantoH",
-        "lutmey"
-      ],
-      "given": [
-        "* ",
-        "ghu' noblu' ",
-        "DaH ghu' bejlu' "
-      ],
-      "when": [
-        "* ",
-        "qaSDI' "
-      ],
-      "then": [
-        "* ",
-        "vaj "
-      ],
-      "and": [
-        "* ",
-        "'ej ",
-        "latlh "
-      ],
-      "but": [
-        "* ",
-        "'ach ",
-        "'a "
-      ]
-    },
-    "tr": {
-      "name": "Turkish",
-      "native": "Türkçe",
-      "feature": [
-        "Özellik"
-      ],
-      "background": [
-        "Geçmiş"
-      ],
-      "scenario": [
-        "Senaryo"
-      ],
-      "scenarioOutline": [
-        "Senaryo taslağı"
-      ],
-      "examples": [
-        "Örnekler"
-      ],
-      "given": [
-        "* ",
-        "Diyelim ki "
-      ],
-      "when": [
-        "* ",
-        "Eğer ki "
-      ],
-      "then": [
-        "* ",
-        "O zaman "
-      ],
-      "and": [
-        "* ",
-        "Ve "
-      ],
-      "but": [
-        "* ",
-        "Fakat ",
-        "Ama "
-      ]
-    },
-    "tt": {
-      "name": "Tatar",
-      "native": "Татарча",
-      "feature": [
-        "Мөмкинлек",
-        "Үзенчәлеклелек"
-      ],
-      "background": [
-        "Кереш"
-      ],
-      "scenario": [
-        "Сценарий"
-      ],
-      "scenarioOutline": [
-        "Сценарийның төзелеше"
-      ],
-      "examples": [
-        "Үрнәкләр",
-        "Мисаллар"
-      ],
-      "given": [
-        "* ",
-        "Әйтик "
-      ],
-      "when": [
-        "* ",
-        "Әгәр "
-      ],
-      "then": [
-        "* ",
-        "Нәтиҗәдә "
-      ],
-      "and": [
-        "* ",
-        "Һәм ",
-        "Вә "
-      ],
-      "but": [
-        "* ",
-        "Ләкин ",
-        "Әмма "
-      ]
-    },
-    "uk": {
-      "name": "Ukrainian",
-      "native": "Українська",
-      "feature": [
-        "Функціонал"
-      ],
-      "background": [
-        "Передумова"
-      ],
-      "scenario": [
-        "Сценарій"
-      ],
-      "scenarioOutline": [
-        "Структура сценарію"
-      ],
-      "examples": [
-        "Приклади"
-      ],
-      "given": [
-        "* ",
-        "Припустимо ",
-        "Припустимо, що ",
-        "Нехай ",
-        "Дано "
-      ],
-      "when": [
-        "* ",
-        "Якщо ",
-        "Коли "
-      ],
-      "then": [
-        "* ",
-        "То ",
-        "Тоді "
-      ],
-      "and": [
-        "* ",
-        "І ",
-        "А також ",
-        "Та "
-      ],
-      "but": [
-        "* ",
-        "Але "
-      ]
-    },
-    "uz": {
-      "name": "Uzbek",
-      "native": "Узбекча",
-      "feature": [
-        "Функционал"
-      ],
-      "background": [
-        "Тарих"
-      ],
-      "scenario": [
-        "Сценарий"
-      ],
-      "scenarioOutline": [
-        "Сценарий структураси"
-      ],
-      "examples": [
-        "Мисоллар"
-      ],
-      "given": [
-        "* ",
-        "Агар "
-      ],
-      "when": [
-        "* ",
-        "Агар "
-      ],
-      "then": [
-        "* ",
-        "Унда "
-      ],
-      "and": [
-        "* ",
-        "Ва "
-      ],
-      "but": [
-        "* ",
-        "Лекин ",
-        "Бирок ",
-        "Аммо "
-      ]
-    },
-    "vi": {
-      "name": "Vietnamese",
-      "native": "Tiếng Việt",
-      "feature": [
-        "Tính năng"
-      ],
-      "background": [
-        "Bối cảnh"
-      ],
-      "scenario": [
-        "Tình huống",
-        "Kịch bản"
-      ],
-      "scenarioOutline": [
-        "Khung tình huống",
-        "Khung kịch bản"
-      ],
-      "examples": [
-        "Dữ liệu"
-      ],
-      "given": [
-        "* ",
-        "Biết ",
-        "Cho "
-      ],
-      "when": [
-        "* ",
-        "Khi "
-      ],
-      "then": [
-        "* ",
-        "Thì "
-      ],
-      "and": [
-        "* ",
-        "Và "
-      ],
-      "but": [
-        "* ",
-        "Nhưng "
-      ]
-    },
-    "zh-CN": {
-      "name": "Chinese simplified",
-      "native": "简体中文",
-      "feature": [
-        "功能"
-      ],
-      "background": [
-        "背景"
-      ],
-      "scenario": [
-        "场景",
-        "剧本"
-      ],
-      "scenarioOutline": [
-        "场景大纲",
-        "剧本大纲"
-      ],
-      "examples": [
-        "例子"
-      ],
-      "given": [
-        "* ",
-        "假如",
-        "假设",
-        "假定"
-      ],
-      "when": [
-        "* ",
-        "当"
-      ],
-      "then": [
-        "* ",
-        "那么"
-      ],
-      "and": [
-        "* ",
-        "而且",
-        "并且",
-        "同时"
-      ],
-      "but": [
-        "* ",
-        "但是"
-      ]
-    },
-    "zh-TW": {
-      "name": "Chinese traditional",
-      "native": "繁體中文",
-      "feature": [
-        "功能"
-      ],
-      "background": [
-        "背景"
-      ],
-      "scenario": [
-        "場景",
-        "劇本"
-      ],
-      "scenarioOutline": [
-        "場景大綱",
-        "劇本大綱"
-      ],
-      "examples": [
-        "例子"
-      ],
-      "given": [
-        "* ",
-        "假如",
-        "假設",
-        "假定"
-      ],
-      "when": [
-        "* ",
-        "當"
-      ],
-      "then": [
-        "* ",
-        "那麼"
-      ],
-      "and": [
-        "* ",
-        "而且",
-        "並且",
-        "同時"
-      ],
-      "but": [
-        "* ",
-        "但是"
-      ]
-    },
-    "ur": {
-      "name": "Urdu",
-      "native": "اردو",
-      "feature": [
-        "صلاحیت",
-        "کاروبار کی ضرورت",
-        "خصوصیت"
-      ],
-      "background": [
-        "پس منظر"
-      ],
-      "scenario": [
-        "منظرنامہ"
-      ],
-      "scenarioOutline": [
-        "منظر نامے کا خاکہ"
-      ],
-      "examples": [
-        "مثالیں"
-      ],
-      "given": [
-        "* ",
-        "اگر ",
-        "بالفرض ",
-        "فرض کیا "
-      ],
-      "when": [
-        "* ",
-        "جب "
-      ],
-      "then": [
-        "* ",
-        "پھر ",
-        "تب "
-      ],
-      "and": [
-        "* ",
-        "اور "
-      ],
-      "but": [
-        "* ",
-        "لیکن "
-      ]
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+define(function(require,exports,module){
+
+var dialects = {
+  "en": {
+    "name": "English",
+    "native": "English",
+    "feature": [
+      "Feature",
+      "Business Need",
+      "Ability"
+    ],
+    "background": [
+      "Background"
+    ],
+    "scenario": [
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Scenario Outline",
+      "Scenario Template"
+    ],
+    "examples": [
+      "Examples",
+      "Scenarios"
+    ],
+    "given": [
+      "* ",
+      "Given "
+    ],
+    "when": [
+      "* ",
+      "When "
+    ],
+    "then": [
+      "* ",
+      "Then "
+    ],
+    "and": [
+      "* ",
+      "And "
+    ],
+    "but": [
+      "* ",
+      "But "
+    ]
+  },
+  "af": {
+    "name": "Afrikaans",
+    "native": "Afrikaans",
+    "feature": [
+      "Funksie",
+      "Besigheid Behoefte",
+      "Vermoë"
+    ],
+    "background": [
+      "Agtergrond"
+    ],
+    "scenario": [
+      "Situasie"
+    ],
+    "scenarioOutline": [
+      "Situasie Uiteensetting"
+    ],
+    "examples": [
+      "Voorbeelde"
+    ],
+    "given": [
+      "* ",
+      "Gegewe "
+    ],
+    "when": [
+      "* ",
+      "Wanneer "
+    ],
+    "then": [
+      "* ",
+      "Dan "
+    ],
+    "and": [
+      "* ",
+      "En "
+    ],
+    "but": [
+      "* ",
+      "Maar "
+    ]
+  },
+  "ar": {
+    "name": "Arabic",
+    "native": "العربية",
+    "feature": [
+      "خاصية"
+    ],
+    "background": [
+      "الخلفية"
+    ],
+    "scenario": [
+      "سيناريو"
+    ],
+    "scenarioOutline": [
+      "سيناريو مخطط"
+    ],
+    "examples": [
+      "امثلة"
+    ],
+    "given": [
+      "* ",
+      "بفرض "
+    ],
+    "when": [
+      "* ",
+      "متى ",
+      "عندما "
+    ],
+    "then": [
+      "* ",
+      "اذاً ",
+      "ثم "
+    ],
+    "and": [
+      "* ",
+      "و "
+    ],
+    "but": [
+      "* ",
+      "لكن "
+    ]
+  },
+  "bm": {
+    "name": "Malay",
+    "native": "Bahasa Melayu",
+    "feature": [
+      "Fungsi"
+    ],
+    "background": [
+      "Latar Belakang"
+    ],
+    "scenario": [
+      "Senario",
+      "Situai",
+      "Keadaan"
+    ],
+    "scenarioOutline": [
+      "Template Senario",
+      "Template Situai",
+      "Template Keadaan",
+      "Menggariskan Senario"
+    ],
+    "examples": [
+      "Contoh"
+    ],
+    "given": [
+      "* ",
+      "Diberi ",
+      "Bagi "
+    ],
+    "when": [
+      "* ",
+      "Apabila "
+    ],
+    "then": [
+      "* ",
+      "Maka ",
+      "Kemudian "
+    ],
+    "and": [
+      "* ",
+      "Dan "
+    ],
+    "but": [
+      "* ",
+      "Tetapi ",
+      "Tapi "
+    ]
+  },
+  "bg": {
+    "name": "Bulgarian",
+    "native": "български",
+    "feature": [
+      "Функционалност"
+    ],
+    "background": [
+      "Предистория"
+    ],
+    "scenario": [
+      "Сценарий"
+    ],
+    "scenarioOutline": [
+      "Рамка на сценарий"
+    ],
+    "examples": [
+      "Примери"
+    ],
+    "given": [
+      "* ",
+      "Дадено "
+    ],
+    "when": [
+      "* ",
+      "Когато "
+    ],
+    "then": [
+      "* ",
+      "То "
+    ],
+    "and": [
+      "* ",
+      "И "
+    ],
+    "but": [
+      "* ",
+      "Но "
+    ]
+  },
+  "ca": {
+    "name": "Catalan",
+    "native": "català",
+    "feature": [
+      "Característica",
+      "Funcionalitat"
+    ],
+    "background": [
+      "Rerefons",
+      "Antecedents"
+    ],
+    "scenario": [
+      "Escenari"
+    ],
+    "scenarioOutline": [
+      "Esquema de l'escenari"
+    ],
+    "examples": [
+      "Exemples"
+    ],
+    "given": [
+      "* ",
+      "Donat ",
+      "Donada ",
+      "Atès ",
+      "Atesa "
+    ],
+    "when": [
+      "* ",
+      "Quan "
+    ],
+    "then": [
+      "* ",
+      "Aleshores ",
+      "Cal "
+    ],
+    "and": [
+      "* ",
+      "I "
+    ],
+    "but": [
+      "* ",
+      "Però "
+    ]
+  },
+  "cy-GB": {
+    "name": "Welsh",
+    "native": "Cymraeg",
+    "feature": [
+      "Arwedd"
+    ],
+    "background": [
+      "Cefndir"
+    ],
+    "scenario": [
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Scenario Amlinellol"
+    ],
+    "examples": [
+      "Enghreifftiau"
+    ],
+    "given": [
+      "* ",
+      "Anrhegedig a "
+    ],
+    "when": [
+      "* ",
+      "Pryd "
+    ],
+    "then": [
+      "* ",
+      "Yna "
+    ],
+    "and": [
+      "* ",
+      "A "
+    ],
+    "but": [
+      "* ",
+      "Ond "
+    ]
+  },
+  "cs": {
+    "name": "Czech",
+    "native": "Česky",
+    "feature": [
+      "Požadavek"
+    ],
+    "background": [
+      "Pozadí",
+      "Kontext"
+    ],
+    "scenario": [
+      "Scénář"
+    ],
+    "scenarioOutline": [
+      "Náčrt Scénáře",
+      "Osnova scénáře"
+    ],
+    "examples": [
+      "Příklady"
+    ],
+    "given": [
+      "* ",
+      "Pokud ",
+      "Za předpokladu "
+    ],
+    "when": [
+      "* ",
+      "Když "
+    ],
+    "then": [
+      "* ",
+      "Pak "
+    ],
+    "and": [
+      "* ",
+      "A také ",
+      "A "
+    ],
+    "but": [
+      "* ",
+      "Ale "
+    ]
+  },
+  "da": {
+    "name": "Danish",
+    "native": "dansk",
+    "feature": [
+      "Egenskab"
+    ],
+    "background": [
+      "Baggrund"
+    ],
+    "scenario": [
+      "Scenarie"
+    ],
+    "scenarioOutline": [
+      "Abstrakt Scenario"
+    ],
+    "examples": [
+      "Eksempler"
+    ],
+    "given": [
+      "* ",
+      "Givet "
+    ],
+    "when": [
+      "* ",
+      "Når "
+    ],
+    "then": [
+      "* ",
+      "Så "
+    ],
+    "and": [
+      "* ",
+      "Og "
+    ],
+    "but": [
+      "* ",
+      "Men "
+    ]
+  },
+  "de": {
+    "name": "German",
+    "native": "Deutsch",
+    "feature": [
+      "Funktionalität"
+    ],
+    "background": [
+      "Grundlage"
+    ],
+    "scenario": [
+      "Szenario"
+    ],
+    "scenarioOutline": [
+      "Szenariogrundriss"
+    ],
+    "examples": [
+      "Beispiele"
+    ],
+    "given": [
+      "* ",
+      "Angenommen ",
+      "Gegeben sei ",
+      "Gegeben seien "
+    ],
+    "when": [
+      "* ",
+      "Wenn "
+    ],
+    "then": [
+      "* ",
+      "Dann "
+    ],
+    "and": [
+      "* ",
+      "Und "
+    ],
+    "but": [
+      "* ",
+      "Aber "
+    ]
+  },
+  "el": {
+    "name": "Greek",
+    "native": "Ελληνικά",
+    "feature": [
+      "Δυνατότητα",
+      "Λειτουργία"
+    ],
+    "background": [
+      "Υπόβαθρο"
+    ],
+    "scenario": [
+      "Σενάριο"
+    ],
+    "scenarioOutline": [
+      "Περιγραφή Σεναρίου"
+    ],
+    "examples": [
+      "Παραδείγματα",
+      "Σενάρια"
+    ],
+    "given": [
+      "* ",
+      "Δεδομένου "
+    ],
+    "when": [
+      "* ",
+      "Όταν "
+    ],
+    "then": [
+      "* ",
+      "Τότε "
+    ],
+    "and": [
+      "* ",
+      "Και "
+    ],
+    "but": [
+      "* ",
+      "Αλλά "
+    ]
+  },
+  "en-au": {
+    "name": "Australian",
+    "native": "Australian",
+    "feature": [
+      "Pretty much"
+    ],
+    "background": [
+      "First off"
+    ],
+    "scenario": [
+      "Awww, look mate"
+    ],
+    "scenarioOutline": [
+      "Reckon it's like"
+    ],
+    "examples": [
+      "You'll wanna"
+    ],
+    "given": [
+      "* ",
+      "Y'know "
+    ],
+    "when": [
+      "* ",
+      "It's just unbelievable "
+    ],
+    "then": [
+      "* ",
+      "But at the end of the day I reckon "
+    ],
+    "and": [
+      "* ",
+      "Too right "
+    ],
+    "but": [
+      "* ",
+      "Yeah nah "
+    ]
+  },
+  "en-lol": {
+    "name": "LOLCAT",
+    "native": "LOLCAT",
+    "feature": [
+      "OH HAI"
+    ],
+    "background": [
+      "B4"
+    ],
+    "scenario": [
+      "MISHUN"
+    ],
+    "scenarioOutline": [
+      "MISHUN SRSLY"
+    ],
+    "examples": [
+      "EXAMPLZ"
+    ],
+    "given": [
+      "* ",
+      "I CAN HAZ "
+    ],
+    "when": [
+      "* ",
+      "WEN "
+    ],
+    "then": [
+      "* ",
+      "DEN "
+    ],
+    "and": [
+      "* ",
+      "AN "
+    ],
+    "but": [
+      "* ",
+      "BUT "
+    ]
+  },
+  "en-old": {
+    "name": "Old English",
+    "native": "Englisc",
+    "feature": [
+      "Hwaet",
+      "Hwæt"
+    ],
+    "background": [
+      "Aer",
+      "Ær"
+    ],
+    "scenario": [
+      "Swa"
+    ],
+    "scenarioOutline": [
+      "Swa hwaer swa",
+      "Swa hwær swa"
+    ],
+    "examples": [
+      "Se the",
+      "Se þe",
+      "Se ðe"
+    ],
+    "given": [
+      "* ",
+      "Thurh ",
+      "Þurh ",
+      "Ðurh "
+    ],
+    "when": [
+      "* ",
+      "Tha ",
+      "Þa ",
+      "Ða "
+    ],
+    "then": [
+      "* ",
+      "Tha ",
+      "Þa ",
+      "Ða ",
+      "Tha the ",
+      "Þa þe ",
+      "Ða ðe "
+    ],
+    "and": [
+      "* ",
+      "Ond ",
+      "7 "
+    ],
+    "but": [
+      "* ",
+      "Ac "
+    ]
+  },
+  "en-pirate": {
+    "name": "Pirate",
+    "native": "Pirate",
+    "feature": [
+      "Ahoy matey!"
+    ],
+    "background": [
+      "Yo-ho-ho"
+    ],
+    "scenario": [
+      "Heave to"
+    ],
+    "scenarioOutline": [
+      "Shiver me timbers"
+    ],
+    "examples": [
+      "Dead men tell no tales"
+    ],
+    "given": [
+      "* ",
+      "Gangway! "
+    ],
+    "when": [
+      "* ",
+      "Blimey! "
+    ],
+    "then": [
+      "* ",
+      "Let go and haul "
+    ],
+    "and": [
+      "* ",
+      "Aye "
+    ],
+    "but": [
+      "* ",
+      "Avast! "
+    ]
+  },
+  "en-Scouse": {
+    "name": "Scouse",
+    "native": "Scouse",
+    "feature": [
+      "Feature"
+    ],
+    "background": [
+      "Dis is what went down"
+    ],
+    "scenario": [
+      "The thing of it is"
+    ],
+    "scenarioOutline": [
+      "Wharrimean is"
+    ],
+    "examples": [
+      "Examples"
+    ],
+    "given": [
+      "* ",
+      "Givun ",
+      "Youse know when youse got "
+    ],
+    "when": [
+      "* ",
+      "Wun ",
+      "Youse know like when "
+    ],
+    "then": [
+      "* ",
+      "Dun ",
+      "Den youse gotta "
+    ],
+    "and": [
+      "* ",
+      "An "
+    ],
+    "but": [
+      "* ",
+      "Buh "
+    ]
+  },
+  "en-tx": {
+    "name": "Texan",
+    "native": "Texan",
+    "feature": [
+      "Feature"
+    ],
+    "background": [
+      "Background"
+    ],
+    "scenario": [
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "All y'all"
+    ],
+    "examples": [
+      "Examples"
+    ],
+    "given": [
+      "* ",
+      "Given y'all "
+    ],
+    "when": [
+      "* ",
+      "When y'all "
+    ],
+    "then": [
+      "* ",
+      "Then y'all "
+    ],
+    "and": [
+      "* ",
+      "And y'all "
+    ],
+    "but": [
+      "* ",
+      "But y'all "
+    ]
+  },
+  "eo": {
+    "name": "Esperanto",
+    "native": "Esperanto",
+    "feature": [
+      "Trajto"
+    ],
+    "background": [
+      "Fono"
+    ],
+    "scenario": [
+      "Scenaro"
+    ],
+    "scenarioOutline": [
+      "Konturo de la scenaro"
+    ],
+    "examples": [
+      "Ekzemploj"
+    ],
+    "given": [
+      "* ",
+      "Donitaĵo "
+    ],
+    "when": [
+      "* ",
+      "Se "
+    ],
+    "then": [
+      "* ",
+      "Do "
+    ],
+    "and": [
+      "* ",
+      "Kaj "
+    ],
+    "but": [
+      "* ",
+      "Sed "
+    ]
+  },
+  "es": {
+    "name": "Spanish",
+    "native": "español",
+    "feature": [
+      "Característica"
+    ],
+    "background": [
+      "Antecedentes"
+    ],
+    "scenario": [
+      "Escenario"
+    ],
+    "scenarioOutline": [
+      "Esquema del escenario"
+    ],
+    "examples": [
+      "Ejemplos"
+    ],
+    "given": [
+      "* ",
+      "Dado ",
+      "Dada ",
+      "Dados ",
+      "Dadas "
+    ],
+    "when": [
+      "* ",
+      "Cuando "
+    ],
+    "then": [
+      "* ",
+      "Entonces "
+    ],
+    "and": [
+      "* ",
+      "Y "
+    ],
+    "but": [
+      "* ",
+      "Pero "
+    ]
+  },
+  "et": {
+    "name": "Estonian",
+    "native": "eesti keel",
+    "feature": [
+      "Omadus"
+    ],
+    "background": [
+      "Taust"
+    ],
+    "scenario": [
+      "Stsenaarium"
+    ],
+    "scenarioOutline": [
+      "Raamstsenaarium"
+    ],
+    "examples": [
+      "Juhtumid"
+    ],
+    "given": [
+      "* ",
+      "Eeldades "
+    ],
+    "when": [
+      "* ",
+      "Kui "
+    ],
+    "then": [
+      "* ",
+      "Siis "
+    ],
+    "and": [
+      "* ",
+      "Ja "
+    ],
+    "but": [
+      "* ",
+      "Kuid "
+    ]
+  },
+  "fa": {
+    "name": "Persian",
+    "native": "فارسی",
+    "feature": [
+      "وِیژگی"
+    ],
+    "background": [
+      "زمینه"
+    ],
+    "scenario": [
+      "سناریو"
+    ],
+    "scenarioOutline": [
+      "الگوی سناریو"
+    ],
+    "examples": [
+      "نمونه ها"
+    ],
+    "given": [
+      "* ",
+      "با فرض "
+    ],
+    "when": [
+      "* ",
+      "هنگامی "
+    ],
+    "then": [
+      "* ",
+      "آنگاه "
+    ],
+    "and": [
+      "* ",
+      "و "
+    ],
+    "but": [
+      "* ",
+      "اما "
+    ]
+  },
+  "fi": {
+    "name": "Finnish",
+    "native": "suomi",
+    "feature": [
+      "Ominaisuus"
+    ],
+    "background": [
+      "Tausta"
+    ],
+    "scenario": [
+      "Tapaus"
+    ],
+    "scenarioOutline": [
+      "Tapausaihio"
+    ],
+    "examples": [
+      "Tapaukset"
+    ],
+    "given": [
+      "* ",
+      "Oletetaan "
+    ],
+    "when": [
+      "* ",
+      "Kun "
+    ],
+    "then": [
+      "* ",
+      "Niin "
+    ],
+    "and": [
+      "* ",
+      "Ja "
+    ],
+    "but": [
+      "* ",
+      "Mutta "
+    ]
+  },
+  "fr": {
+    "name": "French",
+    "native": "français",
+    "feature": [
+      "Fonctionnalité"
+    ],
+    "background": [
+      "Contexte"
+    ],
+    "scenario": [
+      "Scénario"
+    ],
+    "scenarioOutline": [
+      "Plan du scénario",
+      "Plan du Scénario"
+    ],
+    "examples": [
+      "Exemples"
+    ],
+    "given": [
+      "* ",
+      "Soit ",
+      "Etant donné ",
+      "Etant donnée ",
+      "Etant donnés ",
+      "Etant données ",
+      "Étant donné ",
+      "Étant donnée ",
+      "Étant donnés ",
+      "Étant données "
+    ],
+    "when": [
+      "* ",
+      "Quand ",
+      "Lorsque ",
+      "Lorsqu'"
+    ],
+    "then": [
+      "* ",
+      "Alors "
+    ],
+    "and": [
+      "* ",
+      "Et "
+    ],
+    "but": [
+      "* ",
+      "Mais "
+    ]
+  },
+  "gl": {
+    "name": "Galician",
+    "native": "galego",
+    "feature": [
+      "Característica"
+    ],
+    "background": [
+      "Contexto"
+    ],
+    "scenario": [
+      "Escenario"
+    ],
+    "scenarioOutline": [
+      "Esbozo do escenario"
+    ],
+    "examples": [
+      "Exemplos"
+    ],
+    "given": [
+      "* ",
+      "Dado ",
+      "Dada ",
+      "Dados ",
+      "Dadas "
+    ],
+    "when": [
+      "* ",
+      "Cando "
+    ],
+    "then": [
+      "* ",
+      "Entón ",
+      "Logo "
+    ],
+    "and": [
+      "* ",
+      "E "
+    ],
+    "but": [
+      "* ",
+      "Mais ",
+      "Pero "
+    ]
+  },
+  "he": {
+    "name": "Hebrew",
+    "native": "עברית",
+    "feature": [
+      "תכונה"
+    ],
+    "background": [
+      "רקע"
+    ],
+    "scenario": [
+      "תרחיש"
+    ],
+    "scenarioOutline": [
+      "תבנית תרחיש"
+    ],
+    "examples": [
+      "דוגמאות"
+    ],
+    "given": [
+      "* ",
+      "בהינתן "
+    ],
+    "when": [
+      "* ",
+      "כאשר "
+    ],
+    "then": [
+      "* ",
+      "אז ",
+      "אזי "
+    ],
+    "and": [
+      "* ",
+      "וגם "
+    ],
+    "but": [
+      "* ",
+      "אבל "
+    ]
+  },
+  "hi": {
+    "name": "Hindi",
+    "native": "हिंदी",
+    "feature": [
+      "रूप लेख"
+    ],
+    "background": [
+      "पृष्ठभूमि"
+    ],
+    "scenario": [
+      "परिदृश्य"
+    ],
+    "scenarioOutline": [
+      "परिदृश्य रूपरेखा"
+    ],
+    "examples": [
+      "उदाहरण"
+    ],
+    "given": [
+      "* ",
+      "अगर ",
+      "यदि ",
+      "चूंकि "
+    ],
+    "when": [
+      "* ",
+      "जब ",
+      "कदा "
+    ],
+    "then": [
+      "* ",
+      "तब ",
+      "तदा "
+    ],
+    "and": [
+      "* ",
+      "और ",
+      "तथा "
+    ],
+    "but": [
+      "* ",
+      "पर ",
+      "परन्तु ",
+      "किन्तु "
+    ]
+  },
+  "hr": {
+    "name": "Croatian",
+    "native": "hrvatski",
+    "feature": [
+      "Osobina",
+      "Mogućnost",
+      "Mogucnost"
+    ],
+    "background": [
+      "Pozadina"
+    ],
+    "scenario": [
+      "Scenarij"
+    ],
+    "scenarioOutline": [
+      "Skica",
+      "Koncept"
+    ],
+    "examples": [
+      "Primjeri",
+      "Scenariji"
+    ],
+    "given": [
+      "* ",
+      "Zadan ",
+      "Zadani ",
+      "Zadano "
+    ],
+    "when": [
+      "* ",
+      "Kada ",
+      "Kad "
+    ],
+    "then": [
+      "* ",
+      "Onda "
+    ],
+    "and": [
+      "* ",
+      "I "
+    ],
+    "but": [
+      "* ",
+      "Ali "
+    ]
+  },
+  "ht": {
+    "name": "Creole",
+    "native": "kreyòl",
+    "feature": [
+      "Karakteristik",
+      "Mak",
+      "Fonksyonalite"
+    ],
+    "background": [
+      "Kontèks",
+      "Istorik"
+    ],
+    "scenario": [
+      "Senaryo"
+    ],
+    "scenarioOutline": [
+      "Plan senaryo",
+      "Plan Senaryo",
+      "Senaryo deskripsyon",
+      "Senaryo Deskripsyon",
+      "Dyagram senaryo",
+      "Dyagram Senaryo"
+    ],
+    "examples": [
+      "Egzanp"
+    ],
+    "given": [
+      "* ",
+      "Sipoze ",
+      "Sipoze ke ",
+      "Sipoze Ke "
+    ],
+    "when": [
+      "* ",
+      "Lè ",
+      "Le "
+    ],
+    "then": [
+      "* ",
+      "Lè sa a ",
+      "Le sa a "
+    ],
+    "and": [
+      "* ",
+      "Ak ",
+      "Epi ",
+      "E "
+    ],
+    "but": [
+      "* ",
+      "Men "
+    ]
+  },
+  "hu": {
+    "name": "Hungarian",
+    "native": "magyar",
+    "feature": [
+      "Jellemző"
+    ],
+    "background": [
+      "Háttér"
+    ],
+    "scenario": [
+      "Forgatókönyv"
+    ],
+    "scenarioOutline": [
+      "Forgatókönyv vázlat"
+    ],
+    "examples": [
+      "Példák"
+    ],
+    "given": [
+      "* ",
+      "Amennyiben ",
+      "Adott "
+    ],
+    "when": [
+      "* ",
+      "Majd ",
+      "Ha ",
+      "Amikor "
+    ],
+    "then": [
+      "* ",
+      "Akkor "
+    ],
+    "and": [
+      "* ",
+      "És "
+    ],
+    "but": [
+      "* ",
+      "De "
+    ]
+  },
+  "id": {
+    "name": "Indonesian",
+    "native": "Bahasa Indonesia",
+    "feature": [
+      "Fitur"
+    ],
+    "background": [
+      "Dasar"
+    ],
+    "scenario": [
+      "Skenario"
+    ],
+    "scenarioOutline": [
+      "Skenario konsep"
+    ],
+    "examples": [
+      "Contoh"
+    ],
+    "given": [
+      "* ",
+      "Dengan "
+    ],
+    "when": [
+      "* ",
+      "Ketika "
+    ],
+    "then": [
+      "* ",
+      "Maka "
+    ],
+    "and": [
+      "* ",
+      "Dan "
+    ],
+    "but": [
+      "* ",
+      "Tapi "
+    ]
+  },
+  "is": {
+    "name": "Icelandic",
+    "native": "Íslenska",
+    "feature": [
+      "Eiginleiki"
+    ],
+    "background": [
+      "Bakgrunnur"
+    ],
+    "scenario": [
+      "Atburðarás"
+    ],
+    "scenarioOutline": [
+      "Lýsing Atburðarásar",
+      "Lýsing Dæma"
+    ],
+    "examples": [
+      "Dæmi",
+      "Atburðarásir"
+    ],
+    "given": [
+      "* ",
+      "Ef "
+    ],
+    "when": [
+      "* ",
+      "Þegar "
+    ],
+    "then": [
+      "* ",
+      "Þá "
+    ],
+    "and": [
+      "* ",
+      "Og "
+    ],
+    "but": [
+      "* ",
+      "En "
+    ]
+  },
+  "it": {
+    "name": "Italian",
+    "native": "italiano",
+    "feature": [
+      "Funzionalità"
+    ],
+    "background": [
+      "Contesto"
+    ],
+    "scenario": [
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Schema dello scenario"
+    ],
+    "examples": [
+      "Esempi"
+    ],
+    "given": [
+      "* ",
+      "Dato ",
+      "Data ",
+      "Dati ",
+      "Date "
+    ],
+    "when": [
+      "* ",
+      "Quando "
+    ],
+    "then": [
+      "* ",
+      "Allora "
+    ],
+    "and": [
+      "* ",
+      "E "
+    ],
+    "but": [
+      "* ",
+      "Ma "
+    ]
+  },
+  "ja": {
+    "name": "Japanese",
+    "native": "日本語",
+    "feature": [
+      "フィーチャ",
+      "機能"
+    ],
+    "background": [
+      "背景"
+    ],
+    "scenario": [
+      "シナリオ"
+    ],
+    "scenarioOutline": [
+      "シナリオアウトライン",
+      "シナリオテンプレート",
+      "テンプレ",
+      "シナリオテンプレ"
+    ],
+    "examples": [
+      "例",
+      "サンプル"
+    ],
+    "given": [
+      "* ",
+      "前提"
+    ],
+    "when": [
+      "* ",
+      "もし"
+    ],
+    "then": [
+      "* ",
+      "ならば"
+    ],
+    "and": [
+      "* ",
+      "かつ"
+    ],
+    "but": [
+      "* ",
+      "しかし",
+      "但し",
+      "ただし"
+    ]
+  },
+  "jv": {
+    "name": "Javanese",
+    "native": "Basa Jawa",
+    "feature": [
+      "Fitur"
+    ],
+    "background": [
+      "Dasar"
+    ],
+    "scenario": [
+      "Skenario"
+    ],
+    "scenarioOutline": [
+      "Konsep skenario"
+    ],
+    "examples": [
+      "Conto",
+      "Contone"
+    ],
+    "given": [
+      "* ",
+      "Nalika ",
+      "Nalikaning "
+    ],
+    "when": [
+      "* ",
+      "Manawa ",
+      "Menawa "
+    ],
+    "then": [
+      "* ",
+      "Njuk ",
+      "Banjur "
+    ],
+    "and": [
+      "* ",
+      "Lan "
+    ],
+    "but": [
+      "* ",
+      "Tapi ",
+      "Nanging ",
+      "Ananging "
+    ]
+  },
+  "kn": {
+    "name": "Kannada",
+    "native": "ಕನ್ನಡ",
+    "feature": [
+      "ಹೆಚ್ಚಳ"
+    ],
+    "background": [
+      "ಹಿನ್ನೆಲೆ"
+    ],
+    "scenario": [
+      "ಕಥಾಸಾರಾಂಶ"
+    ],
+    "scenarioOutline": [
+      "ವಿವರಣೆ"
+    ],
+    "examples": [
+      "ಉದಾಹರಣೆಗಳು"
+    ],
+    "given": [
+      "* ",
+      "ನೀಡಿದ "
+    ],
+    "when": [
+      "* ",
+      "ಸ್ಥಿತಿಯನ್ನು "
+    ],
+    "then": [
+      "* ",
+      "ನಂತರ "
+    ],
+    "and": [
+      "* ",
+      "ಮತ್ತು "
+    ],
+    "but": [
+      "* ",
+      "ಆದರೆ "
+    ]
+  },
+  "ko": {
+    "name": "Korean",
+    "native": "한국어",
+    "feature": [
+      "기능"
+    ],
+    "background": [
+      "배경"
+    ],
+    "scenario": [
+      "시나리오"
+    ],
+    "scenarioOutline": [
+      "시나리오 개요"
+    ],
+    "examples": [
+      "예"
+    ],
+    "given": [
+      "* ",
+      "조건",
+      "먼저"
+    ],
+    "when": [
+      "* ",
+      "만일",
+      "만약"
+    ],
+    "then": [
+      "* ",
+      "그러면"
+    ],
+    "and": [
+      "* ",
+      "그리고"
+    ],
+    "but": [
+      "* ",
+      "하지만",
+      "단"
+    ]
+  },
+  "lt": {
+    "name": "Lithuanian",
+    "native": "lietuvių kalba",
+    "feature": [
+      "Savybė"
+    ],
+    "background": [
+      "Kontekstas"
+    ],
+    "scenario": [
+      "Scenarijus"
+    ],
+    "scenarioOutline": [
+      "Scenarijaus šablonas"
+    ],
+    "examples": [
+      "Pavyzdžiai",
+      "Scenarijai",
+      "Variantai"
+    ],
+    "given": [
+      "* ",
+      "Duota "
+    ],
+    "when": [
+      "* ",
+      "Kai "
+    ],
+    "then": [
+      "* ",
+      "Tada "
+    ],
+    "and": [
+      "* ",
+      "Ir "
+    ],
+    "but": [
+      "* ",
+      "Bet "
+    ]
+  },
+  "lu": {
+    "name": "Luxemburgish",
+    "native": "Lëtzebuergesch",
+    "feature": [
+      "Funktionalitéit"
+    ],
+    "background": [
+      "Hannergrond"
+    ],
+    "scenario": [
+      "Szenario"
+    ],
+    "scenarioOutline": [
+      "Plang vum Szenario"
+    ],
+    "examples": [
+      "Beispiller"
+    ],
+    "given": [
+      "* ",
+      "ugeholl "
+    ],
+    "when": [
+      "* ",
+      "wann "
+    ],
+    "then": [
+      "* ",
+      "dann "
+    ],
+    "and": [
+      "* ",
+      "an ",
+      "a "
+    ],
+    "but": [
+      "* ",
+      "awer ",
+      "mä "
+    ]
+  },
+  "lv": {
+    "name": "Latvian",
+    "native": "latviešu",
+    "feature": [
+      "Funkcionalitāte",
+      "Fīča"
+    ],
+    "background": [
+      "Konteksts",
+      "Situācija"
+    ],
+    "scenario": [
+      "Scenārijs"
+    ],
+    "scenarioOutline": [
+      "Scenārijs pēc parauga"
+    ],
+    "examples": [
+      "Piemēri",
+      "Paraugs"
+    ],
+    "given": [
+      "* ",
+      "Kad "
+    ],
+    "when": [
+      "* ",
+      "Ja "
+    ],
+    "then": [
+      "* ",
+      "Tad "
+    ],
+    "and": [
+      "* ",
+      "Un "
+    ],
+    "but": [
+      "* ",
+      "Bet "
+    ]
+  },
+  "nl": {
+    "name": "Dutch",
+    "native": "Nederlands",
+    "feature": [
+      "Functionaliteit"
+    ],
+    "background": [
+      "Achtergrond"
+    ],
+    "scenario": [
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Abstract Scenario"
+    ],
+    "examples": [
+      "Voorbeelden"
+    ],
+    "given": [
+      "* ",
+      "Gegeven ",
+      "Stel "
+    ],
+    "when": [
+      "* ",
+      "Als "
+    ],
+    "then": [
+      "* ",
+      "Dan "
+    ],
+    "and": [
+      "* ",
+      "En "
+    ],
+    "but": [
+      "* ",
+      "Maar "
+    ]
+  },
+  "no": {
+    "name": "Norwegian",
+    "native": "norsk",
+    "feature": [
+      "Egenskap"
+    ],
+    "background": [
+      "Bakgrunn"
+    ],
+    "scenario": [
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Scenariomal",
+      "Abstrakt Scenario"
+    ],
+    "examples": [
+      "Eksempler"
+    ],
+    "given": [
+      "* ",
+      "Gitt "
+    ],
+    "when": [
+      "* ",
+      "Når "
+    ],
+    "then": [
+      "* ",
+      "Så "
+    ],
+    "and": [
+      "* ",
+      "Og "
+    ],
+    "but": [
+      "* ",
+      "Men "
+    ]
+  },
+  "pa": {
+    "name": "Panjabi",
+    "native": "ਪੰਜਾਬੀ",
+    "feature": [
+      "ਖਾਸੀਅਤ",
+      "ਮੁਹਾਂਦਰਾ",
+      "ਨਕਸ਼ ਨੁਹਾਰ"
+    ],
+    "background": [
+      "ਪਿਛੋਕੜ"
+    ],
+    "scenario": [
+      "ਪਟਕਥਾ"
+    ],
+    "scenarioOutline": [
+      "ਪਟਕਥਾ ਢਾਂਚਾ",
+      "ਪਟਕਥਾ ਰੂਪ ਰੇਖਾ"
+    ],
+    "examples": [
+      "ਉਦਾਹਰਨਾਂ"
+    ],
+    "given": [
+      "* ",
+      "ਜੇਕਰ ",
+      "ਜਿਵੇਂ ਕਿ "
+    ],
+    "when": [
+      "* ",
+      "ਜਦੋਂ "
+    ],
+    "then": [
+      "* ",
+      "ਤਦ "
+    ],
+    "and": [
+      "* ",
+      "ਅਤੇ "
+    ],
+    "but": [
+      "* ",
+      "ਪਰ "
+    ]
+  },
+  "pl": {
+    "name": "Polish",
+    "native": "polski",
+    "feature": [
+      "Właściwość",
+      "Funkcja",
+      "Aspekt",
+      "Potrzeba biznesowa"
+    ],
+    "background": [
+      "Założenia"
+    ],
+    "scenario": [
+      "Scenariusz"
+    ],
+    "scenarioOutline": [
+      "Szablon scenariusza"
+    ],
+    "examples": [
+      "Przykłady"
+    ],
+    "given": [
+      "* ",
+      "Zakładając ",
+      "Mając "
+    ],
+    "when": [
+      "* ",
+      "Jeżeli ",
+      "Jeśli ",
+      "Gdy ",
+      "Kiedy "
+    ],
+    "then": [
+      "* ",
+      "Wtedy "
+    ],
+    "and": [
+      "* ",
+      "Oraz ",
+      "I "
+    ],
+    "but": [
+      "* ",
+      "Ale "
+    ]
+  },
+  "pt": {
+    "name": "Portuguese",
+    "native": "português",
+    "feature": [
+      "Funcionalidade",
+      "Característica",
+      "Caracteristica"
+    ],
+    "background": [
+      "Contexto",
+      "Cenário de Fundo",
+      "Cenario de Fundo",
+      "Fundo"
+    ],
+    "scenario": [
+      "Cenário",
+      "Cenario"
+    ],
+    "scenarioOutline": [
+      "Esquema do Cenário",
+      "Esquema do Cenario",
+      "Delineação do Cenário",
+      "Delineacao do Cenario"
+    ],
+    "examples": [
+      "Exemplos",
+      "Cenários",
+      "Cenarios"
+    ],
+    "given": [
+      "* ",
+      "Dado ",
+      "Dada ",
+      "Dados ",
+      "Dadas "
+    ],
+    "when": [
+      "* ",
+      "Quando "
+    ],
+    "then": [
+      "* ",
+      "Então ",
+      "Entao "
+    ],
+    "and": [
+      "* ",
+      "E "
+    ],
+    "but": [
+      "* ",
+      "Mas "
+    ]
+  },
+  "ro": {
+    "name": "Romanian",
+    "native": "română",
+    "feature": [
+      "Functionalitate",
+      "Funcționalitate",
+      "Funcţionalitate"
+    ],
+    "background": [
+      "Context"
+    ],
+    "scenario": [
+      "Scenariu"
+    ],
+    "scenarioOutline": [
+      "Structura scenariu",
+      "Structură scenariu"
+    ],
+    "examples": [
+      "Exemple"
+    ],
+    "given": [
+      "* ",
+      "Date fiind ",
+      "Dat fiind ",
+      "Dati fiind ",
+      "Dați fiind ",
+      "Daţi fiind "
+    ],
+    "when": [
+      "* ",
+      "Cand ",
+      "Când "
+    ],
+    "then": [
+      "* ",
+      "Atunci "
+    ],
+    "and": [
+      "* ",
+      "Si ",
+      "Și ",
+      "Şi "
+    ],
+    "but": [
+      "* ",
+      "Dar "
+    ]
+  },
+  "ru": {
+    "name": "Russian",
+    "native": "русский",
+    "feature": [
+      "Функция",
+      "Функционал",
+      "Свойство"
+    ],
+    "background": [
+      "Предыстория",
+      "Контекст"
+    ],
+    "scenario": [
+      "Сценарий"
+    ],
+    "scenarioOutline": [
+      "Структура сценария"
+    ],
+    "examples": [
+      "Примеры"
+    ],
+    "given": [
+      "* ",
+      "Допустим ",
+      "Дано ",
+      "Пусть "
+    ],
+    "when": [
+      "* ",
+      "Если ",
+      "Когда "
+    ],
+    "then": [
+      "* ",
+      "То ",
+      "Тогда "
+    ],
+    "and": [
+      "* ",
+      "И ",
+      "К тому же ",
+      "Также "
+    ],
+    "but": [
+      "* ",
+      "Но ",
+      "А "
+    ]
+  },
+  "sv": {
+    "name": "Swedish",
+    "native": "Svenska",
+    "feature": [
+      "Egenskap"
+    ],
+    "background": [
+      "Bakgrund"
+    ],
+    "scenario": [
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Abstrakt Scenario",
+      "Scenariomall"
+    ],
+    "examples": [
+      "Exempel"
+    ],
+    "given": [
+      "* ",
+      "Givet "
+    ],
+    "when": [
+      "* ",
+      "När "
+    ],
+    "then": [
+      "* ",
+      "Så "
+    ],
+    "and": [
+      "* ",
+      "Och "
+    ],
+    "but": [
+      "* ",
+      "Men "
+    ]
+  },
+  "sk": {
+    "name": "Slovak",
+    "native": "Slovensky",
+    "feature": [
+      "Požiadavka",
+      "Funkcia",
+      "Vlastnosť"
+    ],
+    "background": [
+      "Pozadie"
+    ],
+    "scenario": [
+      "Scenár"
+    ],
+    "scenarioOutline": [
+      "Náčrt Scenáru",
+      "Náčrt Scenára",
+      "Osnova Scenára"
+    ],
+    "examples": [
+      "Príklady"
+    ],
+    "given": [
+      "* ",
+      "Pokiaľ ",
+      "Za predpokladu "
+    ],
+    "when": [
+      "* ",
+      "Keď ",
+      "Ak "
+    ],
+    "then": [
+      "* ",
+      "Tak ",
+      "Potom "
+    ],
+    "and": [
+      "* ",
+      "A ",
+      "A tiež ",
+      "A taktiež ",
+      "A zároveň "
+    ],
+    "but": [
+      "* ",
+      "Ale "
+    ]
+  },
+  "sl": {
+    "name": "Slovenian",
+    "native": "Slovenski",
+    "feature": [
+      "Funkcionalnost",
+      "Funkcija",
+      "Možnosti",
+      "Moznosti",
+      "Lastnost",
+      "Značilnost"
+    ],
+    "background": [
+      "Kontekst",
+      "Osnova",
+      "Ozadje"
+    ],
+    "scenario": [
+      "Scenarij",
+      "Primer"
+    ],
+    "scenarioOutline": [
+      "Struktura scenarija",
+      "Skica",
+      "Koncept",
+      "Oris scenarija",
+      "Osnutek"
+    ],
+    "examples": [
+      "Primeri",
+      "Scenariji"
+    ],
+    "given": [
+      "Dano ",
+      "Podano ",
+      "Zaradi ",
+      "Privzeto "
+    ],
+    "when": [
+      "Ko ",
+      "Ce ",
+      "Če ",
+      "Kadar "
+    ],
+    "then": [
+      "Nato ",
+      "Potem ",
+      "Takrat "
+    ],
+    "and": [
+      "In ",
+      "Ter "
+    ],
+    "but": [
+      "Toda ",
+      "Ampak ",
+      "Vendar "
+    ]
+  },
+  "sr-Latn": {
+    "name": "Serbian (Latin)",
+    "native": "Srpski (Latinica)",
+    "feature": [
+      "Funkcionalnost",
+      "Mogućnost",
+      "Mogucnost",
+      "Osobina"
+    ],
+    "background": [
+      "Kontekst",
+      "Osnova",
+      "Pozadina"
+    ],
+    "scenario": [
+      "Scenario",
+      "Primer"
+    ],
+    "scenarioOutline": [
+      "Struktura scenarija",
+      "Skica",
+      "Koncept"
+    ],
+    "examples": [
+      "Primeri",
+      "Scenariji"
+    ],
+    "given": [
+      "* ",
+      "Zadato ",
+      "Zadate ",
+      "Zatati "
+    ],
+    "when": [
+      "* ",
+      "Kada ",
+      "Kad "
+    ],
+    "then": [
+      "* ",
+      "Onda "
+    ],
+    "and": [
+      "* ",
+      "I "
+    ],
+    "but": [
+      "* ",
+      "Ali "
+    ]
+  },
+  "sr-Cyrl": {
+    "name": "Serbian",
+    "native": "Српски",
+    "feature": [
+      "Функционалност",
+      "Могућност",
+      "Особина"
+    ],
+    "background": [
+      "Контекст",
+      "Основа",
+      "Позадина"
+    ],
+    "scenario": [
+      "Сценарио",
+      "Пример"
+    ],
+    "scenarioOutline": [
+      "Структура сценарија",
+      "Скица",
+      "Концепт"
+    ],
+    "examples": [
+      "Примери",
+      "Сценарији"
+    ],
+    "given": [
+      "* ",
+      "Задато ",
+      "Задате ",
+      "Задати "
+    ],
+    "when": [
+      "* ",
+      "Када ",
+      "Кад "
+    ],
+    "then": [
+      "* ",
+      "Онда "
+    ],
+    "and": [
+      "* ",
+      "И "
+    ],
+    "but": [
+      "* ",
+      "Али "
+    ]
+  },
+  "tl": {
+    "name": "Telugu",
+    "native": "తెలుగు",
+    "feature": [
+      "గుణము"
+    ],
+    "background": [
+      "నేపథ్యం"
+    ],
+    "scenario": [
+      "సన్నివేశం"
+    ],
+    "scenarioOutline": [
+      "కథనం"
+    ],
+    "examples": [
+      "ఉదాహరణలు"
+    ],
+    "given": [
+      "* ",
+      "చెప్పబడినది "
+    ],
+    "when": [
+      "* ",
+      "ఈ పరిస్థితిలో "
+    ],
+    "then": [
+      "* ",
+      "అప్పుడు "
+    ],
+    "and": [
+      "* ",
+      "మరియు "
+    ],
+    "but": [
+      "* ",
+      "కాని "
+    ]
+  },
+  "th": {
+    "name": "Thai",
+    "native": "ไทย",
+    "feature": [
+      "โครงหลัก",
+      "ความต้องการทางธุรกิจ",
+      "ความสามารถ"
+    ],
+    "background": [
+      "แนวคิด"
+    ],
+    "scenario": [
+      "เหตุการณ์"
+    ],
+    "scenarioOutline": [
+      "สรุปเหตุการณ์",
+      "โครงสร้างของเหตุการณ์"
+    ],
+    "examples": [
+      "ชุดของตัวอย่าง",
+      "ชุดของเหตุการณ์"
+    ],
+    "given": [
+      "* ",
+      "กำหนดให้ "
+    ],
+    "when": [
+      "* ",
+      "เมื่อ "
+    ],
+    "then": [
+      "* ",
+      "ดังนั้น "
+    ],
+    "and": [
+      "* ",
+      "และ "
+    ],
+    "but": [
+      "* ",
+      "แต่ "
+    ]
+  },
+  "tlh": {
+    "name": "Klingon",
+    "native": "tlhIngan",
+    "feature": [
+      "Qap",
+      "Qu'meH 'ut",
+      "perbogh",
+      "poQbogh malja'",
+      "laH"
+    ],
+    "background": [
+      "mo'"
+    ],
+    "scenario": [
+      "lut"
+    ],
+    "scenarioOutline": [
+      "lut chovnatlh"
+    ],
+    "examples": [
+      "ghantoH",
+      "lutmey"
+    ],
+    "given": [
+      "* ",
+      "ghu' noblu' ",
+      "DaH ghu' bejlu' "
+    ],
+    "when": [
+      "* ",
+      "qaSDI' "
+    ],
+    "then": [
+      "* ",
+      "vaj "
+    ],
+    "and": [
+      "* ",
+      "'ej ",
+      "latlh "
+    ],
+    "but": [
+      "* ",
+      "'ach ",
+      "'a "
+    ]
+  },
+  "tr": {
+    "name": "Turkish",
+    "native": "Türkçe",
+    "feature": [
+      "Özellik"
+    ],
+    "background": [
+      "Geçmiş"
+    ],
+    "scenario": [
+      "Senaryo"
+    ],
+    "scenarioOutline": [
+      "Senaryo taslağı"
+    ],
+    "examples": [
+      "Örnekler"
+    ],
+    "given": [
+      "* ",
+      "Diyelim ki "
+    ],
+    "when": [
+      "* ",
+      "Eğer ki "
+    ],
+    "then": [
+      "* ",
+      "O zaman "
+    ],
+    "and": [
+      "* ",
+      "Ve "
+    ],
+    "but": [
+      "* ",
+      "Fakat ",
+      "Ama "
+    ]
+  },
+  "tt": {
+    "name": "Tatar",
+    "native": "Татарча",
+    "feature": [
+      "Мөмкинлек",
+      "Үзенчәлеклелек"
+    ],
+    "background": [
+      "Кереш"
+    ],
+    "scenario": [
+      "Сценарий"
+    ],
+    "scenarioOutline": [
+      "Сценарийның төзелеше"
+    ],
+    "examples": [
+      "Үрнәкләр",
+      "Мисаллар"
+    ],
+    "given": [
+      "* ",
+      "Әйтик "
+    ],
+    "when": [
+      "* ",
+      "Әгәр "
+    ],
+    "then": [
+      "* ",
+      "Нәтиҗәдә "
+    ],
+    "and": [
+      "* ",
+      "Һәм ",
+      "Вә "
+    ],
+    "but": [
+      "* ",
+      "Ләкин ",
+      "Әмма "
+    ]
+  },
+  "uk": {
+    "name": "Ukrainian",
+    "native": "Українська",
+    "feature": [
+      "Функціонал"
+    ],
+    "background": [
+      "Передумова"
+    ],
+    "scenario": [
+      "Сценарій"
+    ],
+    "scenarioOutline": [
+      "Структура сценарію"
+    ],
+    "examples": [
+      "Приклади"
+    ],
+    "given": [
+      "* ",
+      "Припустимо ",
+      "Припустимо, що ",
+      "Нехай ",
+      "Дано "
+    ],
+    "when": [
+      "* ",
+      "Якщо ",
+      "Коли "
+    ],
+    "then": [
+      "* ",
+      "То ",
+      "Тоді "
+    ],
+    "and": [
+      "* ",
+      "І ",
+      "А також ",
+      "Та "
+    ],
+    "but": [
+      "* ",
+      "Але "
+    ]
+  },
+  "uz": {
+    "name": "Uzbek",
+    "native": "Узбекча",
+    "feature": [
+      "Функционал"
+    ],
+    "background": [
+      "Тарих"
+    ],
+    "scenario": [
+      "Сценарий"
+    ],
+    "scenarioOutline": [
+      "Сценарий структураси"
+    ],
+    "examples": [
+      "Мисоллар"
+    ],
+    "given": [
+      "* ",
+      "Агар "
+    ],
+    "when": [
+      "* ",
+      "Агар "
+    ],
+    "then": [
+      "* ",
+      "Унда "
+    ],
+    "and": [
+      "* ",
+      "Ва "
+    ],
+    "but": [
+      "* ",
+      "Лекин ",
+      "Бирок ",
+      "Аммо "
+    ]
+  },
+  "vi": {
+    "name": "Vietnamese",
+    "native": "Tiếng Việt",
+    "feature": [
+      "Tính năng"
+    ],
+    "background": [
+      "Bối cảnh"
+    ],
+    "scenario": [
+      "Tình huống",
+      "Kịch bản"
+    ],
+    "scenarioOutline": [
+      "Khung tình huống",
+      "Khung kịch bản"
+    ],
+    "examples": [
+      "Dữ liệu"
+    ],
+    "given": [
+      "* ",
+      "Biết ",
+      "Cho "
+    ],
+    "when": [
+      "* ",
+      "Khi "
+    ],
+    "then": [
+      "* ",
+      "Thì "
+    ],
+    "and": [
+      "* ",
+      "Và "
+    ],
+    "but": [
+      "* ",
+      "Nhưng "
+    ]
+  },
+  "zh-CN": {
+    "name": "Chinese simplified",
+    "native": "简体中文",
+    "feature": [
+      "功能"
+    ],
+    "background": [
+      "背景"
+    ],
+    "scenario": [
+      "场景",
+      "剧本"
+    ],
+    "scenarioOutline": [
+      "场景大纲",
+      "剧本大纲"
+    ],
+    "examples": [
+      "例子"
+    ],
+    "given": [
+      "* ",
+      "假如",
+      "假设",
+      "假定"
+    ],
+    "when": [
+      "* ",
+      "当"
+    ],
+    "then": [
+      "* ",
+      "那么"
+    ],
+    "and": [
+      "* ",
+      "而且",
+      "并且",
+      "同时"
+    ],
+    "but": [
+      "* ",
+      "但是"
+    ]
+  },
+  "zh-TW": {
+    "name": "Chinese traditional",
+    "native": "繁體中文",
+    "feature": [
+      "功能"
+    ],
+    "background": [
+      "背景"
+    ],
+    "scenario": [
+      "場景",
+      "劇本"
+    ],
+    "scenarioOutline": [
+      "場景大綱",
+      "劇本大綱"
+    ],
+    "examples": [
+      "例子"
+    ],
+    "given": [
+      "* ",
+      "假如",
+      "假設",
+      "假定"
+    ],
+    "when": [
+      "* ",
+      "當"
+    ],
+    "then": [
+      "* ",
+      "那麼"
+    ],
+    "and": [
+      "* ",
+      "而且",
+      "並且",
+      "同時"
+    ],
+    "but": [
+      "* ",
+      "但是"
+    ]
+  },
+  "ur": {
+    "name": "Urdu",
+    "native": "اردو",
+    "feature": [
+      "صلاحیت",
+      "کاروبار کی ضرورت",
+      "خصوصیت"
+    ],
+    "background": [
+      "پس منظر"
+    ],
+    "scenario": [
+      "منظرنامہ"
+    ],
+    "scenarioOutline": [
+      "منظر نامے کا خاکہ"
+    ],
+    "examples": [
+      "مثالیں"
+    ],
+    "given": [
+      "* ",
+      "اگر ",
+      "بالفرض ",
+      "فرض کیا "
+    ],
+    "when": [
+      "* ",
+      "جب "
+    ],
+    "then": [
+      "* ",
+      "پھر ",
+      "تب "
+    ],
+    "and": [
+      "* ",
+      "اور "
+    ],
+    "but": [
+      "* ",
+      "لیکن "
+    ]
+  }
+};
+var Errors = require('./errors');
+
+module.exports = function TokenMatcher() {
+  var LANGUAGE_PATTERN = /^\s*#\s*language\s*:\s*([a-zA-Z\-_]+)\s*$/;
+  changeDialect('en');
+
+  this.match_TagLine = function match_TagLine(token) {
+    if(token.line.startsWith('@')) {
+      setTokenMatched(token, 'TagLine', null, null, null, token.line.getTags());
+      return true;
     }
+    return false;
   };
 
-  var Errors = require('./errors');
+  this.match_FeatureLine = function match_FeatureLine(token) {
+    return matchTitleLine(token, 'FeatureLine', dialect.feature);
+  };
 
-  module.exports = function TokenMatcher() {
-    var LANGUAGE_PATTERN = /^\s*#\s*language\s*:\s*([a-zA-Z\-_]+)\s*$/;
-    changeDialect('en');
+  this.match_ScenarioLine = function match_ScenarioLine(token) {
+    return matchTitleLine(token, 'ScenarioLine', dialect.scenario);
+  };
 
-    this.match_TagLine = function match_TagLine(token) {
-      if (token.line.startsWith('@')) {
-        setTokenMatched(token, 'TagLine', null, null, null, token.line.getTags());
-        return true;
-      }
-      return false;
-    };
+  this.match_ScenarioOutlineLine = function match_ScenarioOutlineLine(token) {
+    return matchTitleLine(token, 'ScenarioOutlineLine', dialect.scenarioOutline);
+  };
 
-    this.match_FeatureLine = function match_FeatureLine(token) {
-      return matchTitleLine(token, 'FeatureLine', dialect.feature);
-    };
+  this.match_BackgroundLine = function match_BackgroundLine(token) {
+    return matchTitleLine(token, 'BackgroundLine', dialect.background);
+  };
 
-    this.match_ScenarioLine = function match_ScenarioLine(token) {
-      return matchTitleLine(token, 'ScenarioLine', dialect.scenario);
-    };
+  this.match_ExamplesLine = function match_ExamplesLine(token) {
+    return matchTitleLine(token, 'ExamplesLine', dialect.examples);
+  };
 
-    this.match_ScenarioOutlineLine = function match_ScenarioOutlineLine(token) {
-      return matchTitleLine(token, 'ScenarioOutlineLine', dialect.scenarioOutline);
-    };
+  this.match_TableRow = function match_TableRow(token) {
+    if (token.line.startsWith('|')) {
+      // TODO: indent
+      setTokenMatched(token, 'TableRow', null, null, null, token.line.getTableCells());
+      return true;
+    }
+    return false;
+  };
 
-    this.match_BackgroundLine = function match_BackgroundLine(token) {
-      return matchTitleLine(token, 'BackgroundLine', dialect.background);
-    };
+  this.match_Empty = function match_Empty(token) {
+    if (token.line.isEmpty) {
+      setTokenMatched(token, 'Empty', null, null, 0);
+      return true;
+    }
+    return false;
+  };
 
-    this.match_ExamplesLine = function match_ExamplesLine(token) {
-      return matchTitleLine(token, 'ExamplesLine', dialect.examples);
-    };
+  this.match_Comment = function match_Comment(token) {
+    if(token.line.startsWith('#')) {
+      var text = token.line.getLineText(0); //take the entire line, including leading space
+      setTokenMatched(token, 'Comment', text, null, 0);
+      return true;
+    }
+    return false;
+  };
 
-    this.match_TableRow = function match_TableRow(token) {
-      if (token.line.startsWith('|')) {
-        // TODO: indent
-        setTokenMatched(token, 'TableRow', null, null, null, token.line.getTableCells());
-        return true;
-      }
-      return false;
-    };
+  this.match_Language = function match_Language(token) {
+    var match;
+    if(match = token.line.trimmedLineText.match(LANGUAGE_PATTERN)) {
+      newDialectName = match[1];
+      setTokenMatched(token, 'Language', newDialectName);
 
-    this.match_Empty = function match_Empty(token) {
-      if (token.line.isEmpty) {
-        setTokenMatched(token, 'Empty', null, null, 0);
-        return true;
-      }
-      return false;
-    };
+      changeDialect(newDialectName, token.location);
+      return true;
+    }
+    return false;
+  };
 
-    this.match_Comment = function match_Comment(token) {
-      if (token.line.startsWith('#')) {
-        var text = token.line.getLineText(0); //take the entire line, including leading space
-        setTokenMatched(token, 'Comment', text, null, 0);
-        return true;
-      }
-      return false;
-    };
-
-    this.match_Language = function match_Language(token) {
-      var match;
-      if (match = token.line.trimmedLineText.match(LANGUAGE_PATTERN)) {
-        newDialectName = match[1];
-        setTokenMatched(token, 'Language', newDialectName);
-
-        changeDialect(newDialectName, token.location);
-        return true;
-      }
-      return false;
-    };
-
-    function changeDialect(newDialectName, location) {
-      newDialect = dialects[newDialectName];
-      if (!newDialect) {
-        throw Errors.NoSuchLanguageException.create(newDialectName, location);
-      }
-
-      dialectName = newDialectName;
-      dialect = newDialect;
+  function changeDialect(newDialectName, location) {
+    newDialect = dialects[newDialectName];
+    if(!newDialect) {
+      throw Errors.NoSuchLanguageException.create(newDialectName, location);
     }
 
-    var activeDocStringSeparator = null;
-    var indentToRemove = null;
+    dialectName = newDialectName;
+    dialect = newDialect;
+  }
 
-    this.match_DocStringSeparator = function match_DocStringSeparator(token) {
-      return activeDocStringSeparator == null
-        ?
-        // open
+  var activeDocStringSeparator = null;
+  var indentToRemove = null;
+
+  this.match_DocStringSeparator = function match_DocStringSeparator(token) {
+    return activeDocStringSeparator == null
+      ?
+      // open
       _match_DocStringSeparator(token, '"""', true) ||
       _match_DocStringSeparator(token, '```', true)
-        :
-        // close
-        _match_DocStringSeparator(token, activeDocStringSeparator, false);
-    };
-
-    function _match_DocStringSeparator(token, separator, isOpen) {
-      if (token.line.startsWith(separator)) {
-        var contentType = null;
-        if (isOpen) {
-          contentType = token.line.getRestTrimmed(separator.length);
-          activeDocStringSeparator = separator;
-          indentToRemove = token.line.indent;
-        } else {
-          activeDocStringSeparator = null;
-          indentToRemove = 0;
-        }
-
-        // TODO: Use the separator as keyword. That's needed for pretty printing.
-        setTokenMatched(token, 'DocStringSeparator', contentType);
-        return true;
-      }
-      return false;
-    }
-
-    this.match_EOF = function match_EOF(token) {
-      if (token.isEof) {
-        setTokenMatched(token, 'EOF');
-        return true;
-      }
-      return false;
-    };
-
-    this.match_StepLine = function match_StepLine(token) {
-      var keywords = []
-        .concat(dialect.given)
-        .concat(dialect.when)
-        .concat(dialect.then)
-        .concat(dialect.and)
-        .concat(dialect.but);
-      var length = keywords.length;
-      for (var i = 0, keyword; i < length; i++) {
-        var keyword = keywords[i];
-
-        if (token.line.startsWith(keyword)) {
-          var title = token.line.getRestTrimmed(keyword.length);
-          setTokenMatched(token, 'StepLine', title, keyword);
-          return true;
-        }
-      }
-      return false;
-    };
-
-    this.match_Other = function match_Other(token) {
-      var text = token.line.getLineText(indentToRemove); //take the entire line, except removing DocString indents
-      setTokenMatched(token, 'Other', text, null, 0);
-      return true;
-    };
-
-    function matchTitleLine(token, tokenType, keywords) {
-      var length = keywords.length;
-      for (var i = 0, keyword; i < length; i++) {
-        var keyword = keywords[i];
-
-        if (token.line.startsWithTitleKeyword(keyword)) {
-          var title = token.line.getRestTrimmed(keyword.length + ':'.length);
-          setTokenMatched(token, tokenType, title, keyword);
-          return true;
-        }
-      }
-      return false;
-    }
-
-    function setTokenMatched(token, matchedType, text, keyword, indent, items) {
-      token.matchedType = matchedType;
-      token.matchedText = text;
-      token.matchedKeyword = keyword;
-      token.matchedIndent = (typeof indent === 'number') ? indent : (token.line == null ? 0 : token.line.indent);
-      token.matchedItems = items || [];
-
-      token.location.column = token.matchedIndent + 1;
-      token.matchedGherkinDialect = dialectName;
-    }
+      :
+      // close
+      _match_DocStringSeparator(token, activeDocStringSeparator, false);
   };
 
-  return module.exports;
+  function _match_DocStringSeparator(token, separator, isOpen) {
+    if (token.line.startsWith(separator)) {
+      var contentType = null;
+      if (isOpen) {
+        contentType = token.line.getRestTrimmed(separator.length);
+        activeDocStringSeparator = separator;
+        indentToRemove = token.line.indent;
+      } else {
+        activeDocStringSeparator = null;
+        indentToRemove = 0;
+      }
+
+      // TODO: Use the separator as keyword. That's needed for pretty printing.
+      setTokenMatched(token, 'DocStringSeparator', contentType);
+      return true;
+    }
+    return false;
+  }
+
+  this.match_EOF = function match_EOF(token) {
+    if(token.isEof) {
+      setTokenMatched(token, 'EOF');
+      return true;
+    }
+    return false;
+  };
+
+  this.match_StepLine = function match_StepLine(token) {
+    var keywords = []
+      .concat(dialect.given)
+      .concat(dialect.when)
+      .concat(dialect.then)
+      .concat(dialect.and)
+      .concat(dialect.but);
+    var length = keywords.length;
+    for(var i = 0, keyword; i < length; i++) {
+      var keyword = keywords[i];
+
+      if (token.line.startsWith(keyword)) {
+        var title = token.line.getRestTrimmed(keyword.length);
+        setTokenMatched(token, 'StepLine', title, keyword);
+        return true;
+      }
+    }
+    return false;
+  };
+
+  this.match_Other = function match_Other(token) {
+    var text = token.line.getLineText(indentToRemove); //take the entire line, except removing DocString indents
+    setTokenMatched(token, 'Other', text, null, 0);
+    return true;
+  };
+
+  function matchTitleLine(token, tokenType, keywords) {
+    var length = keywords.length;
+    for(var i = 0, keyword; i < length; i++) {
+      var keyword = keywords[i];
+
+      if (token.line.startsWithTitleKeyword(keyword)) {
+        var title = token.line.getRestTrimmed(keyword.length + ':'.length);
+        setTokenMatched(token, tokenType, title, keyword);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function setTokenMatched(token, matchedType, text, keyword, indent, items) {
+    token.matchedType = matchedType;
+    token.matchedText = text;
+    token.matchedKeyword = keyword;
+    token.matchedIndent = (typeof indent === 'number') ? indent : (token.line == null ? 0 : token.line.indent);
+    token.matchedItems = items || [];
+
+    token.location.column = token.matchedIndent + 1;
+    token.matchedGherkinDialect = dialectName;
+  }
+};
+
+return module.exports;
 
 });

--- a/lib/ace/mode/gherkin/token_scanner.js
+++ b/lib/ace/mode/gherkin/token_scanner.js
@@ -1,0 +1,22 @@
+define(function(require,exports,module){
+
+var Token = require('./token');
+var GherkinLine = require('./gherkin_line');
+
+module.exports = function TokenScanner(source) {
+  var lines = source.split(/\r?\n/);
+  if(lines.length > 0 && lines[lines.length-1].trim() == '') {
+    lines.pop();
+  }
+  var lineNumber = 0;
+
+  this.read = function () {
+    var line = lines[lineNumber++];
+    var location = {line: lineNumber, column: 0};
+    return line == null ? new Token(null, location) : new Token(new GherkinLine(line, lineNumber), location);
+  }
+};
+
+return module.exports;
+
+});

--- a/lib/ace/mode/gherkin/token_scanner.js
+++ b/lib/ace/mode/gherkin/token_scanner.js
@@ -1,3 +1,26 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Cucumber Ltd, Gaspar Nagy, TechTalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 define(function(require,exports,module){
 
 var Token = require('./token');

--- a/lib/ace/mode/gherkin_worker.js
+++ b/lib/ace/mode/gherkin_worker.js
@@ -1,0 +1,79 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2015, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+define(function (require, exports, module) {
+  "use strict";
+
+  var oop = require("../lib/oop");
+  var Mirror = require("../worker/mirror").Mirror;
+  var Parser = require("./gherkin/parser");
+  var TokenScanner = require("./gherkin/token_scanner");
+  var ASTBuilder = require("./gherkin/ast_builder");
+  var TokenMatcher = require("./gherkin/token_matcher");
+
+  var GherkinWorker = exports.GherkinWorker = function (sender) {
+    Mirror.call(this, sender);
+    this.setTimeout(200);
+  };
+
+  oop.inherits(GherkinWorker, Mirror);
+
+  (function () {
+
+    this.onUpdate = function () {
+      var value = this.doc.getValue();
+      var errors = [];
+      var gherkinParser = new Parser();
+
+      try {
+        gherkinParser.parse(new TokenScanner(value), new ASTBuilder(), new TokenMatcher());
+        return this.sender.emit("annotate", []);
+      } catch (e) {
+        if (e.name !== 'CompositeParserException') {
+          throw e; // something unexpected happened other than a parse error
+        }
+
+        for (var i = 0; i < e.errors.length; i++) {
+          var error = e.errors[i];
+          // convert to ace gutter annotation
+          errors.push({
+            row: error.location.line - 1, // must be 0 based
+            column: error.location.column,  // must be 0 based
+            text: error.message,  // text to show in tooltip
+            type: "error" //"error"|"warning"|"info"
+          });
+        }
+        this.sender.emit("annotate", errors);
+      }
+    };
+
+  }).call(GherkinWorker.prototype);
+
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "jsdom": "0.2.x",
         "amd-loader": "~0.0.4",
         "dryice": "0.4.11",
+        "glob": "5.0.3",
         "architect-build": "https://github.com/c9/architect-build/tarball/a3bad51808"
     },
     "mappings": {


### PR DESCRIPTION
This makes a slight modification to Makefile.dryince.js so that any licenses sitting alongside specific language parsers under lib/ace/mode/<language> are also copied over to the build folder so that licenses stick with the code they apply to. This was necessary because license comment blocks are stripped from files during the build process.
