### PR TITLE
Preliminary support for theme and mode data-attributes

### DIFF
--- a/lib/ace/ace.js
+++ b/lib/ace/ace.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -71,7 +71,7 @@ exports.require = require;
  * @param {String | DOMElement} el Either the id of an element, or the element itself
  *
  **/
-exports.edit = function(el) {
+exports.edit = function(el, options) {
     if (typeof(el) == "string") {
         var _id = el;
         el = document.getElementById(_id);
@@ -93,10 +93,25 @@ exports.edit = function(el) {
         el.innerHTML = '';
     }
 
+    if (!options) {
+        options = el.dataset;
+    } else {
+        var temp = options;
+        // Options in the options parameter will override dataset options
+        options = el.dataset;
+        for (var key in temp) {
+            options[key] = temp[key];
+        }
+    }
+
     var doc = exports.createEditSession(value);
 
-    var editor = new Editor(new Renderer(el));
+    var renderer = new Renderer(el);
+    var editor = new Editor(renderer);
+    doc.setUserOptions(options);
+    editor.setUserOptions(options);
     editor.setSession(doc);
+    renderer.setUserOptions(options);
 
     var env = {
         document: doc,
@@ -117,7 +132,7 @@ exports.edit = function(el) {
  * Creates a new [[EditSession]], and returns the associated [[Document]].
  * @param {Document | String} text {:textParam}
  * @param {TextMode} mode {:modeParam}
- * 
+ *
  **/
 exports.createEditSession = function(text, mode) {
     var doc = new EditSession(text, mode);

--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -140,6 +140,7 @@ var SearchHighlight = require("./search_highlight").SearchHighlight;
  **/
 
 var EditSession = function(text, mode) {
+
     this.$breakpoints = [];
     this.$decorations = [];
     this.$frontMarkers = {};
@@ -169,6 +170,24 @@ var EditSession = function(text, mode) {
 (function() {
 
     oop.implement(this, EventEmitter);
+
+    /**
+     * Update the `EditSession` options with a list of options passed by the user
+     * @param {Object} options An object with key, value options
+     *
+     **/
+     this.setUserOptions = function(options) {
+        if (options.mode) {
+            this.setMode(options.mode);
+        }
+        var settable = ["tabSize", "useSoftTabs"];
+        for (var i = 0; i < settable.length; i++) {
+            var key = settable[i];
+            if (options[key]) {
+                this.setOption(key, options[key]);
+            }
+        }
+     };
 
     /**
      * Sets the `EditSession` to point to a new `Document`. If a `BackgroundTokenizer` exists, it also points to `doc`.
@@ -420,7 +439,7 @@ var EditSession = function(text, mode) {
         if (this.$syncInformUndoManager)
             this.$syncInformUndoManager();
     };
-    
+
     this.$defaultUndoManager = {
         undo: function() {},
         redo: function() {},
@@ -899,7 +918,7 @@ var EditSession = function(text, mode) {
     this.$onChangeMode = function(mode, $isPlaceholder) {
         if (!$isPlaceholder)
             this.$modeId = mode.$id;
-        if (this.$mode === mode) 
+        if (this.$mode === mode)
             return;
 
         this.$mode = mode;
@@ -931,7 +950,7 @@ var EditSession = function(text, mode) {
         this.tokenRe = mode.tokenRe;
         this.nonTokenRe = mode.nonTokenRe;
 
-        
+
         if (!$isPlaceholder) {
             // experimental method, used by c9 findiniles
             if (mode.attachToSession)
@@ -974,7 +993,7 @@ var EditSession = function(text, mode) {
      *
      **/
     this.setScrollTop = function(scrollTop) {
-        // TODO: should we force integer lineheight instead? scrollTop = Math.round(scrollTop); 
+        // TODO: should we force integer lineheight instead? scrollTop = Math.round(scrollTop);
         if (this.$scrollTop === scrollTop || isNaN(scrollTop))
             return;
 
@@ -1017,11 +1036,11 @@ var EditSession = function(text, mode) {
      **/
     this.getScreenWidth = function() {
         this.$computeWidth();
-        if (this.lineWidgets) 
+        if (this.lineWidgets)
             return Math.max(this.getLineWidgetMaxWidth(), this.screenWidth);
         return this.screenWidth;
     };
-    
+
     this.getLineWidgetMaxWidth = function() {
         if (this.lineWidgetsWidth != null) return this.lineWidgetsWidth;
         var width = 0;
@@ -1129,7 +1148,7 @@ var EditSession = function(text, mode) {
     this.remove = function(range) {
         return this.doc.remove(range);
     };
-    
+
     /**
      * Removes a range of full lines. This method also triggers the `'change'` event.
      * @param {Number} firstRow The first row to be removed
@@ -1408,7 +1427,7 @@ var EditSession = function(text, mode) {
             x.end.row += diff;
             return x;
         });
-        
+
         var lines = dir == 0
             ? this.doc.getLines(firstRow, lastRow)
             : this.doc.removeFullLines(firstRow, lastRow);
@@ -1607,7 +1626,7 @@ var EditSession = function(text, mode) {
     this.getWrapLimit = function() {
         return this.$wrapLimit;
     };
-    
+
     /**
      * Sets the line length for soft wrap in the editor. Lines will break
      *  at a minimum of the given length minus 20 chars and at a maximum
@@ -1617,7 +1636,7 @@ var EditSession = function(text, mode) {
     this.setWrapLimit = function (limit) {
         this.setWrapLimitRange(limit, limit);
     };
-    
+
     /**
      * Returns an object that defines the minimum and maximum of the wrap limit; it looks something like this:
      *
@@ -1642,7 +1661,7 @@ var EditSession = function(text, mode) {
         var lastRow = end.row;
         var len = lastRow - firstRow;
         var removedFolds = null;
-        
+
         this.$updating = true;
         if (len != 0) {
             if (action === "remove") {
@@ -2042,7 +2061,7 @@ var EditSession = function(text, mode) {
     this.getRowLength = function(row) {
         if (this.lineWidgets)
             var h = this.lineWidgets[row] && this.lineWidgets[row].rowCount || 0;
-        else 
+        else
             h = 0
         if (!this.$useWrapMode || !this.$wrapData[row]) {
             return 1 + h;
@@ -2389,7 +2408,7 @@ var EditSession = function(text, mode) {
 
         return screenRows;
     };
-    
+
     /**
      * @private
      *
@@ -2402,7 +2421,7 @@ var EditSession = function(text, mode) {
             if (!maxScreenColumn)
                 maxScreenColumn = Infinity;
             screenColumn = screenColumn || 0;
-            
+
             var c, column;
             for (column = 0; column < str.length; column++) {
                 c = str.charAt(column);
@@ -2416,11 +2435,11 @@ var EditSession = function(text, mode) {
                     break;
                 }
             }
-            
+
             return [screenColumn, column];
         };
     };
-    
+
     this.destroy = function() {
         if (this.bgTokenizer) {
             this.bgTokenizer.setDocument(null);
@@ -2508,7 +2527,7 @@ config.defineOptions(EditSession.prototype, "session", {
             return "off";
         },
         handlesSet: true
-    },    
+    },
     wrapMethod: {
         // code|text|auto
         set: function(val) {
@@ -2541,8 +2560,12 @@ config.defineOptions(EditSession.prototype, "session", {
         },
         initialValue: true
     },
-    useSoftTabs: {initialValue: true},
+    useSoftTabs: {
+        type: "bool",
+        initialValue: true
+    },
     tabSize: {
+        type: "number",
         set: function(tabSize) {
             if (isNaN(tabSize) || this.$tabSize === tabSize) return;
 

--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -69,6 +69,7 @@ var TokenIterator = require("./token_iterator").TokenIterator;
  * @constructor
  **/
 var Editor = function(renderer, session) {
+
     var container = renderer.getContainerElement();
     this.container = container;
     this.renderer = renderer;
@@ -91,18 +92,18 @@ var Editor = function(renderer, session) {
     this.commands.on("exec", this.$historyTracker);
 
     this.$initOperationListeners();
-    
+
     this._$emitInputEvent = lang.delayedCall(function() {
         this._signal("input", {});
         if (this.session && this.session.bgTokenizer)
             this.session.bgTokenizer.scheduleStart();
     }.bind(this));
-    
+
     this.on("change", function(_, _self) {
         _self._$emitInputEvent.schedule(31);
     });
 
-    this.setSession(session || new EditSession(""));
+    this.setSession(session);
     config.resetOptions(this);
     config._signal("editor", this);
 };
@@ -188,7 +189,7 @@ var Editor = function(renderer, session) {
                 if (scrollIntoView == "animate")
                     this.renderer.animateScrolling(this.curOp.scrollTop);
             }
-            
+
             this.prevOp = this.curOp;
             this.curOp = null;
         }
@@ -231,6 +232,21 @@ var Editor = function(renderer, session) {
         else if (mergeableCommands.indexOf(e.command.name) !== -1)
             this.sequenceStartTime = Date.now();
     };
+
+    /**
+     * Update the `Editor` options with a list of options passed by the user
+     * @param {Object} options An object with key, value options
+     *
+     **/
+     this.setUserOptions = function(options) {
+        var settable = ["selectionStyle", "highlightSelectedWord", "highlightActiveLine", "cursorStyle"];
+        for (var i = 0; i < settable.length; i++) {
+            var key = settable[i];
+            if (options[key]) {
+                this.setOption(key, options[key]);
+            }
+        }
+     };
 
     /**
      * Sets a new key handler, such as "vim" or "windows".
@@ -278,7 +294,7 @@ var Editor = function(renderer, session) {
     this.setSession = function(session) {
         if (this.session == session)
             return;
-        
+
         // make sure operationEnd events are not emitted to wrong session
         if (this.curOp) this.endOperation();
         this.curOp = {};
@@ -310,58 +326,58 @@ var Editor = function(renderer, session) {
             this.$onDocumentChange = this.onDocumentChange.bind(this);
             session.addEventListener("change", this.$onDocumentChange);
             this.renderer.setSession(session);
-    
+
             this.$onChangeMode = this.onChangeMode.bind(this);
             session.addEventListener("changeMode", this.$onChangeMode);
-    
+
             this.$onTokenizerUpdate = this.onTokenizerUpdate.bind(this);
             session.addEventListener("tokenizerUpdate", this.$onTokenizerUpdate);
-    
+
             this.$onChangeTabSize = this.renderer.onChangeTabSize.bind(this.renderer);
             session.addEventListener("changeTabSize", this.$onChangeTabSize);
-    
+
             this.$onChangeWrapLimit = this.onChangeWrapLimit.bind(this);
             session.addEventListener("changeWrapLimit", this.$onChangeWrapLimit);
-    
+
             this.$onChangeWrapMode = this.onChangeWrapMode.bind(this);
             session.addEventListener("changeWrapMode", this.$onChangeWrapMode);
-    
+
             this.$onChangeFold = this.onChangeFold.bind(this);
             session.addEventListener("changeFold", this.$onChangeFold);
-    
+
             this.$onChangeFrontMarker = this.onChangeFrontMarker.bind(this);
             this.session.addEventListener("changeFrontMarker", this.$onChangeFrontMarker);
-    
+
             this.$onChangeBackMarker = this.onChangeBackMarker.bind(this);
             this.session.addEventListener("changeBackMarker", this.$onChangeBackMarker);
-    
+
             this.$onChangeBreakpoint = this.onChangeBreakpoint.bind(this);
             this.session.addEventListener("changeBreakpoint", this.$onChangeBreakpoint);
-    
+
             this.$onChangeAnnotation = this.onChangeAnnotation.bind(this);
             this.session.addEventListener("changeAnnotation", this.$onChangeAnnotation);
-    
+
             this.$onCursorChange = this.onCursorChange.bind(this);
             this.session.addEventListener("changeOverwrite", this.$onCursorChange);
-    
+
             this.$onScrollTopChange = this.onScrollTopChange.bind(this);
             this.session.addEventListener("changeScrollTop", this.$onScrollTopChange);
-    
+
             this.$onScrollLeftChange = this.onScrollLeftChange.bind(this);
             this.session.addEventListener("changeScrollLeft", this.$onScrollLeftChange);
-    
+
             this.selection = session.getSelection();
             this.selection.addEventListener("changeCursor", this.$onCursorChange);
-    
+
             this.$onSelectionChange = this.onSelectionChange.bind(this);
             this.selection.addEventListener("changeSelection", this.$onSelectionChange);
-    
+
             this.onChangeMode();
-    
+
             this.$blockScrolling += 1;
             this.onCursorChange();
             this.$blockScrolling -= 1;
-    
+
             this.onScrollTopChange();
             this.onScrollLeftChange();
             this.onSelectionChange();
@@ -380,9 +396,9 @@ var Editor = function(renderer, session) {
             session: session,
             oldSession: oldSession
         });
-        
+
         this.curOp = null;
-        
+
         oldSession && oldSession._signal("changeEditor", {oldEditor: this});
         session && session._signal("changeEditor", {editor: this});
     };
@@ -540,36 +556,36 @@ var Editor = function(renderer, session) {
         this.$highlightTagPending = true;
         setTimeout(function() {
             self.$highlightTagPending = false;
-            
+
             var session = self.session;
             if (!session || !session.bgTokenizer) return;
-            
+
             var pos = self.getCursorPosition();
             var iterator = new TokenIterator(self.session, pos.row, pos.column);
             var token = iterator.getCurrentToken();
-            
+
             if (!token || !/\b(?:tag-open|tag-name)/.test(token.type)) {
                 session.removeMarker(session.$tagHighlight);
                 session.$tagHighlight = null;
                 return;
             }
-            
+
             if (token.type.indexOf("tag-open") != -1) {
                 token = iterator.stepForward();
                 if (!token)
                     return;
             }
-            
+
             var tag = token.value;
             var depth = 0;
             var prevToken = iterator.stepBackward();
-            
+
             if (prevToken.value == '<'){
                 //find closing tag
                 do {
                     prevToken = token;
                     token = iterator.stepForward();
-                    
+
                     if (token && token.value === tag && token.type.indexOf('tag-name') !== -1) {
                         if (prevToken.value === '<'){
                             depth++;
@@ -577,14 +593,14 @@ var Editor = function(renderer, session) {
                             depth--;
                         }
                     }
-                    
+
                 } while (token && depth >= 0);
             } else {
                 //find opening tag
                 do {
                     token = prevToken;
                     prevToken = iterator.stepBackward();
-                    
+
                     if (token && token.value === tag && token.type.indexOf('tag-name') !== -1) {
                         if (prevToken.value === '<') {
                             depth++;
@@ -593,27 +609,27 @@ var Editor = function(renderer, session) {
                         }
                     }
                 } while (prevToken && depth <= 0);
-                
+
                 //select tag again
                 iterator.stepForward();
             }
-            
+
             if (!token) {
                 session.removeMarker(session.$tagHighlight);
                 session.$tagHighlight = null;
                 return;
             }
-            
+
             var row = iterator.getCurrentTokenRow();
             var column = iterator.getCurrentTokenColumn();
             var range = new Range(row, column, row, column+token.value.length);
-            
+
             //remove range if different
             if (session.$tagHighlight && range.compareRange(session.$backMarkers[session.$tagHighlight].range)!==0) {
                 session.removeMarker(session.$tagHighlight);
                 session.$tagHighlight = null;
             }
-            
+
             if (range && !session.$tagHighlight)
                 session.$tagHighlight = session.addMarker(range, "ace_bracket", "text");
         }, 50);
@@ -699,7 +715,7 @@ var Editor = function(renderer, session) {
         this.renderer.updateLines(delta.start.row, lastRow, wrap);
 
         this._signal("change", delta);
-        
+
         // Update cursor because tab characters can influence the cursor position.
         this.$cursorChange();
         this.$updateHighlightActiveLine();
@@ -862,7 +878,7 @@ var Editor = function(renderer, session) {
         this.renderer.updateFull();
     };
 
-    
+
     /**
      * Returns the string of text currently highlighted.
      * @returns {String}
@@ -870,7 +886,7 @@ var Editor = function(renderer, session) {
     this.getSelectedText = function() {
         return this.session.getTextRange(this.getSelectionRange());
     };
-    
+
     /**
      * Emitted when text is copied.
      * @event copy
@@ -919,9 +935,9 @@ var Editor = function(renderer, session) {
         var e = {text: text, event: event};
         this.commands.exec("paste", this, e);
     };
-    
+
     this.$handlePaste = function(e) {
-        if (typeof e == "string") 
+        if (typeof e == "string")
             e = {text: e};
         this._signal("paste", e);
         var text = e.text;
@@ -930,15 +946,15 @@ var Editor = function(renderer, session) {
         } else {
             var lines = text.split(/\r\n|\r|\n/);
             var ranges = this.selection.rangeList.ranges;
-    
+
             if (lines.length > ranges.length || lines.length < 2 || !lines[1])
                 return this.commands.exec("insertstring", this, text);
-    
+
             for (var i = ranges.length; i--;) {
                 var range = ranges[i];
                 if (!range.isEmpty())
                     this.session.remove(range);
-    
+
                 this.session.insert(range.start, lines[i]);
             }
         }
@@ -970,7 +986,7 @@ var Editor = function(renderer, session) {
 
             }
         }
-        
+
         if (text == "\t")
             text = this.session.getTabString();
 
@@ -1473,7 +1489,7 @@ var Editor = function(renderer, session) {
                 return;
             }
         }
-        
+
         var line = session.getLine(range.start.row);
         var position = range.start;
         var size = session.getTabSize();
@@ -1723,7 +1739,7 @@ var Editor = function(renderer, session) {
             var ranges = selection.rangeList.ranges;
             selection.rangeList.detach(this.session);
             this.inVirtualSelectionMode = true;
-            
+
             var diff = 0;
             var totalDiff = 0;
             var l = ranges.length;
@@ -1752,7 +1768,7 @@ var Editor = function(renderer, session) {
                 if (!copy) diff = 0;
                 totalDiff += diff;
             }
-            
+
             selection.fromOrientedRange(selection.ranges[0]);
             selection.rangeList.attach(this.session);
             this.inVirtualSelectionMode = false;
@@ -2039,7 +2055,7 @@ var Editor = function(renderer, session) {
             "{": "{",
             "}": "{"
         };
-        
+
         do {
             if (token.value.match(/[{}()\[\]]/g)) {
                 for (; i < token.value.length && !found; i++) {
@@ -2076,14 +2092,14 @@ var Editor = function(renderer, session) {
                 if (isNaN(depth[token.value])) {
                     depth[token.value] = 0;
                 }
-                
+
                 if (prevToken.value === '<') {
                     depth[token.value]++;
                 }
                 else if (prevToken.value === '</') {
                     depth[token.value]--;
                 }
-                
+
                 if (depth[token.value] === -1) {
                     matchType = 'tag';
                     found = true;
@@ -2117,7 +2133,7 @@ var Editor = function(renderer, session) {
             }
         }
         else if (matchType === 'tag') {
-            if (token && token.type.indexOf('tag-name') !== -1) 
+            if (token && token.type.indexOf('tag-name') !== -1)
                 var tag = token.value;
             else
                 return;
@@ -2135,7 +2151,7 @@ var Editor = function(renderer, session) {
                 do {
                     token = prevToken;
                     prevToken = iterator.stepBackward();
-                    
+
                     if (prevToken) {
                         if (prevToken.type.indexOf('tag-close') !== -1) {
                             range.setEnd(iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn() + 1);
@@ -2148,7 +2164,7 @@ var Editor = function(renderer, session) {
                             else if (prevToken.value === '</') {
                                 depth[tag]--;
                             }
-                            
+
                             if (depth[tag] === 0)
                                 found = true;
                         }
@@ -2618,10 +2634,12 @@ config.defineOptions(Editor.prototype, "editor", {
         initialValue: "line"
     },
     highlightActiveLine: {
+        type: "bool",
         set: function() {this.$updateHighlightActiveLine();},
         initialValue: true
     },
     highlightSelectedWord: {
+        type: "bool",
         set: function(shouldHighlight) {this.$onSelectionChange();},
         initialValue: true
     },
@@ -2629,7 +2647,7 @@ config.defineOptions(Editor.prototype, "editor", {
         set: function(readOnly) {
             // disabled to not break vim mode!
             // this.textInput.setReadOnly(readOnly);
-            this.$resetCursorStyle(); 
+            this.$resetCursorStyle();
         },
         initialValue: false
     },

--- a/lib/ace/lib/app_config.js
+++ b/lib/ace/lib/app_config.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -62,6 +62,14 @@ var optionsProvider = {
         }
         if (opt.forwardTo)
             return this[opt.forwardTo] && this[opt.forwardTo].setOption(name, value);
+
+        if (typeof value === "string" && opt.type) {
+            if (opt.type === "bool") {
+                value = value === "true";
+            } else if (opt.type === "number") {
+                value = Number(value);
+            }
+        }
 
         if (!opt.handlesSet)
             this["$" + name] = value;
@@ -146,10 +154,10 @@ var AppConfig = function() {
             this.setDefaultValue(path, key, optionHash[key]);
         }, this);
     };
-    
+
     this.warn = warn;
     this.reportError = reportError;
-    
+
 }).call(AppConfig.prototype);
 
 exports.AppConfig = AppConfig;

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -50,7 +50,7 @@ dom.importCssString(editorCss, "ace_editor.css");
 
 /**
  * The class that is responsible for drawing everything you see on the screen!
- * @related editor.renderer 
+ * @related editor.renderer
  * @class VirtualRenderer
  **/
 
@@ -106,7 +106,7 @@ var VirtualRenderer = function(container, theme) {
     this.$horizScroll = false;
     this.$vScroll = false;
 
-    this.scrollBar = 
+    this.scrollBar =
     this.scrollBarV = new VScrollBar(this.container, this);
     this.scrollBarH = new HScrollBar(this.container, this);
     this.scrollBarV.addEventListener("scroll", function(e) {
@@ -156,7 +156,7 @@ var VirtualRenderer = function(container, theme) {
         height : 1,
         gutterOffset: 1
     };
-    
+
     this.scrollMargin = {
         left: 0,
         right: 0,
@@ -230,7 +230,7 @@ var VirtualRenderer = function(container, theme) {
     this.setSession = function(session) {
         if (this.session)
             this.session.doc.off("changeNewLineMode", this.onChangeNewLineMode);
-            
+
         this.session = session;
         if (session && this.scrollMargin.top && session.getScrollTop() <= 0)
             session.setScrollTop(-this.scrollMargin.top);
@@ -242,10 +242,10 @@ var VirtualRenderer = function(container, theme) {
         this.$textLayer.setSession(session);
         if (!session)
             return;
-        
+
         this.$loop.schedule(this.CHANGE_FULL);
         this.session.$setFontMetrics(this.$fontMetrics);
-        
+
         this.onChangeNewLineMode = this.onChangeNewLineMode.bind(this);
         this.onChangeNewLineMode()
         this.session.doc.on("changeNewLineMode", this.onChangeNewLineMode);
@@ -294,7 +294,7 @@ var VirtualRenderer = function(container, theme) {
         this.$loop.schedule(this.CHANGE_TEXT);
         this.$textLayer.$updateEolChar();
     };
-    
+
     this.onChangeTabSize = function() {
         this.$loop.schedule(this.CHANGE_TEXT | this.CHANGE_MARKER);
         this.$textLayer.onChangeTabSize();
@@ -357,7 +357,7 @@ var VirtualRenderer = function(container, theme) {
             width = el.clientWidth || el.scrollWidth;
         var changes = this.$updateCachedSize(force, gutterWidth, width, height);
 
-        
+
         if (!this.$size.scrollerHeight || (!width && !height))
             return this.resizing = 0;
 
@@ -375,7 +375,7 @@ var VirtualRenderer = function(container, theme) {
         // see https://github.com/ajaxorg/ace/issues/2195
         this.scrollBarV.scrollLeft = this.scrollBarV.scrollTop = null;
     };
-    
+
     this.$updateCachedSize = function(force, gutterWidth, width, height) {
         height -= (this.$extraHeight || 0);
         var changes = 0;
@@ -393,7 +393,7 @@ var VirtualRenderer = function(container, theme) {
             size.scrollerHeight = size.height;
             if (this.$horizScroll)
                 size.scrollerHeight -= this.scrollBarH.getHeight();
-                
+
             // this.scrollBarV.setHeight(size.scrollerHeight);
             this.scrollBarV.element.style.bottom = this.scrollBarH.getHeight() + "px";
 
@@ -403,26 +403,26 @@ var VirtualRenderer = function(container, theme) {
         if (width && (force || size.width != width)) {
             changes |= this.CHANGE_SIZE;
             size.width = width;
-            
+
             if (gutterWidth == null)
                 gutterWidth = this.$showGutter ? this.$gutter.offsetWidth : 0;
-            
+
             this.gutterWidth = gutterWidth;
-            
-            this.scrollBarH.element.style.left = 
+
+            this.scrollBarH.element.style.left =
             this.scroller.style.left = gutterWidth + "px";
-            size.scrollerWidth = Math.max(0, width - gutterWidth - this.scrollBarV.getWidth());           
-            
-            this.scrollBarH.element.style.right = 
+            size.scrollerWidth = Math.max(0, width - gutterWidth - this.scrollBarV.getWidth());
+
+            this.scrollBarH.element.style.right =
             this.scroller.style.right = this.scrollBarV.getWidth() + "px";
             this.scroller.style.bottom = this.scrollBarH.getHeight() + "px";
-                
+
             // this.scrollBarH.element.style.setWidth(size.scrollerWidth);
 
             if (this.session && this.session.getUseWrapMode() && this.adjustWrapLimit() || force)
                 changes |= this.CHANGE_FULL;
         }
-        
+
         size.$dirty = !width || !height;
 
         if (changes)
@@ -454,6 +454,24 @@ var VirtualRenderer = function(container, theme) {
         var limit = Math.floor(availableWidth / this.characterWidth);
         return this.session.adjustWrapLimit(limit, this.$showPrintMargin && this.$printMarginColumn);
     };
+
+    /**
+     * Update the `VirtualRenderer` options with a list of options passed by the user
+     * @param {Object} options An object with key, value options
+     *
+     **/
+     this.setUserOptions = function(options) {
+        if (options.theme) {
+            this.setTheme(options.theme);
+        }
+        var settable = ["showInvisibles", "showPrintMargin", "printMarginColumn"];
+        for (var i = 0; i < settable.length; i++) {
+            var key = settable[i];
+            if (options[key]) {
+                this.setOption(key, options[key]);
+            }
+        }
+     };
 
     /**
      * Identifies whether you want to have an animated scroll or not.
@@ -591,7 +609,7 @@ var VirtualRenderer = function(container, theme) {
         var style = this.$printMarginEl.style;
         style.left = ((this.characterWidth * this.$printMarginColumn) + this.$padding) + "px";
         style.visibility = this.$showPrintMargin ? "visible" : "hidden";
-        
+
         if (this.session && this.session.$wrap == -1)
             this.adjustWrapLimit();
     };
@@ -709,7 +727,7 @@ var VirtualRenderer = function(container, theme) {
         this.$loop.schedule(this.CHANGE_FULL);
         this.$updatePrintMargin();
     };
-    
+
     this.setScrollMargin = function(top, bottom, left, right) {
         var sm = this.scrollMargin;
         sm.top = top|0;
@@ -771,12 +789,12 @@ var VirtualRenderer = function(container, theme) {
         this.scrollBarH.setScrollWidth(this.layerConfig.width + 2 * this.$padding + this.scrollMargin.h);
         this.scrollBarH.setScrollLeft(this.scrollLeft + this.scrollMargin.left);
     };
-    
+
     this.$frozen = false;
     this.freeze = function() {
         this.$frozen = true;
     };
-    
+
     this.unfreeze = function() {
         this.$frozen = false;
     };
@@ -788,8 +806,8 @@ var VirtualRenderer = function(container, theme) {
         }
         if ((!this.session || !this.container.offsetWidth || this.$frozen) || (!changes && !force)) {
             this.$changes |= changes;
-            return; 
-        } 
+            return;
+        }
         if (this.$size.$dirty) {
             this.$changes |= changes;
             return this.onResize(true);
@@ -798,7 +816,7 @@ var VirtualRenderer = function(container, theme) {
             this.$textLayer.checkForSizeChanges();
         }
         // this.$logChanges(changes);
-        
+
         this._signal("beforeRender");
         var config = this.layerConfig;
         // text, scrolling and resize changes can cause the view port size to change
@@ -812,7 +830,7 @@ var VirtualRenderer = function(container, theme) {
             changes |= this.$computeLayerConfig();
             // If a change is made offscreen and wrapMode is on, then the onscreen
             // lines may have been pushed down. If so, the first screen row will not
-            // have changed, but the first actual row will. In that case, adjust 
+            // have changed, but the first actual row will. In that case, adjust
             // scrollTop so that the cursor and onscreen content stays in the same place.
             // TODO: find a better way to handle this, that works non wrapped case and doesn't compute layerConfig twice
             if (config.firstRow != this.layerConfig.firstRow && config.firstRowScreen == this.layerConfig.firstRowScreen) {
@@ -834,7 +852,7 @@ var VirtualRenderer = function(container, theme) {
             this.content.style.width = config.width + 2 * this.$padding + "px";
             this.content.style.height = config.minHeight + "px";
         }
-        
+
         // horizontal scrolling
         if (changes & this.CHANGE_H_SCROLL) {
             this.content.style.marginLeft = -this.scrollLeft + "px";
@@ -904,7 +922,7 @@ var VirtualRenderer = function(container, theme) {
         this._signal("afterRender");
     };
 
-    
+
     this.$autosize = function() {
         var height = this.session.getScreenLength() * this.lineHeight;
         var maxHeight = this.$maxLines * this.lineHeight;
@@ -915,34 +933,34 @@ var VirtualRenderer = function(container, theme) {
         if (this.$horizScroll)
             desiredHeight += this.scrollBarH.getHeight();
         var vScroll = height > maxHeight;
-        
+
         if (desiredHeight != this.desiredHeight ||
             this.$size.height != this.desiredHeight || vScroll != this.$vScroll) {
             if (vScroll != this.$vScroll) {
                 this.$vScroll = vScroll;
                 this.scrollBarV.setVisible(vScroll);
             }
-            
+
             var w = this.container.clientWidth;
             this.container.style.height = desiredHeight + "px";
             this.$updateCachedSize(true, this.$gutterWidth, w, desiredHeight);
             // this.$loop.changes = 0;
             this.desiredHeight = desiredHeight;
-            
+
             this._signal("autosize");
         }
     };
-    
+
     this.$computeLayerConfig = function() {
         var session = this.session;
         var size = this.$size;
-        
+
         var hideScrollbars = size.height <= 2 * this.lineHeight;
         var screenLines = this.session.getScreenLength();
         var maxHeight = screenLines * this.lineHeight;
 
         var longestLine = this.$getLongestLine();
-        
+
         var horizScroll = !hideScrollbars && (this.$hScrollBarAlwaysVisible ||
             size.scrollerWidth - longestLine - 2 * this.$padding < 0);
 
@@ -958,19 +976,19 @@ var VirtualRenderer = function(container, theme) {
 
         var offset = this.scrollTop % this.lineHeight;
         var minHeight = size.scrollerHeight + this.lineHeight;
-        
+
         var scrollPastEnd = !this.$maxLines && this.$scrollPastEnd
             ? (size.scrollerHeight - this.lineHeight) * this.$scrollPastEnd
             : 0;
         maxHeight += scrollPastEnd;
-        
+
         var sm = this.scrollMargin;
         this.session.setScrollTop(Math.max(-sm.top,
             Math.min(this.scrollTop, maxHeight - size.scrollerHeight + sm.bottom)));
 
-        this.session.setScrollLeft(Math.max(-sm.left, Math.min(this.scrollLeft, 
+        this.session.setScrollLeft(Math.max(-sm.left, Math.min(this.scrollLeft,
             longestLine + 2 * this.$padding - size.scrollerWidth + sm.right)));
-        
+
         var vScroll = !hideScrollbars && (this.$vScrollBarAlwaysVisible ||
             size.scrollerHeight - maxHeight + scrollPastEnd < 0 || this.scrollTop > sm.top);
         var vScrollChanged = vScrollBefore !== vScroll;
@@ -1005,7 +1023,7 @@ var VirtualRenderer = function(container, theme) {
         offset = this.scrollTop - firstRowScreen * lineHeight;
 
         var changes = 0;
-        if (this.layerConfig.width != longestLine) 
+        if (this.layerConfig.width != longestLine)
             changes = this.CHANGE_H_SCROLL;
         // Horizontal scrollbar visibility may have changed, which changes
         // the client height of the scroller
@@ -1015,7 +1033,7 @@ var VirtualRenderer = function(container, theme) {
             if (vScrollChanged)
                 longestLine = this.$getLongestLine();
         }
-        
+
         this.layerConfig = {
             width : longestLine,
             padding : this.$padding,
@@ -1163,12 +1181,12 @@ var VirtualRenderer = function(container, theme) {
 
         var left = pos.left;
         var top = pos.top;
-        
+
         var topMargin = $viewMargin && $viewMargin.top || 0;
         var bottomMargin = $viewMargin && $viewMargin.bottom || 0;
-        
+
         var scrollTop = this.$scrollAnimation ? this.session.getScrollTop() : this.scrollTop;
-        
+
         if (scrollTop + topMargin > top) {
             if (offset)
                 top -= offset * this.$size.scrollerHeight;
@@ -1291,10 +1309,10 @@ var VirtualRenderer = function(container, theme) {
         if (!this.$animatedScroll)
             return;
         var _self = this;
-        
+
         if (fromValue == toValue)
             return;
-        
+
         if (this.$scrollAnimation) {
             var oldSteps = this.$scrollAnimation.steps;
             if (oldSteps.length) {
@@ -1303,7 +1321,7 @@ var VirtualRenderer = function(container, theme) {
                     return;
             }
         }
-        
+
         var steps = _self.$calcSteps(fromValue, toValue);
         this.$scrollAnimation = {from: fromValue, to: toValue, steps: steps};
 
@@ -1365,7 +1383,7 @@ var VirtualRenderer = function(container, theme) {
         this.session.setScrollTop(y);
         this.session.setScrollLeft(y);
     };
-    
+
     /**
      * Scrolls the editor across both x- and y-axes.
      * @param {Number} deltaX The x value to scroll by
@@ -1527,11 +1545,11 @@ var VirtualRenderer = function(container, theme) {
             if (_self.theme)
                 dom.removeCssClass(_self.container, _self.theme.cssClass);
 
-            var padding = "padding" in module ? module.padding 
+            var padding = "padding" in module ? module.padding
                 : "padding" in (_self.theme || {}) ? 4 : _self.$padding;
             if (_self.$padding && padding != _self.$padding)
                 _self.setPadding(padding);
-                
+
             // this is kept only for backwards compatibility
             _self.$theme = module.cssClass;
 
@@ -1579,7 +1597,7 @@ var VirtualRenderer = function(container, theme) {
     this.unsetStyle = function(style) {
         dom.removeCssClass(this.container, style);
     };
-    
+
     this.setCursorStyle = function(style) {
         if (this.scroller.style.cursor != style)
             this.scroller.style.cursor = style;
@@ -1607,6 +1625,7 @@ var VirtualRenderer = function(container, theme) {
 config.defineOptions(VirtualRenderer.prototype, "renderer", {
     animatedScroll: {initialValue: false},
     showInvisibles: {
+        type: "bool",
         set: function(value) {
             if (this.$textLayer.setShowInvisibles(value))
                 this.$loop.schedule(this.CHANGE_TEXT);
@@ -1614,10 +1633,12 @@ config.defineOptions(VirtualRenderer.prototype, "renderer", {
         initialValue: false
     },
     showPrintMargin: {
+        type: "bool",
         set: function() { this.$updatePrintMargin(); },
         initialValue: true
     },
     printMarginColumn: {
+        type: "number",
         set: function() { this.$updatePrintMargin(); },
         initialValue: 80
     },
@@ -1629,7 +1650,7 @@ config.defineOptions(VirtualRenderer.prototype, "renderer", {
             this.$updatePrintMargin();
         },
         get: function() {
-            return this.$showPrintMargin && this.$printMarginColumn; 
+            return this.$showPrintMargin && this.$printMarginColumn;
         }
     },
     showGutter: {


### PR DESCRIPTION
Implements #2711 
Uses data-attributes to configure the theme and mode of the editor element. I've chosen to use the simple `data-theme="monokai"` over `data-theme="ace/theme/monokai"` because as far as I can tell all themes live in `ace/theme/`. Do let me know if this doesn't make sense.
