### PR TITLE
Fix comment regex for vbscript highlighter

### DIFF
--- a/lib/ace/mode/vbscript_highlight_rules.js
+++ b/lib/ace/mode/vbscript_highlight_rules.js
@@ -84,7 +84,7 @@ var VBScriptHighlightRules = function() {
         },
         {
             token: "punctuation.definition.comment.asp",
-            regex: "'|REM",
+            regex: "'|REM\\b",
             next: "comment",
             caseInsensitive: true
         },


### PR DESCRIPTION
only lines starting with a correct "rem" word should be considered as comments