### PR TITLE
Expose ClipboardEvent in editor paste event

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -920,12 +920,12 @@ var Editor = function(renderer, session) {
      *
      *
      **/
-    this.onPaste = function(text) {
+    this.onPaste = function(text, event) {
         // todo this should change when paste becomes a command
         if (this.$readOnly)
             return;
 
-        var e = {text: text};
+        var e = {text: text, event: event};
         this._signal("paste", e);
         text = e.text;
         if (!this.inMultiSelectMode || this.inVirtualSelectionMode) {

--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -306,7 +306,7 @@ var TextInput = function(parentNode, host) {
         var data = handleClipboardData(e);
         if (typeof data == "string") {
             if (data)
-                host.onPaste(data);
+                host.onPaste(data, e);
             if (useragent.isIE)
                 setTimeout(resetSelection);
             event.preventDefault(e);


### PR DESCRIPTION
This is quite a simple change that would expose the ClipboardEvent to `Editor.on("paste", function(Object e))`

An example handler would be:

```
editor.on('paste', function(e) {
      return console.log(e);
    });
```

Which would output `Object {text: "pasted text", event: ClipboardEvent}` to the console.

The idea behind this is to allow more advanced operations (beyond plain text) on the raw ClipboardEvent before editing the `text` value in the paste event handler. For example, I am currently working on a custom embedded Ace editor, using a custom markdown mode, and would like to allow users to paste images. Using the raw ClipboardEvent I can retrieve the images for processing to the server before modifying `text` to the appropriate value for a markdown image link.

By exposing the raw ClipboardEvent any action can be performed on it, without affecting compatibility with any current usages of the paste event. 

I am quite new to Ace development, but I have updated the only instance I can see where the paste event is raised (using `this._signal("paste", e);`). Please let me know if I have missed anything for PRs (Individual CLA completed).