### PR TITLE
Pass "globals" option into jshint in javascript mode.

### DIFF
--- a/lib/ace/mode/javascript_worker.js
+++ b/lib/ace/mode/javascript_worker.js
@@ -125,7 +125,7 @@ oop.inherits(JavaScriptWorker, Mirror);
         var maxErrorLevel = this.isValidJS(value) ? "warning" : "error";
 
         // var start = new Date();
-        lint(value, this.options);
+        lint(value, this.options, this.options.globals);
         var results = lint.errors;
 
         var errorAdded = false


### PR DESCRIPTION
I took this change from http://stackoverflow.com/questions/28434455/how-to-add-some-known-objects-to-ace-editors-syntax-checker verbatim.

It allows code like this:

		ace.session.on('changeMode', function(e, session) {
			if ("ace/mode/javascript" === session.getMode().$id) {
				if (!!session.$worker) {
					session.$worker.send("setOptions", [ {
						globals: { input: false, output: true },
						strict : "implied"
					} ]);
				}
			}
		});

to work as desired.

Without this change the strict mode *is* properly set to "implied" but the globals are not honored.