### PR TITLE
iSearch quits on unrecognized keys (closes #2691)

### DIFF
--- a/lib/ace/commands/incremental_search_commands.js
+++ b/lib/ace/commands/incremental_search_commands.js
@@ -175,7 +175,8 @@ oop.inherits(IncrementalSearchKeyboardHandler, HashHandler);
         var iSearch = this.$iSearch;
         HashHandler.call(this, exports.iSearchCommands, editor.commands.platform);
         this.$commandExecHandler = editor.commands.addEventListener('exec', function(e) {
-            if (!e.command.isIncrementalSearchCommand) return undefined;
+            if (!e.command.isIncrementalSearchCommand)
+                return iSearch.deactivate();
             e.stopPropagation();
             e.preventDefault();
             var scrollTop = editor.session.getScrollTop();
@@ -202,7 +203,7 @@ oop.inherits(IncrementalSearchKeyboardHandler, HashHandler);
             var extendCmd = this.commands.extendSearchTerm;
             if (extendCmd) { return {command: extendCmd, args: key}; }
         }
-        return {command: "null", passEvent: hashId == 0 || hashId == 4};
+        return false;
     };
 
 }).call(IncrementalSearchKeyboardHandler.prototype);


### PR DESCRIPTION
Based on suggested code in #2691.

Note the one extra change to the return value of `handleKeyboard` -- this was necessary to ensure that the handler was actually able to see these commands, and they weren't silently 'consumed' -- I don't yet understand why this is the case but can you sanity check whether this is the appropriate solution?