### PR TITLE
Update razor_highlight_rule for @functions block

### DIFF
--- a/lib/ace/mode/razor_highlight_rules.js
+++ b/lib/ace/mode/razor_highlight_rules.js
@@ -58,10 +58,10 @@ oop.inherits(RazorLangHighlightRules, CSharpHighlightRules);
 var RazorHighlightRules = function() {
     HtmlHighlightRules.call(this);
 
-    // 'Blocks': @{}, @()
+    // 'Blocks': @{}, @(), @functions{}
 
     var blockStartRule = {
-        regex: '@[({]',
+        regex: '@[({]|@functions{',
         onMatch: function(value, state, stack) {
             stack.unshift(value);
             stack.unshift('razor-block-start');
@@ -72,7 +72,8 @@ var RazorHighlightRules = function() {
 
     var blockEndMap = {
         '@{': '}',
-        '@(': ')'
+        '@(': ')',
+        '@functions{':'}'
     };
 
     var blockEndRule = {


### PR DESCRIPTION
add regex for `@functions` block of razor.

Razor user write many functions or class in `@functions` block and write many comments.
So we need highlight :)