### PR TITLE
Bug fix: editor cursor positioning on mac off on SQLServer theme

### DIFF
--- a/lib/ace/theme/sqlserver.css
+++ b/lib/ace/theme/sqlserver.css
@@ -1,7 +1,3 @@
-.ace_line {
-    font-family: Consolas;
-}
-
 .ace-sqlserver .ace_gutter {
     background: #ebebeb;
     color: #333;


### PR DESCRIPTION
Currently, the SQL Server theme on Mac is broken because the font is set to Consolas, which is a font that it can't render. The result is a cursor that gets positioned off by a few spaces in the editor. This makes it pretty difficult to type.

I've removed this line and am letting it default to the font-family that's rendered in editor.css.