### PR TITLE
Fixes an issue with Jade syntax highlighting

### DIFF
--- a/lib/ace/mode/jade_highlight_rules.js
+++ b/lib/ace/mode/jade_highlight_rules.js
@@ -82,7 +82,7 @@ var JadeHighlightRules = function() {
         },
         {
             token : "punctuation.section.comment",
-            regex : "^\\s*\/\/(?:\\s*[^-\\s]|\\s+\\S)(?:.*$)"
+            regex : "^\\s*\/\/(?:\\s*[^\\s]|\\s+\\S)(?:.*$)"
         },
         {
             onMatch: function(value, currentState, stack) {


### PR DESCRIPTION
Fixes #2772 
Change to regex to allow Jade comments to be highlighted correctly.
