### PR TITLE
Allow to setCompleters after setOptions

### DIFF
--- a/lib/ace/ext/language_tools.js
+++ b/lib/ace/ext/language_tools.js
@@ -84,7 +84,11 @@ var completers = [snippetCompleter, textCompleter, keyWordCompleter];
 // Allows default completers to be removed or replaced with a explict set of completers
 // A null argument here will result in an empty completer array, not a null attribute
 exports.setCompleters = function(val) {
-    completers = val || [];
+  // Seems like you need to mutate completers array instead of re-assigning it
+  completers.splice(0, completers.length);
+    val.forEach(function (v) {
+    completers.push(v);
+  });
 };
 exports.addCompleter = function(completer) {
     completers.push(completer);


### PR DESCRIPTION
- Currently, users have to first setCompleters and then setOptions. This does not allow users to change completers after using setOptions(), which could be desirable if user wants to change completers on editor. 