### PR TITLE
Fix incorrect YAML highlighting of true/false/yes/no inside other words

### DIFF
--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -85,7 +85,7 @@ var YamlHighlightRules = function() {
                 regex : /[+\-]?\.inf\b|NaN\b|0x[\dA-Fa-f_]+|0b[10_]+/
             }, {
                 token : "constant.language.boolean",
-                regex : "(?:true|false|TRUE|FALSE|True|False|yes|no)\\b"
+                regex : "\\b(?:true|false|TRUE|FALSE|True|False|yes|no)\\b"
             }, {
                 token : "paren.lparen",
                 regex : "[[({]"


### PR DESCRIPTION
Consider this YAML:

```
words:
  - piano
  - eyes
  - untrue
```

ACE incorrectly highlights "no", "yes" and "true" at the end of the words. This pull request fixes this issue.