### PR TITLE
Praat

### DIFF
--- a/demo/kitchen-sink/docs/praat.praat
+++ b/demo/kitchen-sink/docs/praat.praat
@@ -142,7 +142,14 @@ procedure oldStyle .str1$ .num .str2$
   .local = 1
 endproc
 
-# New-style procedure declaration
+# New-style procedure declaration with parentheses
 procedure newStyle (.str1$, .num, .str2$)
-  .local = 1
+  # Command with "local" variable
+  .local = Get total duration
+endproc
+
+# New-style procedure declaration with colon
+procedure newStyle: .str1$, .num, .str2$
+  # Command with "local" variable
+  newStyle.local = Get total duration
 endproc

--- a/lib/ace/mode/praat_highlight_rules.js
+++ b/lib/ace/mode/praat_highlight_rules.js
@@ -113,11 +113,11 @@ var PraatHighlightRules = function() {
             {
             // Interpolated strings
                 token : "string.interpolated",
-                regex : /'((?:[a-z][a-zA-Z0-9_]*)(?:\$|#|:[0-9]+)?)'/
+                regex : /'((?:.?[a-z][a-zA-Z0-9_.]*)(?:\$|#|:[0-9]+)?)'/
             }, {
             // stopwatch
                 token : ["text", "text", "keyword.operator", "text", "keyword"],
-                regex : /(^\s*)(?:([a-z][a-zA-Z0-9_]*\$?\s+)(=)(\s+))?(stopwatch)/
+                regex : /(^\s*)(?:(.?[a-z][a-zA-Z0-9_.]*\$?\s+)(=)(\s+))?(stopwatch)/
             }, {
             // Directives which introduce unquoted strings
                 token : ["text", "keyword", "text", "string"],
@@ -133,7 +133,11 @@ var PraatHighlightRules = function() {
             }, {
             // Commands
                 token : ["text", "text", "keyword.operator", "text", "keyword", "text", "keyword"],
-                regex : /(^\s*)(?:([a-z][a-zA-Z0-9_]*\$?\s+)(=)(\s+))?(?:((?:no)?warn|(?:unix_)?nocheck|noprogress)(\s+))?((?:[A-Z][^.:"]+)(?:$|(?:\.{3}|:)))/
+                regex : /(^\s*)(?:(.?[a-z][a-zA-Z0-9_.]*\$?\s+)(=)(\s+))?(?:((?:no)?warn|(?:unix_)?nocheck|noprogress)(\s+))?((?:[A-Z][^.:"]+)(?:$|(?:\.{3}|:)))/
+            }, {
+            // Editor mode
+                token : ["text", "keyword", "text", "keyword"],
+                regex : /(^\s*)((?:no(?:warn|check))?)(\s*)(\b(?:editor(?::?)|endeditor)\b)/
             }, {
             // Demo commands
                 token : ["text", "keyword", "text", "keyword"],
@@ -188,7 +192,7 @@ var PraatHighlightRules = function() {
             }, {
             // Procedure declarations
                 token : ["keyword", "text", "entity.name.function"],
-                regex : /(procedure)(\s+)(\S+)/
+                regex : /(procedure)(\s+)([^:\s]+)/
             }, {
             // New-style procedure calls
                 token : ["entity.name.function", "text"],

--- a/lib/ace/mode/praat_highlight_rules.js
+++ b/lib/ace/mode/praat_highlight_rules.js
@@ -113,11 +113,11 @@ var PraatHighlightRules = function() {
             {
             // Interpolated strings
                 token : "string.interpolated",
-                regex : /'((?:.?[a-z][a-zA-Z0-9_.]*)(?:\$|#|:[0-9]+)?)'/
+                regex : /'((?:\.?[a-z][a-zA-Z0-9_.]*)(?:\$|#|:[0-9]+)?)'/
             }, {
             // stopwatch
                 token : ["text", "text", "keyword.operator", "text", "keyword"],
-                regex : /(^\s*)(?:(.?[a-z][a-zA-Z0-9_.]*\$?\s+)(=)(\s+))?(stopwatch)/
+                regex : /(^\s*)(?:(\.?[a-z][a-zA-Z0-9_.]*\$?\s+)(=)(\s+))?(stopwatch)/
             }, {
             // Directives which introduce unquoted strings
                 token : ["text", "keyword", "text", "string"],
@@ -133,7 +133,7 @@ var PraatHighlightRules = function() {
             }, {
             // Commands
                 token : ["text", "text", "keyword.operator", "text", "keyword", "text", "keyword"],
-                regex : /(^\s*)(?:(.?[a-z][a-zA-Z0-9_.]*\$?\s+)(=)(\s+))?(?:((?:no)?warn|(?:unix_)?nocheck|noprogress)(\s+))?((?:[A-Z][^.:"]+)(?:$|(?:\.{3}|:)))/
+                regex : /(^\s*)(?:(\.?[a-z][a-zA-Z0-9_.]*\$?\s+)(=)(\s+))?(?:((?:no)?warn|(?:unix_)?nocheck|noprogress)(\s+))?((?:[A-Z][^.:"]+)(?:$|(?:\.{3}|:)))/
             }, {
             // Editor mode
                 token : ["text", "keyword", "text", "keyword"],


### PR DESCRIPTION
Commands that follow "local" variables (variables with dots in their names) were not correctly identified. Editor-mode commands were also not properly recognised when following directives.

This pull request fixes both of those problems, and adds some test conditions to the demo file.
