### PR TITLE
fix editor not rerendering when hidden

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -791,7 +791,7 @@ var VirtualRenderer = function(container, theme) {
             changes |= this.$changes;
             this.$changes = 0;
         }
-        if ((!this.session || !this.container.offsetWidth || this.$frozen) || (!changes && !force)) {
+        if ((!this.session || this.$frozen) || (!changes && !force)) {
             this.$changes |= changes;
             return; 
         } 


### PR DESCRIPTION
Hi there!

I've got the following use case: There are two containers, one of which is visible while the other is hidden (display: none). Each container contains an ace editor instance. The user is able to switch between the two containers, and when he does, any unsaved changes will be reset to the initial value.

The problem is that when the user switches back to the original container, the ace editor still displays the unsaved changes from before, because `$updateLines` was never called, which is because `$renderChanges` will exit early, which is because the container's offset width is 0.

I discovered the original commit which introduced this behaviour: https://github.com/ajaxorg/ace/commit/67ba8f5f29ed1d0c3b3d31229d5597a99860f21c#diff-1d3adf2538ef07e28972236f3a26311a

However, I don't exactly understand the issue that it was supposed to fix and whether this condition is still necessary today. Running the test suite yields no red results. Please take a look!

Thank you!