### PR TITLE
Fix autocompletion error in php mode

### DIFF
--- a/lib/ace/mode/php_completions.js
+++ b/lib/ace/mode/php_completions.js
@@ -9374,11 +9374,10 @@ var PhpCompletions = function() {
 
     this.getArrayKeyCompletions = function(state, session, pos, prefix) {
         var line = session.getLine(pos.row).substr(0, pos.column);
-        /(\$[\w]*)\[["']([^'"]*)$/i.test(line);
-        var variable = RegExp.$1;
+        var variable = line.match(/(\$[\w]*)\[["']([^'"]*)$/i)[1];
 
         if (!variableMap[variable]) {
-            return;
+            return [];
         }
 
         var keys = [];


### PR DESCRIPTION
Fix 'variable' always be '' in chrome
Fix getArrayKeyCompletions() should not return undefined