### PR TITLE
display xml syntax error in case unknown namespace prefix used

### DIFF
--- a/lib/ace/mode/xml/sax.js
+++ b/lib/ace/mode/xml/sax.js
@@ -154,7 +154,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 						errorHandler.warning('unclosed xml attribute');
 					}
 				}
-				appendElement(el,domBuilder,parseStack);
+				appendElement(el,domBuilder,parseStack,errorHandler);
 				
 				
 				if(el.uri === 'http://www.w3.org/1999/xhtml' && !el.closed){
@@ -347,7 +347,7 @@ function parseElementStartPart(source,start,el,entityReplacer,errorHandler){
 /**
  * @return end of the elementStartPart(end of elementEndPart for selfClosed el)
  */
-function appendElement(el,domBuilder,parseStack){
+function appendElement(el,domBuilder,parseStack,errorHandler){
 	var tagName = el.tagName;
 	var localNSMap = null;
 	var currentNSMap = parseStack[parseStack.length-1].currentNSMap;
@@ -405,6 +405,9 @@ function appendElement(el,domBuilder,parseStack){
 	}
 	//no prefix element has default namespace
 	var ns = el.uri = currentNSMap[prefix || ''];
+	if (prefix && !ns) {
+		errorHandler.error('unexpected namespace ' + prefix);
+	}
 	domBuilder.startElement(ns,localName,tagName,el);
 	//endPrefixMapping and startPrefixMapping have not any help for dom builder
 	//localNSMap = null


### PR DESCRIPTION
Following xml passed syntax check, though it shouldn't

```
<Select>
    <core:a key="123" notexist="true" text="Text"/>
</Select>
```

fix checks that prefix (core) namespace do exists
