### PR TITLE
Fix highlighting for Rust comments

### DIFF
--- a/lib/ace/mode/rust_highlight_rules.js
+++ b/lib/ace/mode/rust_highlight_rules.js
@@ -93,7 +93,10 @@ var RustHighlightRules = function() {
            regex: '\\b(?:Self|isize|usize|char|bool|u8|u16|u32|u64|f16|f32|f64|i8|i16|i32|i64|str|option|either|c_float|c_double|c_void|FILE|fpos_t|DIR|dirent|c_char|c_schar|c_uchar|c_short|c_ushort|c_int|c_uint|c_long|c_ulong|size_t|ptrdiff_t|clock_t|time_t|c_longlong|c_ulonglong|intptr_t|uintptr_t|off_t|dev_t|ino_t|pid_t|mode_t|ssize_t)\\b' },
          { token: 'variable.language.source.rust', regex: '\\bself\\b' },
          { token: 'keyword.operator',
-           regex: /[$]|->|--?|\+\+?|==?|<<=|>>=|[<>]=?|[&]{2}|[|]{2}|[$]|[|!&^*\-+%/]=?/ },
+         // `[*/](?![*/])=?` is separated because `//` and `/* */` become comments and must be
+         // guarded against. This states either `*` or `/` may be matched as long as the match
+         // it isn't followed by either of the two. An `=` may be on the end.
+           regex: /\$|[-=]>|[-+%^=!&|<>]=?|[*/](?![*/])=?/ },
          { token : "punctuation.operator", regex : /[?:,;.]/ },
          { token : "paren.lparen", regex : /[\[({]/ },
          { token : "paren.rparen", regex : /[\])}]/ },

--- a/lib/ace/mode/rust_highlight_rules.js
+++ b/lib/ace/mode/rust_highlight_rules.js
@@ -43,7 +43,10 @@ var RustHighlightRules = function() {
 
     this.$rules = { start:
        [ { token: 'variable.other.source.rust',
-           regex: '\'[a-zA-Z_][a-zA-Z0-9_]*[^\\\']' },
+           // `(?![\\\'])` to keep a lifetime name highlighting from continuing one character
+           // past the name. The end `\'` will block this from matching for a character like
+           // `'a'` (it should have character highlighting, not variable highlighting).
+           regex: '\'[a-zA-Z_][a-zA-Z0-9_]*(?![\\\'])' },
          { token: 'string.quoted.single.source.rust',
            regex: "'(?:[^'\\\\]|" + stringEscape + ")'" },
          {

--- a/lib/ace/mode/rust_highlight_rules.js
+++ b/lib/ace/mode/rust_highlight_rules.js
@@ -41,7 +41,7 @@ var RustHighlightRules = function() {
     // regexp must not have capturing parentheses. Use (?:) instead.
     // regexps are ordered -> the first match is used
 
-    this.$rules = { start: 
+    this.$rules = { start:
        [ { token: 'variable.other.source.rust',
            regex: '\'[a-zA-Z_][a-zA-Z0-9_]*[^\\\']' },
          { token: 'string.quoted.single.source.rust',
@@ -96,7 +96,7 @@ var RustHighlightRules = function() {
            regex: /[$]|->|--?|\+\+?|==?|<<=|>>=|[<>]=?|[&]{2}|[|]{2}|[$]|[|!&^*\-+%/]=?/ },
          { token : "punctuation.operator", regex : /[?:,;.]/ },
          { token : "paren.lparen", regex : /[\[({]/ },
-         { token : "paren.rparen", regex : /[\])}]/ }, 
+         { token : "paren.rparen", regex : /[\])}]/ },
          { token: 'constant.language.source.rust',
            regex: '\\b(?:true|false|Some|None|Ok|Err)\\b' },
          { token: 'support.constant.source.rust',


### PR DESCRIPTION
The [recent](https://github.com/ajaxorg/ace/pull/2586) regex change for Rust now has comments using keyword syntax highlighting. I'm not sure why [playpen](play.rust-lang.org) still works properly but neither [rustbyexample.com](http://rustbyexample.com/) or the [kitchen sink demo](http://ace.c9.io/build/kitchen-sink.html) do comments correctly anymore.

These are basically the operators Rust uses:
```rust
$
=>
->

- -=
+ +=
% %=
^ ^=
= ==
! !=

* *=
/ /=

& &= &&
| |= ||
> >= >> >>=
< <= << <<=
```

`*/` are treated separately because they interfere with `//` and `/* */` commenting. Ideally they'd be grouped into those 4 groups but without capturing (which the file says not to use) and both forward and reverse look-around (see [look-around assertions](http://perldoc.perl.org/perlre.html#Extended-Patterns)), guarding against false positives such as `++` and `%%=` (and `+++--%%%`) is problematic. So I ignored it and grouped them together.

Lifetime annotation (`struct <'a> Name(&'a i32)`) doesn't currently highlight correctly anywhere. The right `>` will be highlighted because it's one character past the end of the name. This just changes it to look-ahead so the next character isn't matched (I'm not sure why it avoid a `\` so I didn't change it).

This may need tests or something but I didn't look at them. I just tried modifying the local `mode-rust.js` file the playpen was using while I tried to fix it.

cc @bluss because you seemed interested in the previous regex change here

[EDIT] Forgot about `>>=` and `<<=` so I added them to the character list.