### PR TITLE
Haskell: fix import with identifier list

### DIFF
--- a/lib/ace/mode/haskell_highlight_rules.js
+++ b/lib/ace/mode/haskell_highlight_rules.js
@@ -44,8 +44,8 @@ var HaskellHighlightRules = function() {
     // regexp must not have capturing parentheses. Use (?:) instead.
     // regexps are ordered -> the first match is used
 
-    this.$rules = { start: 
-       [ { token: 
+    this.$rules = { start:
+       [ { token:
             [ 'punctuation.definition.entity.haskell',
               'keyword.operator.function.infix.haskell',
               'punctuation.definition.entity.haskell' ],
@@ -56,7 +56,7 @@ var HaskellHighlightRules = function() {
            regex: '\\[\\]' },
          { token: 'keyword.other.haskell',
            regex: '\\bmodule\\b',
-           push: 
+           push:
             [ { token: 'keyword.other.haskell', regex: '\\bwhere\\b', next: 'pop' },
               { include: '#module_name' },
               { include: '#module_exports' },
@@ -64,7 +64,7 @@ var HaskellHighlightRules = function() {
               { defaultToken: 'meta.declaration.module.haskell' } ] },
          { token: 'keyword.other.haskell',
            regex: '\\bclass\\b',
-           push: 
+           push:
             [ { token: 'keyword.other.haskell',
                 regex: '\\bwhere\\b',
                 next: 'pop' },
@@ -77,7 +77,7 @@ var HaskellHighlightRules = function() {
               { defaultToken: 'meta.declaration.class.haskell' } ] },
          { token: 'keyword.other.haskell',
            regex: '\\binstance\\b',
-           push: 
+           push:
             [ { token: 'keyword.other.haskell',
                 regex: '\\bwhere\\b|$',
                 next: 'pop' },
@@ -85,15 +85,15 @@ var HaskellHighlightRules = function() {
               { defaultToken: 'meta.declaration.instance.haskell' } ] },
          { token: 'keyword.other.haskell',
            regex: 'import',
-           push: 
-            [ { token: 'meta.import.haskell', regex: '$|;', next: 'pop' },
+           push:
+            [ { token: 'meta.import.haskell', regex: '$|;|^', next: 'pop' },
               { token: 'keyword.other.haskell', regex: 'qualified|as|hiding' },
               { include: '#module_name' },
               { include: '#module_exports' },
               { defaultToken: 'meta.import.haskell' } ] },
          { token: [ 'keyword.other.haskell', 'meta.deriving.haskell' ],
            regex: '(deriving)(\\s*\\()',
-           push: 
+           push:
             [ { token: 'meta.deriving.haskell', regex: '\\)', next: 'pop' },
               { token: 'entity.other.inherited-class.haskell',
                 regex: '\\b[A-Z][a-zA-Z_\']*' },
@@ -108,7 +108,7 @@ var HaskellHighlightRules = function() {
            comment: 'Floats are always decimal' },
          { token: 'constant.numeric.haskell',
            regex: '\\b(?:[0-9]+|0(?:[xX][0-9a-fA-F]+|[oO][0-7]+))\\b' },
-         { token: 
+         { token:
             [ 'meta.preprocessor.c',
               'punctuation.definition.preprocessor.c',
               'meta.preprocessor.c' ],
@@ -117,7 +117,7 @@ var HaskellHighlightRules = function() {
          { include: '#pragma' },
          { token: 'punctuation.definition.string.begin.haskell',
            regex: '"',
-           push: 
+           push:
             [ { token: 'punctuation.definition.string.end.haskell',
                 regex: '"',
                 next: 'pop' },
@@ -128,7 +128,7 @@ var HaskellHighlightRules = function() {
               { token: 'constant.character.escape.control.haskell',
                 regex: '\\^[A-Z@\\[\\]\\\\\\^_]' },
               { defaultToken: 'string.quoted.double.haskell' } ] },
-         { token: 
+         { token:
             [ 'punctuation.definition.string.begin.haskell',
               'string.quoted.single.haskell',
               'constant.character.escape.haskell',
@@ -137,13 +137,13 @@ var HaskellHighlightRules = function() {
               'constant.character.escape.control.haskell',
               'punctuation.definition.string.end.haskell' ],
            regex: '(\')(?:([\\ -\\[\\]-~])|(\\\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\"\'\\&]))|(\\\\o[0-7]+)|(\\\\x[0-9A-Fa-f]+)|(\\^[A-Z@\\[\\]\\\\\\^_]))(\')' },
-         { token: 
+         { token:
             [ 'meta.function.type-declaration.haskell',
               'entity.name.function.haskell',
               'meta.function.type-declaration.haskell',
               'keyword.other.double-colon.haskell' ],
            regex: '^(\\s*)([a-z_][a-zA-Z0-9_\']*|\\([|!%$+\\-.,=</>]+\\))(\\s*)(::)',
-           push: 
+           push:
             [ { token: 'meta.function.type-declaration.haskell',
                 regex: '$',
                 next: 'pop' },
@@ -160,32 +160,32 @@ var HaskellHighlightRules = function() {
            regex: '[|!%$?~+:\\-.=</>\\\\]+',
            comment: 'In case this regex seems overly general, note that Haskell permits the definition of new operators which can be nearly any string of punctuation characters, such as $%^&*.' },
          { token: 'punctuation.separator.comma.haskell', regex: ',' } ],
-      '#block_comment': 
+      '#block_comment':
        [ { token: 'punctuation.definition.comment.haskell',
            regex: '\\{-(?!#)',
-           push: 
+           push:
             [ { include: '#block_comment' },
               { token: 'punctuation.definition.comment.haskell',
                 regex: '-\\}',
                 next: 'pop' },
               { defaultToken: 'comment.block.haskell' } ] } ],
-      '#comments': 
+      '#comments':
        [ { token: 'punctuation.definition.comment.haskell',
            regex: '--.*',
-           push_: 
+           push_:
             [ { token: 'comment.line.double-dash.haskell',
                 regex: '$',
                 next: 'pop' },
               { defaultToken: 'comment.line.double-dash.haskell' } ] },
          { include: '#block_comment' } ],
-      '#infix_op': 
+      '#infix_op':
        [ { token: 'entity.name.function.infix.haskell',
            regex: '\\([|!%$+:\\-.=</>]+\\)|\\(,+\\)' } ],
-      '#module_exports': 
+      '#module_exports':
        [ { token: 'meta.declaration.exports.haskell',
            regex: '\\(',
-           push: 
-            [ { token: 'meta.declaration.exports.haskell',
+           push:
+            [ { token: 'meta.declaration.exports.haskell.end',
                 regex: '\\)',
                 next: 'pop' },
               { token: 'entity.name.function.haskell',
@@ -196,22 +196,22 @@ var HaskellHighlightRules = function() {
               { token: 'meta.other.unknown.haskell',
                 regex: '\\(.*?\\)',
                 comment: 'So named because I don\'t know what to call this.' },
-              { defaultToken: 'meta.declaration.exports.haskell' } ] } ],
-      '#module_name': 
+              { defaultToken: 'meta.declaration.exports.haskell.end' } ] } ],
+      '#module_name':
        [ { token: 'support.other.module.haskell',
            regex: '[A-Z][A-Za-z._\']*' } ],
-      '#pragma': 
+      '#pragma':
        [ { token: 'meta.preprocessor.haskell',
            regex: '\\{-#',
-           push: 
+           push:
             [ { token: 'meta.preprocessor.haskell',
                 regex: '#-\\}',
                 next: 'pop' },
               { token: 'keyword.other.preprocessor.haskell',
                 regex: '\\b(?:LANGUAGE|UNPACK|INLINE)\\b' },
               { defaultToken: 'meta.preprocessor.haskell' } ] } ],
-      '#type_signature': 
-       [ { token: 
+      '#type_signature':
+       [ { token:
             [ 'meta.class-constraint.haskell',
               'entity.other.inherited-class.haskell',
               'meta.class-constraint.haskell',
@@ -230,7 +230,7 @@ var HaskellHighlightRules = function() {
            regex: '\\b[A-Z][a-zA-Z0-9_\']*\\b' },
          { token: 'support.constant.unit.haskell', regex: '\\(\\)' },
          { include: '#comments' } ] }
-    
+
     this.normalizeRules();
 };
 


### PR DESCRIPTION
In the following Haskell code:

```
import           Data.Aeson (Value(..))
import           Network.Wai (Application)
import Network.Wai.Middleware.Static
```

The last two imports are not correctly highlighted. This fixes it.