### PR TITLE
Fix custom identifierRegexps (issue #2532)

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -226,7 +226,7 @@ var Autocomplete = function() {
         var pos = editor.getCursorPosition();
 
         var line = session.getLine(pos.row);
-        var prefix = util.retrievePrecedingIdentifier(line, pos.column);
+        var prefix = util.getCompletionPrefix(editor);
 
         this.base = session.doc.createAnchor(pos.row, pos.column - prefix.length);
         this.base.$insertRight = true;
@@ -241,7 +241,7 @@ var Autocomplete = function() {
                 var pos = editor.getCursorPosition();
                 var line = session.getLine(pos.row);
                 callback(null, {
-                    prefix: util.retrievePrecedingIdentifier(line, pos.column, results && results[0] && results[0].identifierRegex),
+                    prefix: prefix,
                     matches: matches,
                     finished: (--total === 0)
                 });

--- a/lib/ace/autocomplete/util.js
+++ b/lib/ace/autocomplete/util.js
@@ -71,4 +71,19 @@ exports.retrieveFollowingIdentifier = function(text, pos, regex) {
     return buf;
 };
 
+exports.getCompletionPrefix = function (editor) {
+    var pos = editor.getCursorPosition();
+    var line = editor.session.getLine(pos.row);
+    var prefix;
+    editor.completers.forEach(function(completer) {
+        if (completer.identifierRegexps) {
+            completer.identifierRegexps.forEach(function(identifierRegex) {
+                if (!prefix && identifierRegex)
+                    prefix = this.retrievePrecedingIdentifier(line, pos.column, identifierRegex);
+            }.bind(this));
+        }
+    }.bind(this));
+    return prefix || this.retrievePrecedingIdentifier(line, pos.column);
+};
+
 });

--- a/lib/ace/ext/language_tools.js
+++ b/lib/ace/ext/language_tools.js
@@ -137,33 +137,17 @@ var loadSnippetFile = function(id) {
     });
 };
 
-function getCompletionPrefix(editor) {
-    var pos = editor.getCursorPosition();
-    var line = editor.session.getLine(pos.row);
-    var prefix;
-    // Try to find custom prefixes on the completers
-    editor.completers.forEach(function(completer) {
-        if (completer.identifierRegexps) {
-            completer.identifierRegexps.forEach(function(identifierRegex) {
-                if (!prefix && identifierRegex)
-                    prefix = util.retrievePrecedingIdentifier(line, pos.column, identifierRegex);
-            });
-        }
-    });
-    return prefix || util.retrievePrecedingIdentifier(line, pos.column);
-}
-
 var doLiveAutocomplete = function(e) {
     var editor = e.editor;
     var hasCompleter = editor.completer && editor.completer.activated;
 
     // We don't want to autocomplete with no prefix
     if (e.command.name === "backspace") {
-        if (hasCompleter && !getCompletionPrefix(editor))
+        if (hasCompleter && !util.getCompletionPrefix(editor))
             editor.completer.detach();
     }
     else if (e.command.name === "insertstring") {
-        var prefix = getCompletionPrefix(editor);
+        var prefix = util.getCompletionPrefix(editor);
         // Only autocomplete if there's a prefix that can be matched
         if (prefix && !hasCompleter) {
             if (!editor.completer) {


### PR DESCRIPTION
- Add util.getCompletionPrefix and use it instead of util.retrievePrecedingIdentifier in gatherCompletions and doLiveAutocomplete functions as suggested at https://github.com/ajaxorg/ace/issues/2532
- I tried using https://github.com/ajaxorg/ace/pull/2352 but this didn't seem to fix my issue (I am using a identifierRegexps that includes square brackets). Instead, using util.getCompletionPrefix as I do in this commit fixes the issue for me

```
var completer = [{
        identifierRegexps: [/[\[\]a-zA-Z_0-9]/],
        getCompletions: function (editor, session, pos, prefix, callback) {
          if (prefix.length === 0) {callback(null, []); return;}
          callback(null, config.extraAutocompletes);
        }
      }]
aceLanguageTools.setCompleters(completers);
```

Result:
![image](https://cloud.githubusercontent.com/assets/6097953/11738852/2e7b283e-9f9b-11e5-92fe-3ea8fdbf543c.png)
