### PR TITLE
Update scroller height along with content

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -840,6 +840,7 @@ var VirtualRenderer = function(container, theme) {
             this.content.style.marginTop = (-config.offset) + "px";
             this.content.style.width = config.width + 2 * this.$padding + "px";
             this.content.style.height = config.minHeight + "px";
+            this.scroller.style.height = config.minHeight + "px";
         }
         
         // horizontal scrolling


### PR DESCRIPTION
I have 

$(window).resize(function() {
    //calculate new height for ace_editor to fit page
    editor.height(new_height);
    ace_editor.resize()
})

When I open the developer console, the editor shrinks correctly. But when I then close the developer console, the content grows, but the scroller stays small, so it looks like the editor contents are cut off.

![01_initial_page_load](https://cloud.githubusercontent.com/assets/11790423/9123786/a98db950-3c46-11e5-9483-1895df14ff3a.png)
![02_open_console](https://cloud.githubusercontent.com/assets/11790423/9123787/a99abee8-3c46-11e5-967e-4352b1575eb7.png)
![03_close_console](https://cloud.githubusercontent.com/assets/11790423/9123788/a99a9468-3c46-11e5-96de-35e06fd2350c.png)

