### PR TITLE
add 'getCurrentTokenPosition()' (closes #2528)

### DIFF
--- a/lib/ace/token_iterator.js
+++ b/lib/ace/token_iterator.js
@@ -143,6 +143,14 @@ var TokenIterator = function(session, initialRow, initialColumn) {
         
         return column;  
     };
+
+    /**
+     * Return the current token position.
+     * @returns {Position}
+     */
+    this.getCurrentTokenPosition = function() {
+        return {row: this.$row, column: this.getCurrentTokenColumn()};
+    };
             
 }).call(TokenIterator.prototype);
 


### PR DESCRIPTION
Just a utility function to reduce boilerplate (as much of Ace's API deals with either `Position`s or `Range`s)