### PR TITLE
[CSS Completer] Add colon next the cursor when completing a property

### DIFF
--- a/lib/ace/mode/css_completions.js
+++ b/lib/ace/mode/css_completions.js
@@ -180,7 +180,7 @@ var CssCompletions = function() {
         return properties.map(function(property){
             return {
                 caption: property,
-                snippet: property + ': $0',
+                snippet: property + ': $0;',
                 meta: "property",
                 score: Number.MAX_VALUE
             };


### PR DESCRIPTION
Fix #2839
