### PR TITLE
[Bug Fix] Yaml highlighting issue when using `:`

### DIFF
--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -97,7 +97,7 @@ var YamlHighlightRules = function() {
         "qqstring" : [
             {
                 token : "string",
-                regex : '(?=(?:(?:\\\\.)|(?:[^:]))*?:)',
+                regex : '(?=(?:(?:\\\\.)|(?:[^:]))*?^[ \\-]*[a-zA-Z_][\\w\\-]*:)',
                 next : "start"
             }, {
                 token : "string",

--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -97,7 +97,7 @@ var YamlHighlightRules = function() {
         "qqstring" : [
             {
                 token : "string",
-                regex : '(?=(?:(?:\\\\.)|(?:[^:]))*?^[ \\-]*[a-zA-Z_][\\w\\-]*:)',
+                regex : '(?=(?:(?:\\\\.)|(?:[^:]))*?^[ \\-]*[a-zA-Z_][\\w\\-]*:|#)',
                 next : "start"
             }, {
                 token : "string",


### PR DESCRIPTION
Just stopping at `:` will lead to highlighting issues. 
Example:

``` yaml
sql: |
  select time::timestamp from example
# Comment
```

Instead match for a new line and string before the `:` or a comment.
