### PR TITLE
Fixed a crash in vim.

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -154,19 +154,21 @@ define(function(require, exports, module) {
     return this.ace.inVirtualSelectionMode && this.ace.selection.index;
   };
   this.onChange = function(delta) {
-    if (delta.action[0] == 'i') {
-      var change = { text: delta.lines };
-      var curOp = this.curOp = this.curOp || {};
-      if (!curOp.changeHandlers)
-        curOp.changeHandlers = this._eventRegistry["change"] && this._eventRegistry["change"].slice();
-      if (this.virtualSelectionMode()) return;
-      if (!curOp.lastChange) {
-        curOp.lastChange = curOp.change = change;
-      } else {
-        curOp.lastChange.next = curOp.lastChange = change;
+    if (typeof delta.action === 'string' && delta.action.length > 0) {
+      if (delta.action[0] == 'i') {
+        var change = { text: delta.lines };
+        var curOp = this.curOp = this.curOp || {};
+        if (!curOp.changeHandlers)
+          curOp.changeHandlers = this._eventRegistry["change"] && this._eventRegistry["change"].slice();
+        if (this.virtualSelectionMode()) return;
+        if (!curOp.lastChange) {
+          curOp.lastChange = curOp.change = change;
+        } else {
+          curOp.lastChange.next = curOp.lastChange = change;
+        }
       }
+      this.$updateMarkers(delta);
     }
-    this.$updateMarkers(delta);
   };
   this.onSelectionChange = function() {
     var curOp = this.curOp = this.curOp || {};


### PR DESCRIPTION
This happens when I use the 'o' command. This commit fixes it.

```
Uncaught TypeError: Cannot read property '0' of undefined
onChange @ keybinding-vim.js:122
ace.define.EventEmitter._signal @ jsoneditor.js:10342
ace.define.onDocumentChange @ jsoneditor.js:18509
ace.define.EventEmitter._signal @ jsoneditor.js:10342
ace.define.onChange @ jsoneditor.js:15192
ace.define.EventEmitter._signal @ jsoneditor.js:10342
ace.define.insertNewLine @ jsoneditor.js:13239
ace.define.insert @ jsoneditor.js:13189
ace.define.insert @ jsoneditor.js:15706
ace.define.insert @ jsoneditor.js:18724
CodeMirror.commands.newlineAndIndent @ keybinding-vim.js:61
actions.newLineAndEnterInsertMode @ keybinding-vim.js:2888
commandDispatcher.processAction @ keybinding-vim.js:1825
commandDispatcher.processCommand @ keybinding-vim.js:1751
(anonymous function) @ keybinding-vim.js:1507
operation @ keybinding-vim.js:148
vimApi.findKey @ keybinding-vim.js:1501
vimApi.handleKey @ keybinding-vim.js:1401
(anonymous function) @ keybinding-vim.js:5281
operation @ keybinding-vim.js:162
Vim.handleKey @ keybinding-vim.js:5280
multiSelectHandleKey @ keybinding-vim.js:5315
exports.handler.handleKeyboard @ keybinding-vim.js:5394
ace.define.$callKeyboardHandlers @ jsoneditor.js:10988
ace.define.onTextInput @ jsoneditor.js:11015
ace.define.onTextInput @ jsoneditor.js:18750
ace.define.sendText @ jsoneditor.js:9097
ace.define.onInput @ jsoneditor.js:9106
```