### PR TITLE
If a completer returns undefined results, prevents ace throwing exception

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -235,13 +235,13 @@ var Autocomplete = function() {
         var total = editor.completers.length;
         editor.completers.forEach(function(completer, i) {
             completer.getCompletions(editor, session, pos, prefix, function(err, results) {
-                if (!err)
+                if (!err && results)
                     matches = matches.concat(results);
                 // Fetch prefix again, because they may have changed by now
                 var pos = editor.getCursorPosition();
                 var line = session.getLine(pos.row);
                 callback(null, {
-                    prefix: util.retrievePrecedingIdentifier(line, pos.column, results[0] && results[0].identifierRegex),
+                    prefix: util.retrievePrecedingIdentifier(line, pos.column, results && results[0] && results[0].identifierRegex),
                     matches: matches,
                     finished: (--total === 0)
                 });


### PR DESCRIPTION
~~While this may have been caused by me with the Less mode (not sure)~~  **--scratch that, this happened for me in a PHP file**, this code change would at least prevent a misbehaving autocompleter from crashing Ace. Note that autocompletions still work in all other cases, so it must be from one errant token.