### PR TITLE
fix jshint: prefix typof

### DIFF
--- a/lib/ace/mode/javascript/jshint.js
+++ b/lib/ace/mode/javascript/jshint.js
@@ -4299,7 +4299,11 @@ var JSHINT = (function() {
   prefix("typeof", (function() {
     var p = expression(150);
     this.first = p;
-
+    
+    if (!p) { // 'typeof' followed by nothing? Give up.
+      quit("E041", this.line || 0, this.character || 0);
+    }
+    
     // The `typeof` operator accepts unresolvable references, so the operand
     // may be undefined.
     if (p.identifier) {


### PR DESCRIPTION
Every time I write:
```js
typeof 
```
In `javascript` when worker enabled. I see next error:
```js
Uncaught TypeError: Cannot read property 'identifier' of undefined
```

This error occurs in [jshint](https://github.com/ajaxorg/ace/blob/master/lib/ace/mode/javascript/jshint.js#L4305):
```js
refix("typeof", (function() {
    var p = expression(150);
    this.first = p;
        
    if (p.identifier) { /* p could be undefined */
      p.forgiveUndef = true;
    }
    return this;
  }));
```
Would be great to update jshint this bug [already fixed](https://github.com/jshint/jshint/blob/master/src/jshint.js#L2209) by https://github.com/jshint/jshint/pull/2508.