### PR TITLE
Haskell Cabal mode, with folding

### DIFF
--- a/demo/kitchen-sink/docs/haskell_cabal.cabal
+++ b/demo/kitchen-sink/docs/haskell_cabal.cabal
@@ -1,0 +1,77 @@
+name:                reload
+version:             0.1.0.0
+synopsis:            Initial project template from stack
+Description:
+    The \'cabal\' command-line program simplifies the process of managing
+    Haskell software by automating the fetching, configuration, compilation
+    and installation of Haskell libraries and programs.
+homepage:            https://github.com/jpmoresmau/dbIDE/reload#readme
+license:             BSD3
+license-file:        LICENSE
+author:              JP Moresmau
+maintainer:          jpmoresmau@gmail.com
+copyright:           2016 JP Moresmau
+category:            Web
+build-type:          Simple
+-- extra-source-files:
+cabal-version:       >=1.10
+
+Flag network-uri
+  description:  Get Network.URI from the network-uri package
+  default:      True
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Language.Haskell.Reload
+  build-depends:       base >= 4.7 && < 5
+                     , aeson
+                     , scotty
+                     , wai
+                     , text
+                     , directory
+                     , filepath
+                     , bytestring
+                     , containers
+                     , mime-types
+                     , transformers
+                     , wai-handler-launch
+                     , wai-middleware-static
+                     , wai-extra
+                     , http-types
+  default-language:    Haskell2010
+  other-modules:       Language.Haskell.Reload.FileBrowser
+  ghc-options:         -Wall -O2
+
+executable reload-exe
+  hs-source-dirs:      app
+  main-is:             Main.hs
+  ghc-options:         -threaded -O2 -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , reload
+  default-language:    Haskell2010
+
+test-suite reload-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:       base
+                     , reload
+                     , hspec
+                     , hspec-wai
+                     , hspec-wai-json
+                     , aeson
+                     , directory
+                     , filepath
+                     , text
+                     , containers
+                     , unordered-containers
+                     , bytestring
+                     , wai-extra
+  ghc-options:         -threaded -O2 -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+  other-modules:       Language.Haskell.Reload.FileBrowserSpec
+                       Language.Haskell.ReloadSpec
+
+source-repository head
+  type:     git
+  location: https://github.com/jpmoresmau/dbIDE/reload

