### PR TITLE
ACE ends in infinite loop and hangs browser because gutterOffset is NaN from a divide by zero

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -1032,7 +1032,7 @@ var VirtualRenderer = function(container, theme) {
             minHeight : minHeight,
             maxHeight : maxHeight,
             offset : offset,
-            gutterOffset : Math.max(0, Math.ceil((offset + size.height - size.scrollerHeight) / lineHeight)),
+            gutterOffset : lineHeight ? Math.max(0, Math.ceil((offset + size.height - size.scrollerHeight) / lineHeight)) : 0,
             height : this.$size.scrollerHeight
         };
 


### PR DESCRIPTION
I found ACE stuck in [this infinite loop](https://github.com/ajaxorg/ace/blob/74712db7068d01378145890c0c4c6bc428439df9/lib/ace/layer/gutter.js#L137) when updating the gutter because `gutterOffset` was NaN. When it is NaN, all math operations are NaN or false and it never exits the loop and hangs the browser.

The culprit is a divide check from a value that can be 0.