### PR TITLE
clear emacs mark on kill-region (#2820)

### DIFF
--- a/lib/ace/keyboard/emacs.js
+++ b/lib/ace/keyboard/emacs.js
@@ -588,6 +588,7 @@ exports.handler.addCommands({
         exec: function(editor) {
             exports.killRing.add(editor.getCopyText());
             editor.commands.byName.cut.exec(editor);
+            editor.setEmacsMark(null);
         },
         readOnly: true,
         multiSelectAction: "forEach"


### PR DESCRIPTION
This PR fixes #2820 by clearing the mark after `killRegion` (e.g. `C-w`).

I think this is the correct solution but may be missing something re: multiple selections + Emacs mode...