### PR TITLE
Java Numeral Syntax Highlighting

### DIFF
--- a/lib/ace/mode/java_highlight_rules.js
+++ b/lib/ace/mode/java_highlight_rules.js
@@ -79,11 +79,20 @@ var JavaHighlightRules = function() {
                 token : "string", // single line
                 regex : "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"
             }, {
-                token : "constant.numeric", // hex
-                regex : "0[xX][0-9a-fA-F]+\\b"
-            }, {
                 token : "constant.numeric", // float
-                regex : "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b"
+                regex : /(\+|\-)?\d(_*\d)*(?:(?:\.\d(_*\d)*)?(?:(e|E)(\+|\-)?\d(_*\d)*))?(d|D|f|F)?\b/
+            }, {
+                token : "constant.numeric", // binary
+                regex : /0(b|B)[0-1](_*[0-1])*\b/
+            }, {
+                token : "constant.numeric", // long
+                regex : /\d(_*\d)*(l|L)?\b/
+            }, {
+                token : "constant.numeric", // hex
+                regex : /0(x|X)[0-9a-fA-F](_*[0-9a-fA-F])*\b/
+            }, {
+                token : "constant.numeric", //octal - srsly java pls stop
+                regex : /0_+[0-7](_*[0-7])?/
             }, {
                 token : "constant.language.boolean",
                 regex : "(?:true|false)\\b"


### PR DESCRIPTION
Fixed Java syntax highlighting to recognise more valid numeral
literals. closes #2736.

As per issue, used these docs when creating the regexes.
https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html