### PR TITLE
Update travis ci settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 # Project files that should not be in the repo
 .*
 \#*
-!/.gitignore
 .*.gz
 *.tmTheme.js
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Project files that should not be in the repo
 .*
 \#*
+!/.gitignore
 .*.gz
 *.tmTheme.js
 

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,11 @@
 language: node_js
+
+node_js:
+  - "4"
+  - "0.12"
+  - "0.10"
+
+matrix:
+  fast_finish: true
+
+sudo: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,31 @@
+/*jshint node:true */
+module.exports = function ( grunt ) {
+	grunt.loadNpmTasks( 'grunt-contrib-jshint' );
+	grunt.loadNpmTasks( 'grunt-jsonlint' );
+	grunt.loadNpmTasks( 'grunt-jscs' );
+
+	grunt.initConfig( {
+		jshint: {
+			options: {
+				jshintrc: true
+			},
+			all: [
+				'*.js',
+				'**/*.js',
+				'!node_modules/**'
+			]
+		},
+		jscs: {
+			src: '<%= jshint.all %>'
+		},
+		jsonlint: {
+			all: [
+				'**/*.json',
+				'!node_modules/**'
+			]
+		}
+	} );
+
+	grunt.registerTask( 'test', [ 'jshint', 'jscs', 'jsonlint' ] );
+	grunt.registerTask( 'default', 'test' );
+};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,6 @@
 module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( 'grunt-contrib-jshint' );
 	grunt.loadNpmTasks( 'grunt-jsonlint' );
-	grunt.loadNpmTasks( 'grunt-jscs' );
 
 	grunt.initConfig( {
 		jshint: {
@@ -14,9 +13,6 @@ module.exports = function ( grunt ) {
 				'**/*.js',
 				'!node_modules/**'
 			]
-		},
-		jscs: {
-			src: '<%= jshint.all %>'
 		},
 		jsonlint: {
 			all: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,6 @@ module.exports = function ( grunt ) {
 		}
 	} );
 
-	grunt.registerTask( 'test', [ 'jshint', 'jscs', 'jsonlint' ] );
+	grunt.registerTask( 'test', [ 'jshint', 'jsonlint' ] );
 	grunt.registerTask( 'default', 'test' );
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,12 @@
         "node-jsdom": "3.1.5",
         "amd-loader": "~0.0.4",
         "dryice": "0.4.11",
-        "architect-build": "https://github.com/c9/architect-build/tarball/17268dce65"
+        "architect-build": "https://github.com/c9/architect-build/tarball/17268dce65".
+        "grunt": "0.4.5",
+        "grunt-cli": "0.1.13",
+        "grunt-contrib-jshint": "0.11.3",
+        "grunt-jscs": "2.1.0",
+        "grunt-jsonlint": "1.0.5"
     },
     "mappings": {
         "ace": "."

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "node-jsdom": "3.1.5",
         "amd-loader": "~0.0.4",
         "dryice": "0.4.11",
-        "architect-build": "https://github.com/c9/architect-build/tarball/17268dce65".
+        "architect-build": "https://github.com/c9/architect-build/tarball/17268dce65",
         "grunt": "0.4.5",
         "grunt-cli": "0.1.13",
         "grunt-contrib-jshint": "0.11.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "grunt": "0.4.5",
         "grunt-cli": "0.1.13",
         "grunt-contrib-jshint": "0.11.3",
-        "grunt-jscs": "2.1.0",
         "grunt-jsonlint": "1.0.5"
     },
     "mappings": {


### PR DESCRIPTION
Add support for running on travis ci new server and make tests run faster by setting sudo: false.

Also set node_js: so that it knows which version to install and test against.
