### PR TITLE
Resolve unreachable code after return statement #2825

### DIFF
--- a/lib/ace/mode/php/php.js
+++ b/lib/ace/mode/php/php.js
@@ -1367,9 +1367,7 @@ PHP.Parser.prototype.parseEscapeSequences = function( str, quote ) {
                 return chr(octdec(str));
             }
         }
-        );
-
-    return str;
+    );
 };
 
 /* This is an automatically GENERATED file, which should not be manually edited.


### PR DESCRIPTION
This should fix the warning thrown when activating php mode:

> : unreachable code after return statement
> return str;
> ..../src/worker-php.js
> Line 2657, col 4

Original issue posted here: https://github.com/ajaxorg/ace/issues/2825