### PR TITLE
Adds hasOwnProperty check for cloned Objects

### DIFF
--- a/lib/ace/lib/lang.js
+++ b/lib/ace/lib/lang.js
@@ -98,7 +98,9 @@ exports.deepCopy = function deepCopy(obj) {
     
     copy = cons();
     for (var key in obj) {
-        copy[key] = deepCopy(obj[key]);
+        if(obj.hasOwnProperty(key)) {
+            copy[key] = deepCopy(obj[key]);
+        }
     }
     return copy;
 };


### PR DESCRIPTION
This is necessary for applications where Object.prototype is extended. In our case we use Ember with native prototype extensions enabled. Without this check, Ember's extensions are copied over and error out in the app.