### PR TITLE
Scroll support for mobile

### DIFF
--- a/lib/ace/ext/whitespace_test.js
+++ b/lib/ace/ext/whitespace_test.js
@@ -33,9 +33,9 @@ module.exports = {
         indent = whitespace.$detectIndentation(s.doc.$lines);
         assert.equal(indent.ch, "\t");
         assert.equal(indent.length, undefined);
-        s.doc.removeInLine(0, 0, 1);
+        s.doc.removeInLine(0, 0, 2);
         
-        s.insert({row: 0, column: 0}, "x\n    y\n");
+        s.insert({row: 0, column: 0}, "x\n    y\n        z\n");
         indent = whitespace.$detectIndentation(s.doc.$lines);
         assert.equal(indent.ch, "\t");
         assert.equal(indent.length, 4);

--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -120,18 +120,18 @@ exports.addTouchMoveListener = function (el, callback) {
         var startx, starty;
         exports.addListener(el, "touchstart", function (e) {
             var touchObj = e.changedTouches[0];
-            startx = parseInt(touchObj.clientX);
-            starty = parseInt(touchObj.clientY);
+            startx = touchObj.clientX;
+            starty = touchObj.clientY;
         });
         exports.addListener(el, "touchmove", function (e) {
             var factor = 1,
             touchObj = e.changedTouches[0];
 
-            e.wheelX = -(parseInt(touchObj.clientX) - startx) / factor;
-            e.wheelY = -(parseInt(touchObj.clientY) - starty) / factor;
+            e.wheelX = -(touchObj.clientX - startx) / factor;
+            e.wheelY = -(touchObj.clientY - starty) / factor;
 
-            startx = parseInt(touchObj.clientX);
-            starty = parseInt(touchObj.clientY);
+            startx = touchObj.clientX)
+            starty = touchObj.clientY;
 
             callback(e);
         });

--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -130,7 +130,7 @@ exports.addTouchMoveListener = function (el, callback) {
             e.wheelX = -(touchObj.clientX - startx) / factor;
             e.wheelY = -(touchObj.clientY - starty) / factor;
 
-            startx = touchObj.clientX)
+            startx = touchObj.clientX;
             starty = touchObj.clientY;
 
             callback(e);

--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -115,6 +115,29 @@ exports.capture = function(el, eventHandler, releaseCaptureHandler) {
     return onMouseUp;
 };
 
+exports.addTouchMoveListener = function (el, callback) {
+    if ("ontouchmove" in el) {
+        var startx, starty;
+        exports.addListener(el, "touchstart", function (e) {
+            var touchObj = e.changedTouches[0];
+            startx = parseInt(touchObj.clientX);
+            starty = parseInt(touchObj.clientY);
+        });
+        exports.addListener(el, "touchmove", function (e) {
+            var factor = 1,
+            touchObj = e.changedTouches[0];
+
+            e.wheelX = -(parseInt(touchObj.clientX) - startx) / factor;
+            e.wheelY = -(parseInt(touchObj.clientY) - starty) / factor;
+
+            startx = parseInt(touchObj.clientX);
+            starty = parseInt(touchObj.clientY);
+
+            callback(e);
+        });
+    } 
+};
+
 exports.addMouseWheelListener = function(el, callback) {
     if ("onmousewheel" in el) {
         exports.addListener(el, "mousewheel", function(e) {

--- a/lib/ace/mouse/default_handlers.js
+++ b/lib/ace/mouse/default_handlers.js
@@ -46,6 +46,7 @@ function DefaultHandlers(mouseHandler) {
     editor.setDefaultHandler("tripleclick", this.onTripleClick.bind(mouseHandler));
     editor.setDefaultHandler("quadclick", this.onQuadClick.bind(mouseHandler));
     editor.setDefaultHandler("mousewheel", this.onMouseWheel.bind(mouseHandler));
+    editor.setDefaultHandler("touchmove", this.onTouchMove.bind(mouseHandler));
 
     var exports = ["select", "startSelect", "selectEnd", "selectAllEnd", "selectByWordsEnd",
         "selectByLinesEnd", "dragWait", "dragWaitEnd", "focusWait"];
@@ -245,6 +246,26 @@ function DefaultHandlers(mouseHandler) {
         var t = ev.domEvent.timeStamp;
         var dt = t - (this.$lastScrollTime||0);
         
+        var editor = this.editor;
+        var isScrolable = editor.renderer.isScrollableBy(ev.wheelX * ev.speed, ev.wheelY * ev.speed);
+        if (isScrolable || dt < 200) {
+            this.$lastScrollTime = t;
+            editor.renderer.scrollBy(ev.wheelX * ev.speed, ev.wheelY * ev.speed);
+            return ev.stop();
+        }
+    };
+    
+    this.onTouchMove = function (ev) {
+        if (ev.getAccelKey())
+            return;
+        if (ev.getShiftKey() && ev.wheelY && !ev.wheelX) {
+            ev.wheelX = ev.wheelY;
+            ev.wheelY = 0;
+        }
+
+        var t = ev.domEvent.timeStamp;
+        var dt = t - (this.$lastScrollTime || 0);
+
         var editor = this.editor;
         var isScrolable = editor.renderer.isScrollableBy(ev.wheelX * ev.speed, ev.wheelY * ev.speed);
         if (isScrolable || dt < 200) {

--- a/lib/ace/mouse/default_handlers.js
+++ b/lib/ace/mouse/default_handlers.js
@@ -256,13 +256,6 @@ function DefaultHandlers(mouseHandler) {
     };
     
     this.onTouchMove = function (ev) {
-        if (ev.getAccelKey())
-            return;
-        if (ev.getShiftKey() && ev.wheelY && !ev.wheelX) {
-            ev.wheelX = ev.wheelY;
-            ev.wheelY = 0;
-        }
-
         var t = ev.domEvent.timeStamp;
         var dt = t - (this.$lastScrollTime || 0);
 

--- a/lib/ace/mouse/mouse_handler.js
+++ b/lib/ace/mouse/mouse_handler.js
@@ -121,6 +121,14 @@ var MouseHandler = function(editor) {
 
         this.editor._emit(name, mouseEvent);
     };
+    
+    this.onTouchMove = function (name, e) {
+        var mouseEvent = new MouseEvent(e, this.editor);
+        mouseEvent.speed = 1;//this.$scrollSpeed * 2;
+        mouseEvent.wheelX = e.wheelX;
+        mouseEvent.wheelY = e.wheelY;
+        this.editor._emit(name, mouseEvent);
+    };
 
     this.setState = function(state) {
         this.state = state;

--- a/lib/ace/mouse/mouse_handler.js
+++ b/lib/ace/mouse/mouse_handler.js
@@ -68,6 +68,7 @@ var MouseHandler = function(editor) {
         }
     }
     event.addMouseWheelListener(editor.container, this.onMouseWheel.bind(this, "mousewheel"));
+    event.addTouchMoveListener(editor.container, this.onTouchMove.bind(this, "touchmove"));
 
     var gutterEl = editor.renderer.$gutter;
     event.addListener(gutterEl, "mousedown", this.onMouseEvent.bind(this, "guttermousedown"));

--- a/lib/ace/test/all_browser.js
+++ b/lib/ace/test/all_browser.js
@@ -21,6 +21,7 @@ var testNames = [
     "ace/editor_navigation_test",
     "ace/editor_text_edit_test",
     "ace/ext/static_highlight_test",
+    "ace/ext/whitespace_test",
     "ace/incremental_search_test",
     "ace/keyboard/emacs_test",
     "ace/keyboard/keybinding_test",


### PR DESCRIPTION
There is an outstanding issue with scroll support on touch devices (one the issues described here: fix: #37 , fix: #403, fix: #1726 ). Added event listeners for touch move and touch start events to scroll appropriately.   