### PR TITLE
Fix invalid syntax in autoresize.html

### DIFF
--- a/demo/autoresize.html
+++ b/demo/autoresize.html
@@ -49,7 +49,6 @@ require(["ace/ace"], function(ace) {
 
     var editor = ace.edit("editor3");
     editor.setOptions({
-        maxLines: 100,
         autoScrollEditorIntoView: true,
         maxLines: 8
     });


### PR DESCRIPTION
The options literal had a duplicate key.