### PR TITLE
Fix comment regex for vbscript highlighter

### DIFF
--- a/lib/ace/mode/vbscript_highlight_rules.js
+++ b/lib/ace/mode/vbscript_highlight_rules.js
@@ -84,7 +84,7 @@ var VBScriptHighlightRules = function() {
         },
         {
             token: "punctuation.definition.comment.asp",
-            regex: "'|REM",
+            regex: "'|REM[ \t]",
             next: "comment",
             caseInsensitive: true
         },


### PR DESCRIPTION
All lines starting by rem where considered as comment which is wrong :
Dim remake as Integer (remake is a variable, not a comment)