### PR TITLE
Avoiding $highlightRules null on xml mode

### DIFF
--- a/lib/ace/mode/text.js
+++ b/lib/ace/mode/text.js
@@ -364,7 +364,7 @@ var Mode = function() {
     this.$createKeywordList = function() {
         if (!this.$highlightRules)
             this.getTokenizer();
-        return this.$keywordList = this.$highlightRules.$keywordList || [];
+        return this.$keywordList = this.$highlightRules?this.$highlightRules.$keywordList:[] || [];
     };
 
     this.getCompletions = function(state, session, pos, prefix) {


### PR DESCRIPTION
When editing xml files, we have this.$highlightRules = null