### PR TITLE
Fix EditSession breakpoints documentation.

### DIFF
--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -537,8 +537,8 @@ var EditSession = function(text, mode) {
     };
 
     /**
-     * Returns an array of numbers, indicating which rows have breakpoints.
-     * @returns {[Number]}
+     * Returns an array of strings, indicating the breakpoint class (if any) applied to each row.
+     * @returns {[String]}
      **/
     this.getBreakpoints = function() {
         return this.$breakpoints;
@@ -566,7 +566,7 @@ var EditSession = function(text, mode) {
     };
 
     /**
-     * Sets a breakpoint on the row number given by `rows`. This function also emites the `'changeBreakpoint'` event.
+     * Sets a breakpoint on the row number given by `row`. This function also emites the `'changeBreakpoint'` event.
      * @param {Number} row A row index
      * @param {String} className Class of the breakpoint
      *
@@ -582,7 +582,7 @@ var EditSession = function(text, mode) {
     };
 
     /**
-     * Removes a breakpoint on the row number given by `rows`. This function also emites the `'changeBreakpoint'` event.
+     * Removes a breakpoint on the row number given by `row`. This function also emites the `'changeBreakpoint'` event.
      * @param {Number} row A row index
      *
      **/


### PR DESCRIPTION
closes #1852 "getBreakpoints should return array of numbers"
closes #1854 "toggle breakpoint"

#1852 pointed out setBreakpoints(getBreakpoints()) is bad, which I could add a warning about.

Questions:
- I see a mixture of {Array} vs {[Number]} et all for type annotation.  The latter doesn't appear to display correctly on e.g. https://ace.c9.io/#nav=api&api=edit_session - which is preferred, if any?
- I've been creating typescript annotations for my own amusement locally.  Interested in seeing them upstream?  If not, I'll direct my attention towards https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/ace/ace.d.ts (which appears to have made the mistake of believing the docs for getBreakpoints.)
- If I fix more documentation errata, any preference on commit or pull request size?