### PR TITLE
Add array-of-tables to keygroup markup for toml files.

### DIFF
--- a/lib/ace/mode/toml_highlight_rules.js
+++ b/lib/ace/mode/toml_highlight_rules.js
@@ -59,6 +59,10 @@ var TomlHighlightRules = function() {
         },
         {
             token: ["variable.keygroup.toml"],
+            regex: "(?:^\\s*)(\\[\\[([^\\]]+)\\]\\])"
+        },
+        {
+            token: ["variable.keygroup.toml"],
             regex: "(?:^\\s*)(\\[([^\\]]+)\\])"
         },
         {


### PR DESCRIPTION
The markup for array-of-tables at https://github.com/toml-lang/toml#array-of-tables is
[[ foo ]]

Right now, the last ] isn't part of the markup. Figured making this an explicit token is the most apparent way to fix this.