### PR TITLE
Vim keybinding error fix

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -2230,7 +2230,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
             return;
           }
           if (motionArgs.toJumplist) {
-            if (!operator)
+            if (!operator && cm.ace.curOp != null)
               cm.ace.curOp.command.scrollIntoView = "center-animate"; // ace_patch
             var jumpList = vimGlobalState.jumpList;
             // if the current motion is # or *, use cachedCursor


### PR DESCRIPTION
When current operation is null command is not defined causing the issue. Reproducible when searching for text and press enter.