### PR TITLE
rust: fix incorrect idenfier highlighting

### DIFF
--- a/lib/ace/mode/_test/text_rust.txt
+++ b/lib/ace/mode/_test/text_rust.txt
@@ -27,4 +27,7 @@ fn map<T, U>(vector: &[T], function: &fn(v: &T) -> U) -> ~[U] {
 14E-111_f64; 45isize 0x1i32 0o777u32 0b01 14f32 1_2.78f32 1_2.3E+7f32
 
 // not numbers
-14._E-111_f64; 0xi32 0b777u
+14._E-111_f64; 0xi32; 0b777u
+
+// identifiers ending in constant.numeric
+foo1; foo1u32; foo1f32; foo0xF; foo1.0

--- a/lib/ace/mode/_test/tokens_rust.json
+++ b/lib/ace/mode/_test/tokens_rust.json
@@ -260,7 +260,20 @@
   ["keyword.operator","-"],
   ["constant.numeric.source.rust","111_f64"],
   ["punctuation.operator",";"],
-  ["text"," 0xi"],
-  ["constant.numeric.source.rust","32"],
-  ["text"," 0b777u"]
+  ["text","0xi32"],
+  ["punctuation.operator",";"],
+  ["text","0b777u"]
+],[
+   "start",
+  ["text","foo1"],
+  ["punctuation.operator",";"],
+  ["text","foo1u32"],
+  ["punctuation.operator",";"],
+  ["text","foo1f32"],
+  ["punctuation.operator",";"],
+  ["text","foo0xF"],
+  ["punctuation.operator",";"],
+  ["text","foo1"],
+  ["punctuation.operator","."],
+  ["constant.numeric.source.rust","0"]
 ]]

--- a/lib/ace/mode/rust_highlight_rules.js
+++ b/lib/ace/mode/rust_highlight_rules.js
@@ -127,9 +127,9 @@ var RustHighlightRules = function() {
          { token: 'meta.preprocessor.source.rust',
            regex: '\\b\\w\\(\\w\\)*!|#\\[[\\w=\\(\\)_]+\\]\\b' },
          { token: 'constant.numeric.source.rust',
-           regex: /(?:0x[a-fA-F0-9_]+|0o[0-7_]+|0b[01_]+|[0-9][0-9_]*(?!\.))(?:[iu](?:size|8|16|32|64))?\b/ },
+           regex: /\b(?:0x[a-fA-F0-9_]+|0o[0-7_]+|0b[01_]+|[0-9][0-9_]*(?!\.))(?:[iu](?:size|8|16|32|64))?\b/ },
          { token: 'constant.numeric.source.rust',
-           regex: /(?:[0-9][0-9_]*)(?:\.[0-9][0-9_]*)?(?:[Ee][+-][0-9][0-9_]*)?(?:f32|f64)?\b/ } ] }
+           regex: /\b(?:[0-9][0-9_]*)(?:\.[0-9][0-9_]*)?(?:[Ee][+-][0-9][0-9_]*)?(?:f32|f64)?\b/ } ] }
     
     this.normalizeRules();
 };


### PR DESCRIPTION
for identifiers ending in constant.numeric

Fixes rust-lang/rust-playpen#201