### PR TITLE
Update link to kitchen sink

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ console.log(addResult);
 </pre>
                             <p id="embed_link"><a href="#nav=embedding">Learn how to embed this in your own site</a></p>
                             <p class="highlight_note">Looking for a more full-featured demo? Check out the
-                                <a href="build/kitchen-sink.html" target="_blank">kitchen sink</a>.
+                                <a href="kitchen-sink.html" target="_blank">kitchen sink</a>.
                             </p>
                             <h2>Features</h2>
                             <ul class="content-list">


### PR DESCRIPTION
Update link in static homepage to point to new location of kitchen sink demo. Current link points to build/... which 404's, as below:

<img width="792" alt="current link" src="https://cloud.githubusercontent.com/assets/7144173/11604455/863e1614-9ae4-11e5-9782-c8566d3a5ba5.png">

<img width="458" alt="current result" src="https://cloud.githubusercontent.com/assets/7144173/11604459/98659a92-9ae4-11e5-9659-b2da90269b4f.png">

