### PR TITLE
fix regex in tex highlight rules

### DIFF
--- a/lib/ace/mode/_test/tokens_tex.json
+++ b/lib/ace/mode/_test/tokens_tex.json
@@ -77,9 +77,8 @@
 ],[
    "start",
   ["text"," x="],
-  ["keyword","\\left\\"],
-  ["paren.keyword.operator","{"],
-  ["text"," "],
+  ["keyword","\\left"],
+  ["text", "\\{ "],
   ["keyword","\\begin"],
   ["paren.keyword.operator","{"],
   ["nospell.text","array"],

--- a/lib/ace/mode/tex_highlight_rules.js
+++ b/lib/ace/mode/tex_highlight_rules.js
@@ -64,7 +64,7 @@ var TexHighlightRules = function(textClass) {
                next : "nospell"
             }, {
                 token : "keyword", // command
-                regex : "\\\\(?:[a-zA-z0-9]+|[^a-zA-z0-9])"
+                regex : "\\\\(?:[a-zA-Z0-9]+|[^a-zA-Z0-9])"
             }, {
                // Obviously these are neither keywords nor operators, but
                // labelling them as such was the easiest way to get them
@@ -98,7 +98,7 @@ var TexHighlightRules = function(textClass) {
                regex : "\\\\(?:documentclass|usepackage|newcounter|setcounter|addtocounter|value|arabic|stepcounter|newenvironment|renewenvironment|ref|vref|eqref|pageref|label|cite[a-zA-Z]*|tag|begin|end|bibitem)\\b"
            }, {
                token : "keyword", // command
-               regex : "\\\\(?:[a-zA-z0-9]+|[^a-zA-z0-9])",
+               regex : "\\\\(?:[a-zA-Z0-9]+|[^a-zA-Z0-9])",
                next : "start"
            }, {
                token : "paren.keyword.operator",


### PR DESCRIPTION
This fixes an issue where commands are highlighted incorrectly in tex mode:

<img width="185" alt="screen shot 2016-06-04 at 2 05 59 pm" src="https://cloud.githubusercontent.com/assets/1976582/15802113/7d75d7ac-2a5d-11e6-8da8-7bf1deb1d748.png">

Note that the `[option]` bit is tokenized as part of the keyword due to the incorrect regular expression.