### PR TITLE
Make deepCopy work correctly with arrays

### DIFF
--- a/lib/ace/lib/lang.js
+++ b/lib/ace/lib/lang.js
@@ -89,13 +89,24 @@ exports.deepCopy = function (obj) {
         return obj;
     
     var copy = cons();
-    for (var key in obj) {
-        if (typeof obj[key] === "object") {
-            copy[key] = exports.deepCopy(obj[key]);
-        } else {
-            copy[key] = obj[key];
+    if (Array.isArray(obj)) {
+        for (var key = 0; key < obj.length; key++) {
+            if (typeof obj[key] === "object") {
+                copy[key] = exports.deepCopy(obj[key]);
+            } else {
+                copy[key] = obj[key];
+            }
+        }
+    } else {
+        for (var key in obj) {
+            if (typeof obj[key] === "object") {
+                copy[key] = exports.deepCopy(obj[key]);
+            } else {
+                copy[key] = obj[key];
+            }
         }
     }
+
     return copy;
 };
 


### PR DESCRIPTION
When using libraries that extend arrays, lang.deepCopy fails as it tries to copy objects set by those libraries. This is the case for example with Ember 1.11 where, for example, calling: 
```javascript
editor.getSession().setMode("ace/mode/javascript")
```
Fails with the following error:
```
TypeError: this is undefined
Stack trace:
Descriptor@http://localhost:4200/assets/vendor.js:25649:5
exports.deepCopy@http://localhost:8000/src/ace.js:1754:16
exports.deepCopy@http://localhost:8000/src/ace.js:1757:25
this.embedRules@http://localhost:8000/src/ace.js:5258:56
JavaScriptHighlightRules@http://localhost:8000/src/mode-javascript.js:392:1
this.getTokenizer@http://localhost:8000/src/ace.js:5610:60
this.$onChangeMode@http://localhost:8000/src/ace.js:8584:25
this.setMode/<@http://localhost:8000/src/ace.js:8563:17
exports.loadModule@http://localhost:8000/src/ace.js:3613:1
this.setMode@http://localhost:8000/src/ace.js:8552:1
```
This patch makes lang.deepCopy iterate over the array using a normal _for_ loop instead of a _for in_ loop and solves this error.