--- a/lib/ace/ext/modelist.js
+++ b/lib/ace/ext/modelist.js
@@ -88,6 +88,7 @@ var supportedModes = {
     HAML:        ["haml"],
     Handlebars:  ["hbs|handlebars|tpl|mustache"],
     Haskell:     ["hs"],
+    Haskell_Cabal:     ["cabal"],
     haXe:        ["hx"],
     HTML:        ["html|htm|xhtml"],
     HTML_Elixir: ["eex|html.eex"],

--- a/lib/ace/mode/folding/haskell_cabal.js
+++ b/lib/ace/mode/folding/haskell_cabal.js
@@ -48,7 +48,7 @@ oop.inherits(FoldMode, BaseFoldMode);
   this.isHeading = function (session,row) {
       var heading = "markup.heading";
       var token = session.getTokens(row)[0];
-      return row==0 || (token && token.type.lastIndexOf(heading, 0) === 0);
+      return row==0 || (token && token.type.lastIndexOf(heading, 0) === 0);
   };
 
   this.getFoldWidget = function(session, foldStyle, row) {

--- a/lib/ace/mode/folding/haskell_cabal.js
+++ b/lib/ace/mode/folding/haskell_cabal.js
@@ -1,0 +1,115 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+/*
+* Folding mode for Cabal files (Haskell): allow folding each seaction, including
+* the initial general section.
+*/
+define(function(require, exports, module) {
+"use strict";
+
+var oop = require("../../lib/oop");
+var BaseFoldMode = require("./fold_mode").FoldMode;
+var Range = require("../../range").Range;
+
+var FoldMode = exports.FoldMode = function() {};
+oop.inherits(FoldMode, BaseFoldMode);
+
+(function() {
+  /**
+  is the row a heading?
+  */
+  this.isHeading = function (session,row) {
+      var heading = "markup.heading";
+      var token = session.getTokens(row)[0];
+      return row==0 || (token && token.type.lastIndexOf(heading, 0) === 0);
+  };
+
+  this.getFoldWidget = function(session, foldStyle, row) {
+      if (this.isHeading(session,row)){
+        return "start";
+      } else if (foldStyle === "markbeginend" && !(/^\s*$/.test(session.getLine(row)))){
+        var maxRow = session.getLength();
+        while (++row < maxRow) {
+          if (!(/^\s*$/.test(session.getLine(row)))){
+              break;
+          }
+        }
+        if (row==maxRow || this.isHeading(session,row)){
+          return "end";
+        }
+      }
+      return "";
+  };
+
+
+  this.getFoldWidgetRange = function(session, foldStyle, row) {
+      var line = session.getLine(row);
+      var startColumn = line.length;
+      var maxRow = session.getLength();
+      var startRow = row;
+      var endRow = row;
+      // go until next heading
+      if (this.isHeading(session,row)) {
+          while (++row < maxRow) {
+              if (this.isHeading(session,row)){
+                row--;
+                break;
+              }
+          }
+
+          endRow = row;
+          // remove empty lines at end
+          if (endRow > startRow) {
+              while (endRow > startRow && /^\s*$/.test(session.getLine(endRow)))
+                  endRow--;
+          }
+
+          if (endRow > startRow) {
+              var endColumn = session.getLine(endRow).length;
+              return new Range(startRow, startColumn, endRow, endColumn);
+          }
+      // go back to heading
+      } else if (this.getFoldWidget(session, foldStyle, row)==="end"){
+        var endRow = row;
+        var endColumn = session.getLine(endRow).length;
+        while (--row>=0){
+          if (this.isHeading(session,row)){
+            break;
+          }
+        }
+        var line = session.getLine(row);
+        var startColumn = line.length;
+        return new Range(row, startColumn, endRow, endColumn);
+      }
+    };
+
+}).call(FoldMode.prototype);
+
+});

--- a/lib/ace/mode/haskell_cabal.js
+++ b/lib/ace/mode/haskell_cabal.js
@@ -1,0 +1,60 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2012, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * Contributor(s):
+ *
+ *
+ *
+ * ***** END LICENSE BLOCK ***** */
+/**
+* Haskell Cabal files mode (https://www.haskell.org/cabal/users-guide/developing-packages.html)
+**/
+
+define(function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var CabalHighlightRules = require("./haskell_cabal_highlight_rules").CabalHighlightRules;
+var FoldMode = require("./folding/haskell_cabal").FoldMode;
+
+var Mode = function() {
+    this.HighlightRules = CabalHighlightRules;
+    this.foldingRules = new FoldMode();
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.lineCommentStart = "--";
+    this.blockComment = null;
+    this.$id = "ace/mode/haskell_cabal";
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+});

--- a/lib/ace/mode/haskell_cabal_highlight_rules.js
+++ b/lib/ace/mode/haskell_cabal_highlight_rules.js
@@ -1,0 +1,68 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+ /**
+ * Haskell Cabal files highlighter (https://www.haskell.org/cabal/users-guide/developing-packages.html)
+ **/
+define(function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var CabalHighlightRules = function() {
+
+    // regexp must not have capturing parentheses. Use (?:) instead.
+    // regexps are ordered -> the first match is used
+    this.$rules = {
+        "start" : [
+            {
+                token : "comment",
+                regex : "^\\s*--.*$"
+            }, {
+                token: ["keyword"],
+                regex: /^(\s*\w.*?)(\:(?:\s+|$))/
+            }, {
+                token : "constant.numeric", // float
+                regex : /[\d_]+(?:(?:[\.\d_]*)?)/
+            }, {
+                token : "constant.language.boolean",
+                regex : "(?:true|false|TRUE|FALSE|True|False|yes|no)\\b"
+            }, {
+                token : "markup.heading",
+                regex : /^(\w.*)$/
+            }
+        ]};
+
+};
+
+oop.inherits(CabalHighlightRules, TextHighlightRules);
+
+exports.CabalHighlightRules = CabalHighlightRules;
+});


### PR DESCRIPTION
Haskell uses [Cabal files](https://www.haskell.org/cabal/) to document a package and its dependencies. This mode adds syntax highlighting and folding to these files.