### PR TITLE
Fix long completion highlights

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -456,7 +456,7 @@ var FilteredList = function(array, filterText) {
             var caption = item.value || item.caption || item.snippet;
             if (!caption) continue;
             var lastIndex = -1;
-            var matchMask = [];
+            var matchIndexLookup = {};
             var penalty = 0;
             var index, distance;
 
@@ -479,11 +479,11 @@ var FilteredList = function(array, filterText) {
                             penalty += 10;
                         penalty += distance;
                     }
-                    matchMask.push(index);
+                    matchIndexLookup[index] = true;
                     lastIndex = index;
                 }
             }
-            item.matchMask = matchMask;
+            item.matchIndexLookup = matchIndexLookup;
             item.exactMatch = penalty ? 0 : 1;
             item.score = (item.score || 0) - penalty;
             results.push(item);

--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -456,7 +456,7 @@ var FilteredList = function(array, filterText) {
             var caption = item.value || item.caption || item.snippet;
             if (!caption) continue;
             var lastIndex = -1;
-            var matchMask = 0;
+            var matchMask = [];
             var penalty = 0;
             var index, distance;
 
@@ -479,7 +479,7 @@ var FilteredList = function(array, filterText) {
                             penalty += 10;
                         penalty += distance;
                     }
-                    matchMask = matchMask | (1 << index);
+                    matchMask.push(index);
                     lastIndex = index;
                 }
             }

--- a/lib/ace/autocomplete/popup.js
+++ b/lib/ace/autocomplete/popup.js
@@ -185,7 +185,7 @@ var AcePopup = function(parentNode) {
         var flag, c;
         for (var i = 0; i < data.caption.length; i++) {
             c = data.caption[i];
-            flag = data.matchMask.indexOf(i) >= 0 ? 1 : 0;
+            flag = data.matchIndexLookup[i] ? 1 : 0;
             if (last !== flag) {
                 tokens.push({type: data.className || "" + ( flag ? "completion-highlight" : ""), value: c});
                 last = flag;

--- a/lib/ace/autocomplete/popup.js
+++ b/lib/ace/autocomplete/popup.js
@@ -185,7 +185,7 @@ var AcePopup = function(parentNode) {
         var flag, c;
         for (var i = 0; i < data.caption.length; i++) {
             c = data.caption[i];
-            flag = data.matchMask & (1 << i) ? 1 : 0;
+            flag = data.matchMask.indexOf(i) >= 0 ? 1 : 0;
             if (last !== flag) {
                 tokens.push({type: data.className || "" + ( flag ? "completion-highlight" : ""), value: c});
                 last = flag;

--- a/lib/ace/autocomplete_popup_tokenizer_test.js
+++ b/lib/ace/autocomplete_popup_tokenizer_test.js
@@ -1,0 +1,97 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+if (typeof process !== "undefined") {
+    require("amd-loader");
+    require("./test/mockdom");
+}
+
+define(function(require, exports, module) {
+"use strict";
+
+var EditSession = require("./edit_session").EditSession;
+var Editor = require("./editor").Editor;
+var Text = require("./mode/text").Mode;
+var MockRenderer = require("./test/mockrenderer").MockRenderer;
+var Autocomplete = require("./autocomplete").Autocomplete;
+var assert = require("./test/assertions");
+var textCompleter = require("./autocomplete/text_completer");
+
+function forceTokenize(session){
+    for (var i = 0, l = session.getLength(); i < l; i++)
+        session.getTokens(i)
+}
+
+module.exports = {
+
+    setUp : function(next) {
+        this.editor = new Editor(new MockRenderer());
+        this.editor.completers = [textCompleter];
+        this.autocomplete = new Autocomplete();
+        next();
+    },
+
+    "test: popup tokenizer works on string exactly 31 characters": function() {
+        var session = new EditSession(["000000000000000000000000000000A A"]);
+        this.editor.setSession(session);
+        this.editor.getSession().getSelection().moveCursorTo(1, 0);
+        this.editor.completer = this.autocomplete;
+        this.editor.completer.autoInsert = 
+        this.editor.completer.autoSelect = false;
+        this.editor.completer.showPopup(this.editor, true);
+
+        var tokens = this.autocomplete.popup.session.getTokens(0);
+        // should be one token before highlight, one token for highlight
+        // and one token for meta tag
+        assert.equal(tokens.length, 3);
+    },
+
+    "test: popup tokenizer works on string over 31 characters" : function() {
+        var session = new EditSession(["000000000000000000000000000000X00A A"]);
+        this.editor.setSession(session);
+        this.editor.getSession().getSelection().moveCursorTo(1, 0);
+        this.editor.completer = this.autocomplete;
+        this.editor.completer.autoInsert = 
+        this.editor.completer.autoSelect = false;
+        this.editor.completer.showPopup(this.editor, true);
+
+        var tokens = this.autocomplete.popup.session.getTokens(0);
+        // should be one token before highlight, one token for highlight
+        // and one token for meta tag
+        assert.equal(tokens.length, 3);
+    },
+
+};
+
+});
+
+if (typeof module !== "undefined" && module === require.main) {
+    require("asyncjs").test.testcase(module.exports).exec()
+}

--- a/lib/ace/test/all_browser.js
+++ b/lib/ace/test/all_browser.js
@@ -56,6 +56,7 @@ var testNames = [
     "ace/snippets_test",
     "ace/token_iterator_test",
     "ace/tokenizer_test",
+    "ace/autocomplete_popup_tokenizer_test",
     "ace/virtual_renderer_test"
 ];
 

--- a/lib/ace/test/mockrenderer.js
+++ b/lib/ace/test/mockrenderer.js
@@ -187,6 +187,19 @@ MockRenderer.prototype.setStyle = function() {
 MockRenderer.prototype.unsetStyle = function() {
 };
 
+MockRenderer.prototype.getTheme = function() {
+};
+
+MockRenderer.prototype.getOption = function() {
+    return {};
+};
+
+MockRenderer.prototype.$cursorLayer = {
+    getPixelPosition: function() {
+        return { top: 0, left: 0 };
+    }
+};
+
 MockRenderer.prototype.textToScreenCoordinates = function() {
     return {
         pageX: 0,


### PR DESCRIPTION
This builds on https://github.com/ajaxorg/ace/pull/2634 to fix https://github.com/ajaxorg/ace/issues/2632.

The additional commit here introduces a constant time lookup for checking if an index should be highlighted (replacing the array scans introduced in https://github.com/ajaxorg/ace/pull/2634)

There was some discussion in https://github.com/ajaxorg/ace/pull/2634 of the increased memory usage here.  For a match of length `m` with `n` matches, this stores `m*n` numbers which, though square-ish looking, is completely manageable in practice (since both the match length and number of matches are well bounded in general).

Thanks @pthurlow for getting the ball rolling here and writing a great test.

(Note my signed CLA has already been accepted)
