### PR TITLE
Add getShowGutter and setShowGutter functions to Editor

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -1289,6 +1289,23 @@ var Editor = function(renderer, session) {
     this.getFadeFoldWidgets = function() {
         return this.getOption("fadeFoldWidgets");
     };
+    
+    /**
+    * Returns `true` if the gutter is being shown.
+    * @returns {Boolean}
+    **/
+    this.getShowGutter = function(){
+        return this.getOption("showGutter");
+    };
+
+    /**
+    * Identifies whether you want to show the gutter or not.
+    * @param {Boolean} show Set to `true` to show the gutter
+    *
+    **/
+    this.setShowGutter = function(show){
+        return this.setOption("showGutter", show);
+    };
 
     /**
      * Removes the current selection or one character.


### PR DESCRIPTION
This adds the getShowGutter and setShowGutter functions to the Editor object, they were implemented only in the VirtualRenderer before. I copied these two functions directly from the [virtual_renderer.js code](https://github.com/ajaxorg/ace/blob/4bc34f4eae5a45c00e7e5d94f25ebe7439aa7ce3/lib/ace/virtual_renderer.js#L536-551).

I'm working on a little project which is using Ace, and this would be useful for me since I'd be able to change all Ace settings I need from Editor and wouldn't have to access the renderer.

Please let me know if I should change the code style somehow or put the functions at a different place in the file.
