### PR TITLE
fix code block syntax highlighting for adjacent code blocks

### DIFF
--- a/lib/ace/mode/_test/tokens_markdown.json
+++ b/lib/ace/mode/_test/tokens_markdown.json
@@ -110,5 +110,5 @@
 ],[
    "allowBlock"
 ],[
-   "start"
+   "allowBlock"
 ]]

--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -136,6 +136,7 @@ var MarkdownHighlightRules = function() {
         // code block
         "allowBlock": [
             {token : "support.function", regex : "^ {4}.+", next : "allowBlock"},
+            {token : "empty_line", regex : '^$', next: "allowBlock"},
             {token : "empty", regex : "", next : "start"}
         ],
 


### PR DESCRIPTION
If two code blocks are separated by an empty line the second block
is not highlighted as code.  This little change fixes that problem.

Closes #1845 