### PR TITLE
user-override for regex finding completion identifier

### DIFF
--- a/lib/ace/autocomplete/util.js
+++ b/lib/ace/autocomplete/util.js
@@ -45,10 +45,7 @@ exports.parForEach = function(array, fn, callback) {
     }
 };
 
-var ID_REGEX = /[a-zA-Z_0-9\$\-\u00A2-\uFFFF]/;
-
 exports.retrievePrecedingIdentifier = function(text, pos, regex) {
-    regex = regex || ID_REGEX;
     var buf = [];
     for (var i = pos-1; i >= 0; i--) {
         if (regex.test(text[i]))
@@ -60,7 +57,6 @@ exports.retrievePrecedingIdentifier = function(text, pos, regex) {
 };
 
 exports.retrieveFollowingIdentifier = function(text, pos, regex) {
-    regex = regex || ID_REGEX;
     var buf = [];
     for (var i = pos; i < text.length; i++) {
         if (regex.test(text[i]))
@@ -70,6 +66,8 @@ exports.retrieveFollowingIdentifier = function(text, pos, regex) {
     }
     return buf;
 };
+
+var ID_REGEX = /[a-zA-Z_0-9\$\-\u00A2-\uFFFF]/;
 
 exports.getCompletionPrefix = function (editor) {
     var pos = editor.getCursorPosition();
@@ -83,7 +81,7 @@ exports.getCompletionPrefix = function (editor) {
             }.bind(this));
         }
     }.bind(this));
-    return prefix || this.retrievePrecedingIdentifier(line, pos.column);
+    return prefix || this.retrievePrecedingIdentifier(line, pos.column, editor.$defaultCompletionIdentifierRegex || ID_REGEX);
 };
 
 });


### PR DESCRIPTION
When your autocompleter's identifierRegexps don't match the preceding
characters, Ace will revert to a default identifier regexp (ID_REGEX).
It is however not given that you wish to use this one as it may filter
out completion alternatives that shouldn't be filtered out.

In my case I have a list of regular expressions which I wish to have as
autocompletion in an editor. Regardless of preceding characters, I wish
to display either all regular expressions in the list, or a subset which
I've filtered out using other means in my completer's "getCompletion()"
function. It is not possible for me to tell what characters will precede
the regular expression that is to be added in the text field.
I tried solving this by setting "identifierRegexps = [/a^/]" in my
completer (so it would match nothing), but since it doesn't match
anything, Ace will fall back on using ID_REGEX. And in the case I wanted
to add a regex "ABC<here>ABC", Ace would only list the regular
expressions in my list that started with "abc".

This patch makes it possible to set another fallback regex for
autocompletion when none of the completers' identifierRegexps match.
To set another fallback regex a user would do this in his/her code:
editor.$defaultCompletionIdentifierRegex = /[custom]/;