### PR TITLE
Adjusted "insert" so minification couldn't wrongly replace whitespace.

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -971,7 +971,7 @@ var Editor = function(renderer, session) {
             }
         }
         
-        if (text == "\t")
+        if (text == String.fromCharCode(9))
             text = this.session.getTabString();
 
         // remove selected text


### PR DESCRIPTION
Found while building an app that minification ate "\t" on line 974 and replaced it with " ". This is one, probably naive, way to prevent that happening again.

Symptom of the problem: even with useSoftTabs disabled, spaces entered were being replaced with a number of spaces equal to session.$tabSize

Symptom existed only when using minified sources, pulled both from ajaxorg/ace-builds and from the jsdelivr CDN. In chrome, the resultant error is in the "pretty printed" minified file at line 9730.