### PR TITLE
Update jade_highlight_rules.js

### DIFF
--- a/lib/ace/mode/jade_highlight_rules.js
+++ b/lib/ace/mode/jade_highlight_rules.js
@@ -138,7 +138,7 @@ var JadeHighlightRules = function() {
         // Match any tag, id or class. skip AST filters
         {
             token: "meta.tag.any.jade",
-            regex: /^\s*(?!\w+\:)(?:[\w]+|(?=\.|#)])/,
+            regex: /^\s*(?!\w+\:)(?:[\w-]+|(?=\.|#)])/,
             next: "tag_single"
         },
         {


### PR DESCRIPTION
The jade syntax highlighting was missing support for hyphenated tags. This change should fix that.