### PR TITLE
rst mode improvements

### DIFF
--- a/demo/kitchen-sink/docs/rst.rst
+++ b/demo/kitchen-sink/docs/rst.rst
@@ -3,7 +3,410 @@
 
 .. seealso::
 
-The authoritative `reStructuredText User Documentation
-<http://docutils.sourceforge.net/rst.html>`_.  The "ref" links in this
-document link to the description of the individual constructs in the reST
-reference.
+   http://docutils.sourceforge.net/docs/user/rst/quickstart.html
+
+
+ReStructuredText Primer
+=======================
+
+:Author: Richard Jones
+:Version: $Revision: 5801 $
+:Copyright: This document has been placed in the public domain.
+
+.. contents::
+
+
+The text below contains links that look like "(quickref__)".  These
+are relative links that point to the `Quick reStructuredText`_ user
+reference.  If these links don't work, please refer to the `master
+quick reference`_ document.
+
+__
+.. _Quick reStructuredText: quickref.html
+.. _master quick reference:
+   http://docutils.sourceforge.net/docs/user/rst/quickref.html
+
+.. Note:: This document is an informal introduction to
+   reStructuredText.  The `What Next?`_ section below has links to
+   further resources, including a formal reference.
+
+
+Structure
+---------
+
+From the outset, let me say that "Structured Text" is probably a bit
+of a misnomer.  It's more like "Relaxed Text" that uses certain
+consistent patterns.  These patterns are interpreted by a HTML
+converter to produce "Very Structured Text" that can be used by a web
+browser.
+
+The most basic pattern recognised is a **paragraph** (quickref__).
+That's a chunk of text that is separated by blank lines (one is
+enough).  Paragraphs must have the same indentation -- that is, line
+up at their left edge.  Paragraphs that start indented will result in
+indented quote paragraphs. For example::
+
+  This is a paragraph.  It's quite
+  short.
+
+     This paragraph will result in an indented block of
+     text, typically used for quoting other text.
+
+  This is another one.
+
+Results in:
+
+  This is a paragraph.  It's quite
+  short.
+
+     This paragraph will result in an indented block of
+     text, typically used for quoting other text.
+
+  This is another one.
+
+__ quickref.html#paragraphs
+
+
+Text styles
+-----------
+
+(quickref__)
+
+__ quickref.html#inline-markup
+
+Inside paragraphs and other bodies of text, you may additionally mark
+text for *italics* with "``*italics*``" or **bold** with
+"``**bold**``".  This is called "inline markup".
+
+If you want something to appear as a fixed-space literal, use
+"````double back-quotes````".  Note that no further fiddling is done
+inside the double back-quotes -- so asterisks "``*``" etc. are left
+alone.
+
+If you find that you want to use one of the "special" characters in
+text, it will generally be OK -- reStructuredText is pretty smart.
+For example, this lone asterisk * is handled just fine, as is the
+asterisk in this equation: 5*6=30.  If you actually
+want text \*surrounded by asterisks* to **not** be italicised, then
+you need to indicate that the asterisk is not special.  You do this by
+placing a backslash just before it, like so "``\*``" (quickref__), or
+by enclosing it in double back-quotes (inline literals), like this::
+
+    ``*``
+
+__ quickref.html#escaping
+
+.. Tip:: Think of inline markup as a form of (parentheses) and use it
+   the same way: immediately before and after the text being marked
+   up.  Inline markup by itself (surrounded by whitespace) or in the
+   middle of a word won't be recognized.  See the `markup spec`__ for
+   full details.
+
+__ ../../ref/rst/restructuredtext.html#inline-markup
+
+
+Lists
+-----
+
+Lists of items come in three main flavours: **enumerated**,
+**bulleted** and **definitions**.  In all list cases, you may have as
+many paragraphs, sublists, etc. as you want, as long as the left-hand
+side of the paragraph or whatever aligns with the first line of text
+in the list item.
+
+Lists must always start a new paragraph -- that is, they must appear
+after a blank line.
+
+**enumerated** lists (numbers, letters or roman numerals; quickref__)
+  __ quickref.html#enumerated-lists
+
+  Start a line off with a number or letter followed by a period ".",
+  right bracket ")" or surrounded by brackets "( )" -- whatever you're
+  comfortable with.  All of the following forms are recognised::
+
+    1. numbers
+
+    A. upper-case letters
+       and it goes over many lines
+
+       with two paragraphs and all!
+
+    a. lower-case letters
+
+       3. with a sub-list starting at a different number
+       4. make sure the numbers are in the correct sequence though!
+
+    I. upper-case roman numerals
+
+    i. lower-case roman numerals
+
+    (1) numbers again
+
+    1) and again
+
+  Results in (note: the different enumerated list styles are not
+  always supported by every web browser, so you may not get the full
+  effect here):
+
+  1. numbers
+
+  A. upper-case letters
+     and it goes over many lines
+
+     with two paragraphs and all!
+
+  a. lower-case letters
+
+     3. with a sub-list starting at a different number
+     4. make sure the numbers are in the correct sequence though!
+
+  I. upper-case roman numerals
+
+  i. lower-case roman numerals
+
+  (1) numbers again
+
+  1) and again
+
+**bulleted** lists (quickref__)
+  __ quickref.html#bullet-lists
+
+  Just like enumerated lists, start the line off with a bullet point
+  character - either "-", "+" or "*"::
+
+    * a bullet point using "*"
+
+      - a sub-list using "-"
+
+        + yet another sub-list
+
+      - another item
+
+  Results in:
+
+  * a bullet point using "*"
+
+    - a sub-list using "-"
+
+      + yet another sub-list
+
+    - another item
+
+**definition** lists (quickref__)
+  __ quickref.html#definition-lists
+
+  Unlike the other two, the definition lists consist of a term, and
+  the definition of that term.  The format of a definition list is::
+
+    what
+      Definition lists associate a term with a definition.
+
+    *how*
+      The term is a one-line phrase, and the definition is one or more
+      paragraphs or body elements, indented relative to the term.
+      Blank lines are not allowed between term and definition.
+
+  Results in:
+
+  what
+    Definition lists associate a term with a definition.
+
+  *how*
+    The term is a one-line phrase, and the definition is one or more
+    paragraphs or body elements, indented relative to the term.
+    Blank lines are not allowed between term and definition.
+
+
+Preformatting (code samples)
+----------------------------
+(quickref__)
+
+__ quickref.html#literal-blocks
+
+To just include a chunk of preformatted, never-to-be-fiddled-with
+text, finish the prior paragraph with "``::``".  The preformatted
+block is finished when the text falls back to the same indentation
+level as a paragraph prior to the preformatted block.  For example::
+
+  An example::
+
+      Whitespace, newlines, blank lines, and all kinds of markup
+        (like *this* or \this) is preserved by literal blocks.
+    Lookie here, I've dropped an indentation level
+    (but not far enough)
+
+  no more example
+
+Results in:
+
+  An example::
+
+      Whitespace, newlines, blank lines, and all kinds of markup
+        (like *this* or \this) is preserved by literal blocks.
+    Lookie here, I've dropped an indentation level
+    (but not far enough)
+
+  no more example
+
+Note that if a paragraph consists only of "``::``", then it's removed
+from the output::
+
+  ::
+
+      This is preformatted text, and the
+      last "::" paragraph is removed
+
+Results in:
+
+::
+
+    This is preformatted text, and the
+    last "::" paragraph is removed
+
+
+Sections
+--------
+
+(quickref__)
+
+__ quickref.html#section-structure
+
+To break longer text up into sections, you use **section headers**.
+These are a single line of text (one or more words) with adornment: an
+underline alone, or an underline and an overline together, in dashes
+"``-----``", equals "``======``", tildes "``~~~~~~``" or any of the
+non-alphanumeric characters ``= - ` : ' " ~ ^ _ * + # < >`` that you
+feel comfortable with.  An underline-only adornment is distinct from
+an overline-and-underline adornment using the same character.  The
+underline/overline must be at least as long as the title text.  Be
+consistent, since all sections marked with the same adornment style
+are deemed to be at the same level::
+
+  Chapter 1 Title
+  ===============
+
+  Section 1.1 Title
+  -----------------
+
+  Subsection 1.1.1 Title
+  ~~~~~~~~~~~~~~~~~~~~~~
+
+  Section 1.2 Title
+  -----------------
+
+  Chapter 2 Title
+  ===============
+
+This results in the following structure, illustrated by simplified
+pseudo-XML::
+
+    <section>
+        <title>
+            Chapter 1 Title
+        <section>
+            <title>
+                Section 1.1 Title
+            <section>
+                <title>
+                    Subsection 1.1.1 Title
+        <section>
+            <title>
+                Section 1.2 Title
+    <section>
+        <title>
+            Chapter 2 Title
+
+(Pseudo-XML uses indentation for nesting and has no end-tags.  It's
+not possible to show actual processed output, as in the other
+examples, because sections cannot exist inside block quotes.  For a
+concrete example, compare the section structure of this document's
+source text and processed output.)
+
+Note that section headers are available as link targets, just using
+their name.  To link to the Lists_ heading, I write "``Lists_``".  If
+the heading has a space in it like `text styles`_, we need to quote
+the heading "```text styles`_``".
+
+
+Document Title / Subtitle
+`````````````````````````
+
+The title of the whole document is distinct from section titles and
+may be formatted somewhat differently (e.g. the HTML writer by default
+shows it as a centered heading).
+
+To indicate the document title in reStructuredText, use a unique adornment
+style at the beginning of the document.  To indicate the document subtitle,
+use another unique adornment style immediately after the document title.  For
+example::
+
+    ================
+     Document Title
+    ================
+    ----------
+     Subtitle
+    ----------
+
+    Section Title
+    =============
+
+    ...
+
+Note that "Document Title" and "Section Title" above both use equals
+signs, but are distict and unrelated styles.  The text of
+overline-and-underlined titles (but not underlined-only) may be inset
+for aesthetics.
+
+
+Images
+------
+
+(quickref__)
+
+__ quickref.html#directives
+
+To include an image in your document, you use the the ``image`` directive__.
+For example::
+
+  .. image:: images/biohazard.png
+
+results in:
+
+.. image:: images/biohazard.png
+
+The ``images/biohazard.png`` part indicates the filename of the image
+you wish to appear in the document. There's no restriction placed on
+the image (format, size etc).  If the image is to appear in HTML and
+you wish to supply additional information, you may::
+
+  .. image:: images/biohazard.png
+     :height: 100
+     :width: 200
+     :scale: 50
+     :alt: alternate text
+
+See the full `image directive documentation`__ for more info.
+
+__ ../../ref/rst/directives.html
+__ ../../ref/rst/directives.html#images
+
+
+What Next?
+----------
+
+This primer introduces the most common features of reStructuredText,
+but there are a lot more to explore.  The `Quick reStructuredText`_
+user reference is a good place to go next.  For complete details, the
+`reStructuredText Markup Specification`_ is the place to go [#]_.
+
+Users who have questions or need assistance with Docutils or
+reStructuredText should post a message to the Docutils-users_ mailing
+list.
+
+.. [#] If that relative link doesn't work, try the master document:
+   http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html.
+
+.. _reStructuredText Markup Specification:
+   ../../ref/rst/restructuredtext.html
+.. _Docutils-users: ../mailing-lists.html#docutils-users
+.. _Docutils project web site: http://docutils.sourceforge.net/

--- a/demo/kitchen-sink/docs/rst.rst
+++ b/demo/kitchen-sink/docs/rst.rst
@@ -1,3 +1,4 @@
+==========================================
 *reStructuredText* Highlighter for **Ace**
 ==========================================
 
@@ -118,35 +119,11 @@ Lists must always start a new paragraph -- that is, they must appear
 after a blank line.
 
 **enumerated** lists (numbers, letters or roman numerals; quickref__)
-  __ quickref.html#enumerated-lists
+__ quickref.html#enumerated-lists
 
-  Start a line off with a number or letter followed by a period ".",
-  right bracket ")" or surrounded by brackets "( )" -- whatever you're
-  comfortable with.  All of the following forms are recognised::
-
-    1. numbers
-
-    A. upper-case letters
-       and it goes over many lines
-
-       with two paragraphs and all!
-
-    a. lower-case letters
-
-       3. with a sub-list starting at a different number
-       4. make sure the numbers are in the correct sequence though!
-
-    I. upper-case roman numerals
-
-    i. lower-case roman numerals
-
-    (1) numbers again
-
-    1) and again
-
-  Results in (note: the different enumerated list styles are not
-  always supported by every web browser, so you may not get the full
-  effect here):
+Start a line off with a number or letter followed by a period ".",
+right bracket ")" or surrounded by brackets "( )" -- whatever you're
+comfortable with.  All of the following forms are recognised::
 
   1. numbers
 
@@ -168,23 +145,37 @@ after a blank line.
 
   1) and again
 
+Results in (note: the different enumerated list styles are not
+always supported by every web browser, so you may not get the full
+effect here):
+
+1. numbers
+
+A. upper-case letters
+   and it goes over many lines
+
+   with two paragraphs and all!
+
+a. lower-case letters
+
+   3. with a sub-list starting at a different number
+   4. make sure the numbers are in the correct sequence though!
+
+I. upper-case roman numerals
+
+i. lower-case roman numerals
+
+(1) numbers again
+
+1) and again
+
 **bulleted** lists (quickref__)
-  __ quickref.html#bullet-lists
+__ quickref.html#bullet-lists
 
-  Just like enumerated lists, start the line off with a bullet point
-  character - either "-", "+" or "*"::
+Just like enumerated lists, start the line off with a bullet point
+character - either "-", "+" or "\*"::
 
-    * a bullet point using "*"
-
-      - a sub-list using "-"
-
-        + yet another sub-list
-
-      - another item
-
-  Results in:
-
-  * a bullet point using "*"
+  * a bullet point using "\*"
 
     - a sub-list using "-"
 
@@ -192,21 +183,21 @@ after a blank line.
 
     - another item
 
+Results in:
+
+* a bullet point using "\*"
+
+  - a sub-list using "-"
+
+    + yet another sub-list
+
+  - another item
+
 **definition** lists (quickref__)
-  __ quickref.html#definition-lists
+__ quickref.html#definition-lists
 
-  Unlike the other two, the definition lists consist of a term, and
-  the definition of that term.  The format of a definition list is::
-
-    what
-      Definition lists associate a term with a definition.
-
-    *how*
-      The term is a one-line phrase, and the definition is one or more
-      paragraphs or body elements, indented relative to the term.
-      Blank lines are not allowed between term and definition.
-
-  Results in:
+Unlike the other two, the definition lists consist of a term, and
+the definition of that term.  The format of a definition list is::
 
   what
     Definition lists associate a term with a definition.
@@ -215,6 +206,16 @@ after a blank line.
     The term is a one-line phrase, and the definition is one or more
     paragraphs or body elements, indented relative to the term.
     Blank lines are not allowed between term and definition.
+
+Results in:
+
+what
+  Definition lists associate a term with a definition.
+
+*how*
+  The term is a one-line phrase, and the definition is one or more
+  paragraphs or body elements, indented relative to the term.
+  Blank lines are not allowed between term and definition.
 
 
 Preformatting (code samples)
@@ -239,14 +240,14 @@ level as a paragraph prior to the preformatted block.  For example::
 
 Results in:
 
-  An example::
+An example::
 
-      Whitespace, newlines, blank lines, and all kinds of markup
-        (like *this* or \this) is preserved by literal blocks.
-    Lookie here, I've dropped an indentation level
-    (but not far enough)
+    Whitespace, newlines, blank lines, and all kinds of markup
+      (like *this* or \this) is preserved by literal blocks.
+  Lookie here, I've dropped an indentation level
+  (but not far enough)
 
-  no more example
+no more example
 
 Note that if a paragraph consists only of "``::``", then it's removed
 from the output::

--- a/lib/ace/mode/rst_highlight_rules.js
+++ b/lib/ace/mode/rst_highlight_rules.js
@@ -50,6 +50,9 @@ var RSTHighlightRules = function() {
     comment: "comment"
   };
 
+  var startStringPrefix = "(^|\\s|[\"'(<\\[{\\-/:])";
+  var endStringSuffix = "(?:$|(?=\\s|[\\\\.,;!?\\-/:\"')>\\]}]))";
+
   this.$rules = {
     "start": [
       /* NB: Only the underline of the heading is highlighted.
@@ -62,8 +65,8 @@ var RSTHighlightRules = function() {
       /* Generic directive syntax (e.g. .. code-block:: c)
        * All of the directive body is highlighted as a code block. */
       {
-        token : [tokens.directive, tokens.literal],
-        regex : "(^\\s*\\.\\. [^:]+::)(.*$)",
+        token : ["text", tokens.directive, tokens.literal],
+        regex : "(^\\s*\\.\\. )([^: ]+::)(.*$)",
         next  : "codeblock"
       },
       {
@@ -112,18 +115,18 @@ var RSTHighlightRules = function() {
       },
       /* Inline markup */
       {
-        token : tokens.literal,
-        regex : "``",
+        token : ["text", tokens.literal],
+        regex : startStringPrefix + "(``)(?=\\S)",
         next  : "code"
       },
       {
-        token : tokens.bold,
-        regex : "\\*\\*",
+        token : ["text", tokens.bold],
+        regex : startStringPrefix + "(\\*\\*)(?=\\S)",
         next  : "bold"
       },
       {
-        token : tokens.italic,
-        regex : "\\*",
+        token : ["text", tokens.italic],
+        regex : startStringPrefix + "(\\*)(?=\\S)",
         next  : "italic"
       },
       /* Substitution reference */
@@ -134,12 +137,12 @@ var RSTHighlightRules = function() {
       /* Link/footnote references */
       {
         token : tokens.entity,
-        regex : ":[\\w-:]+:`",
+        regex : ":[\\w-:]+:`\\S",
         next  : "entity"
       },
       {
-        token : tokens.entity,
-        regex : "_`",
+        token : ["text", tokens.entity],
+        regex : startStringPrefix + "(_`)(?=\\S)",
         next  : "entity"
       },
       {
@@ -147,8 +150,8 @@ var RSTHighlightRules = function() {
         regex : "_[A-Za-z0-9\\-]+?"
       },
       {
-        token : tokens.link,
-        regex : "`",
+        token : ["text", tokens.link],
+        regex : startStringPrefix + "(`)(?=\\S)",
         next  : "link"
       },
       {
@@ -197,7 +200,7 @@ var RSTHighlightRules = function() {
     "code": [
       {
         token : tokens.literal,
-        regex : "``",
+        regex : "\\S``" + endStringSuffix,
         next  : "start"
       },
       {
@@ -210,7 +213,7 @@ var RSTHighlightRules = function() {
     "bold": [
       {
         token : tokens.bold,
-        regex : "\\*\\*",
+        regex : "\\S\\*\\*" + endStringSuffix,
         next  : "start"
       },
       {
@@ -223,7 +226,7 @@ var RSTHighlightRules = function() {
     "italic": [
       {
         token : tokens.italic,
-        regex : "\\*",
+        regex : "\\S\\*" + endStringSuffix,
         next  : "start"
       },
       {
@@ -236,7 +239,7 @@ var RSTHighlightRules = function() {
     "entity": [
       {
         token : tokens.entity,
-        regex : "`",
+        regex : "\\S`" + endStringSuffix,
         next  : "start"
       },
       {
@@ -249,7 +252,7 @@ var RSTHighlightRules = function() {
     "link": [
       {
         token : tokens.link,
-        regex : "`__?",
+        regex : "\\S`__?" + endStringSuffix,
         next  : "start"
       },
       {

--- a/lib/ace/mode/rst_highlight_rules.js
+++ b/lib/ace/mode/rst_highlight_rules.js
@@ -113,24 +113,38 @@ var RSTHighlightRules = function() {
       /* Inline markup */
       {
         token : tokens.literal,
-        regex : "``(?:\\\\`|[^`])+?``"
+        regex : "``",
+        next  : "code"
       },
       {
         token : tokens.bold,
-        regex : "\\*\\*(?:\\\\\\*|[^\\*])+?\\*\\*"
+        regex : "\\*\\*",
+        next  : "bold"
       },
       {
         token : tokens.italic,
-        regex : "\\*(?:\\\\\\*|[^\\*])+?\\*"
+        regex : "\\*",
+        next  : "italic"
       },
       /* Link/footnote references */
       {
         token : tokens.entity,
-        regex : ":[\\w-]+:`[^`]+?`"
+        regex : ":[\\w-:]+:`",
+        next  : "entity"
+      },
+      {
+        token : tokens.entity,
+        regex : "_`",
+        next  : "entity"
+      },
+      {
+        token : tokens.entity,
+        regex : "_[A-Za-z0-9\\-]+?"
       },
       {
         token : tokens.link,
-        regex : "`[^`]+?`__?"
+        regex : "`",
+        next  : "link"
       },
       {
         token : tokens.link,
@@ -149,13 +163,10 @@ var RSTHighlightRules = function() {
       {
         token : tokens.table,
         regex : "\\|"
-      },
-      {
-        defaultToken : "text"
       }
     ],
 
-    /* This state is used for all directive bodies and litteral blocks.
+    /* This state is used for all directive bodies and literal blocks.
      * The parser returns to the "start" state when reaching the first
      * non-empty line that does not start with at least one space. */
     "codeblock": [
@@ -173,6 +184,71 @@ var RSTHighlightRules = function() {
         token : "empty",
         regex : "",
         next : "start"
+      }
+    ],
+
+    /* Inline code
+     * The parser returns to the "start" state when reaching "``" */
+    "code": [
+      {
+        token : tokens.literal,
+        regex : "``",
+        next  : "start"
+      },
+      {
+        defaultToken: tokens.literal
+      }
+    ],
+
+    /* Bold (strong) text
+     * The parser returns to the "start" state when reaching "**" */
+    "bold": [
+      {
+        token : tokens.bold,
+        regex : "\\*\\*",
+        next  : "start"
+      },
+      {
+        defaultToken: tokens.bold
+      }
+    ],
+
+    /* Italic (emphasis) text
+     * The parser returns to the "start" state when reaching "*" */
+    "italic": [
+      {
+        token : tokens.italic,
+        regex : "\\*",
+        next  : "start"
+      },
+      {
+        defaultToken: tokens.italic
+      }
+    ],
+
+    /* Explicit role/class text or link anchor definition
+     * The parser returns to the "start" state when reaching "`" */
+    "entity": [
+      {
+        token : tokens.entity,
+        regex : "`",
+        next  : "start"
+      },
+      {
+        defaultToken: tokens.entity
+      }
+    ],
+
+    /* Link reference
+     * The parser returns to the "start" state when reaching "`_" or "`__" */
+    "link": [
+      {
+        token : tokens.link,
+        regex : "`__?",
+        next  : "start"
+      },
+      {
+        defaultToken: tokens.link
       }
     ],
 

--- a/lib/ace/mode/rst_highlight_rules.js
+++ b/lib/ace/mode/rst_highlight_rules.js
@@ -126,6 +126,11 @@ var RSTHighlightRules = function() {
         regex : "\\*",
         next  : "italic"
       },
+      /* Substitution reference */
+      {
+        token : tokens.entity,
+        regex : "\\|[\\w\\-]+?\\|"
+      },
       /* Link/footnote references */
       {
         token : tokens.entity,

--- a/lib/ace/mode/rst_highlight_rules.js
+++ b/lib/ace/mode/rst_highlight_rules.js
@@ -37,112 +37,117 @@ var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 
 var RSTHighlightRules = function() {
 
+  var tokens = {
+    title: "markup.heading",
+    list: "markup.heading",
+    table: "constant",
+    directive: "keyword.operator",
+    entity: "string",
+    link: "markup.underline.list",
+    bold: "markup.bold",
+    italic: "markup.italic",
+    literal: "support.function",
+    comment: "comment"
+  };
+
   this.$rules = {
     "start": [
       /* NB: Only the underline of the heading is highlighted.
        * ACE tokenizer does not allow backtracking, the underlined text of the
        * heading cannot be highlighted. */
       {
-        token : "markup.heading",
+        token : tokens.title,
         regex : "(^)([\\=\\-`:\\.'\"~\\^_\\*\\+#])(\\2{2,}\\s*$)"
       },
       /* Generic directive syntax (e.g. .. code-block:: c)
        * All of the directive body is highlighted as a code block. */
       {
-        token : ["text", "keyword.operator", "markup.raw"],
-        regex : "(^\\s*)(\\.\\. [^:]+::)(.*$)",
+        token : [tokens.directive, tokens.literal],
+        regex : "(^\\s*\\.\\. [^:]+::)(.*$)",
         next  : "codeblock"
       },
       {
-        token : "keyword.operator",
+        token : tokens.directive,
         regex : "::$",
         next  : "codeblock"
       },
       /* Link/anchor definitions */
       {
-        token : "markup.link",
-        regex : "^\\.\\. _[^:]+:.*$"
+        token : [tokens.entity, tokens.link],
+        regex : "(^\\.\\. _[^:]+:)(.*$)"
       },
       {
-        token : "markup.link",
-        regex : "^__ https?://.*$"
+        token : [tokens.entity, tokens.link],
+        regex : "(^__ )(https?://.*$)"
       },
       /* Footnote definition */
       {
-        token : "markup.list",
+        token : tokens.entity,
         regex : "^\\.\\. \\[[^\\]]+\\] "
       },
       /* Comment block start */
       {
-        token : "comment",
+        token : tokens.comment,
         regex : "^\\.\\. .*$",
         next  : "comment"
       },
       /* List items */
       {
-        token : "markup.list",
-        regex : "^\\s*[\\*\\+-] "
-      },
-      {
-        token : "markup.list",
-        regex : "^\\s*\\d+\\. "
-      },
-      {
-        token : "markup.list",
-        regex : "^\\s*#\\. "
+        token : tokens.list,
+        regex : "^\\s*(?:[\\*\\+-]|\\d+\\.|#\\.) "
       },
       /* "Simple" tables */
       {
-        token : "markup.table",
+        token : tokens.table,
         regex : "^={2,}(?: +={2,})+$"
       },
       /* "Grid" tables */
       {
-        token : "markup.table",
+        token : tokens.table,
         regex : "^\\+-{2,}(?:\\+-{2,})+\\+$"
       },
       {
-        token : "markup.table",
+        token : tokens.table,
         regex : "^\\+={2,}(?:\\+={2,})+\\+$"
       },
       /* Inline markup */
       {
-        token : "markup.raw",
+        token : tokens.literal,
         regex : "``(?:\\\\`|[^`])+?``"
       },
       {
-        token : "markup.bold",
+        token : tokens.bold,
         regex : "\\*\\*(?:\\\\\\*|[^\\*])+?\\*\\*"
       },
       {
-        token : "markup.italic",
+        token : tokens.italic,
         regex : "\\*(?:\\\\\\*|[^\\*])+?\\*"
       },
       /* Link/footnote references */
       {
-        token : "markup.link",
+        token : tokens.entity,
         regex : ":[\\w-]+:`[^`]+?`"
       },
       {
-        token : "markup.link",
+        token : tokens.link,
         regex : "`[^`]+?`__?"
       },
       {
-        token : "markup.link",
+        token : tokens.link,
         regex : "[A-Za-z0-9\\-]+?__?"
       },
       {
-        token : "markup.link",
+        token : tokens.link,
         regex : "\\[[^\\]]+?\\]_"
       },
       {
-        token : "markup.link",
+        token : tokens.link,
         regex : "https?://\\S+"
       },
       /* "Grid" tables column separator
        * This is at the end to make it lower priority over all other rules. */
       {
-        token : "markup.table",
+        token : tokens.table,
         regex : "\\|"
       },
       {
@@ -155,12 +160,12 @@ var RSTHighlightRules = function() {
      * non-empty line that does not start with at least one space. */
     "codeblock": [
       {
-        token : "markup.raw",
+        token : tokens.literal,
         regex : "^ +.+$",
         next : "codeblock"
       },
       {
-        token : "markup.raw",
+        token : tokens.literal,
         regex : '^$',
         next: "codeblock"
       },
@@ -176,12 +181,12 @@ var RSTHighlightRules = function() {
      * non-empty line that does not start with at least one space. */
     "comment": [
       {
-        token : "comment",
+        token : tokens.comment,
         regex : "^ +.+$",
         next : "comment"
       },
       {
-        token : "comment",
+        token : tokens.comment,
         regex : '^$',
         next: "comment"
       },

--- a/lib/ace/mode/rst_highlight_rules.js
+++ b/lib/ace/mode/rst_highlight_rules.js
@@ -40,8 +40,8 @@ var RSTHighlightRules = function() {
   this.$rules = {
     "start": [
       /* NB: Only the underline of the heading is highlighted.
-       * ACE tokenizer works line per line, it is not possible to have tokens
-       * that spread on multiple lines. */
+       * ACE tokenizer does not allow backtracking, the underlined text of the
+       * heading cannot be highlighted. */
       {
         token : "markup.heading",
         regex : "(^)([\\=\\-`:\\.'\"~\\^_\\*\\+#])(\\2{2,}\\s*$)"

--- a/lib/ace/mode/rst_highlight_rules.js
+++ b/lib/ace/mode/rst_highlight_rules.js
@@ -97,7 +97,15 @@ var RSTHighlightRules = function() {
       /* List items */
       {
         token : tokens.list,
-        regex : "^\\s*(?:[\\*\\+-]|\\d+\\.|#\\.) "
+        regex : "^\\s*[\\*\\+-] "
+      },
+      {
+        token : tokens.list,
+        regex : "^\\s*(?:[A-Za-z]|[0-9]+|[ivxlcdmIVXLCDM]+)\\. "
+      },
+      {
+        token : tokens.list,
+        regex : "^\\s*\\(?(?:[A-Za-z]|[0-9]+|[ivxlcdmIVXLCDM]+)\\) "
       },
       /* "Simple" tables */
       {


### PR DESCRIPTION
* support multi-line inline markup
* fix comment about headings
* add support for substitution references
* add more rst example text in kitchen-sink