### PR TITLE
Explicitly left-align Ace editor text

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -3,6 +3,7 @@
     overflow: hidden;
     font: 12px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
     direction: ltr;
+    text-align: left;
 }
 
 .ace_scroller {


### PR DESCRIPTION
If a parent of the Ace container has a different text-align value, Ace will otherwise inherit that alignment, which conflicts with the way that Ace operates assuming left-aligned text.