### PR TITLE
Fix for tests crashing on node 0.12 and higher.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "mime": "1.2.x"
     },
     "devDependencies": {
-        "asyncjs": "0.0.x",
+        "asyncjs": "fjakobs/async.js",
         "node-jsdom": "3.1.5",
         "amd-loader": "~0.0.4",
         "dryice": "0.4.11",


### PR DESCRIPTION
A possible fix for tests failing to run on node 0.12 and higher due to deprecated path.exists function being removed. Ideally the author of asyncjs will publish the changes in master to NPM in a new patch release but pointing to master via package.json also works to get those fixes. Fixes #2722 