### PR TITLE
Move searchbox to scroller element so it doesn't hide the scrollbar

### DIFF
--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -72,7 +72,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
 (function() {
     this.setEditor = function(editor) {
         editor.searchBox = this;
-        editor.container.appendChild(this.element);
+        editor.renderer.scroller.appendChild(this.element);
         this.editor = editor;
     };
 


### PR DESCRIPTION
On a related note, I also tried moving this searchbox to the content element, but it jitters when scrolling.

Still, the scroller element seems to be the perfect place.
