### PR TITLE
fixes #2480 of original

### DIFF
--- a/lib/ace/layer/text.js
+++ b/lib/ace/layer/text.js
@@ -354,7 +354,7 @@ var Text = function(parentEl) {
             }
         };
 
-        var output = value.replace(replaceReg, replaceFunc);
+        var output = value.replace(replaceReg, replaceFunc).replace(/\]\]>/g, "]]&#62;");
 
         if (!this.$textToken[token.type]) {
             var classes = "ace_" + token.type.replace(/\./g, " ace_");


### PR DESCRIPTION
This will fix #2480.  This solution is meant to be temporary.  The actual bug of why "]]>" corrupts the code output should still be investigated.  This little problem could be a symptom of something more sinister under the hood, particularly with CDATA support for XML and generally with any code sample.

In the meantime this little stop gap works.