### PR TITLE
Fix typos

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -1033,8 +1033,8 @@ var Editor = function(renderer, session) {
     };
 
     /**
-     * Pass in `true` to enable overwrites in your session, or `false` to disable. If overwrites is enabled, any text you enter will type over any text after it. If the value of `overwrite` changes, this function also emites the `changeOverwrite` event.
-     * @param {Boolean} overwrite Defines wheter or not to set overwrites
+     * Pass in `true` to enable overwrites in your session, or `false` to disable. If overwrites is enabled, any text you enter will type over any text after it. If the value of `overwrite` changes, this function also emits the `changeOverwrite` event.
+     * @param {Boolean} overwrite Defines whether or not to set overwrites
      *
      *
      * @related EditSession.setOverwrite
@@ -1831,7 +1831,7 @@ var Editor = function(renderer, session) {
     };
 
     /**
-     * Returns the number of currently visibile rows.
+     * Returns the number of currently visible rows.
      * @returns {Number}
      **/
     this.$getVisibleRowCount = function() {
@@ -2181,7 +2181,7 @@ var Editor = function(renderer, session) {
     };
 
     /**
-     * Moves the cursor to the specified line number, and also into the indiciated column.
+     * Moves the cursor to the specified line number, and also into the indicated column.
      * @param {Number} lineNumber The line number to go to
      * @param {Number} column A column number to go to
      * @param {Boolean} animate If `true` animates scolling
@@ -2338,7 +2338,7 @@ var Editor = function(renderer, session) {
     };
 
     /**
-     * Replaces the first occurance of `options.needle` with the value in `replacement`.
+     * Replaces the first occurrence of `options.needle` with the value in `replacement`.
      * @param {String} replacement The text to replace with
      * @param {Object} options The [[Search `Search`]] options to use
      *
@@ -2365,7 +2365,7 @@ var Editor = function(renderer, session) {
     };
 
     /**
-     * Replaces all occurances of `options.needle` with the value in `replacement`.
+     * Replaces all occurrences of `options.needle` with the value in `replacement`.
      * @param {String} replacement The text to replace with
      * @param {Object} options The [[Search `Search`]] options to use
      *


### PR DESCRIPTION
Found some typos in the inline documentation -
`emites` → `emits`
`wheter` → `whether`
`visibile` → `visible`
`indiciated` → `indicated`
`occurance` → `occurrence`
`occurances` → `occurrences`