### PR TITLE
fix setSession not removing changeFold listener

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -291,7 +291,7 @@ var Editor = function(renderer, session) {
             this.session.removeEventListener("changeTabSize", this.$onChangeTabSize);
             this.session.removeEventListener("changeWrapLimit", this.$onChangeWrapLimit);
             this.session.removeEventListener("changeWrapMode", this.$onChangeWrapMode);
-            this.session.removeEventListener("onChangeFold", this.$onChangeFold);
+            this.session.removeEventListener("changeFold", this.$onChangeFold);
             this.session.removeEventListener("changeFrontMarker", this.$onChangeFrontMarker);
             this.session.removeEventListener("changeBackMarker", this.$onChangeBackMarker);
             this.session.removeEventListener("changeBreakpoint", this.$onChangeBreakpoint);


### PR DESCRIPTION
When reusing an editor instance and switching sessions if a fold is created in the first session, then that session is later restored the session is still listening to changeFold because `removeEventListener('onChangeFold')` doesn't match `changeFold`.

```
Uncaught TypeError: Cannot read property 'isMultiLine' of null
```