### PR TITLE
postMessage with "*" for targetOrigin is a security concern

### DIFF
--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -379,7 +379,7 @@ if (typeof window == "object" && window.postMessage && !useragent.isOldIE) {
                 callback();
             }
         });
-        win.postMessage(messageName, "*");
+        win.postMessage(messageName, window.location.href);
     };
 }
 


### PR DESCRIPTION
and should not be done: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
