### PR TITLE
fixups for regex character ranges

### DIFF
--- a/lib/ace/mode/erlang_highlight_rules.js
+++ b/lib/ace/mode/erlang_highlight_rules.js
@@ -510,7 +510,7 @@ var ErlangHighlightRules = function() {
               'punctuation.definition.parameters.end.erlang',
               'meta.directive.ifdef.erlang',
               'punctuation.section.directive.end.erlang' ],
-           regex: '^(\\s*)(-)(\\s*)(ifdef)(\\s*)(\\()(\\s*)([a-zA-z\\d@_]+)(\\s*)(\\))(\\s*)(\\.)' },
+           regex: '^(\\s*)(-)(\\s*)(ifdef)(\\s*)(\\()(\\s*)([a-zA-Z\\d@_]+)(\\s*)(\\))(\\s*)(\\.)' },
          { token: 
             [ 'meta.directive.ifndef.erlang',
               'punctuation.section.directive.begin.erlang',
@@ -524,7 +524,7 @@ var ErlangHighlightRules = function() {
               'punctuation.definition.parameters.end.erlang',
               'meta.directive.ifndef.erlang',
               'punctuation.section.directive.end.erlang' ],
-           regex: '^(\\s*)(-)(\\s*)(ifndef)(\\s*)(\\()(\\s*)([a-zA-z\\d@_]+)(\\s*)(\\))(\\s*)(\\.)' },
+           regex: '^(\\s*)(-)(\\s*)(ifndef)(\\s*)(\\()(\\s*)([a-zA-Z\\d@_]+)(\\s*)(\\))(\\s*)(\\.)' },
          { token: 
             [ 'meta.directive.undef.erlang',
               'punctuation.section.directive.begin.erlang',
@@ -538,7 +538,7 @@ var ErlangHighlightRules = function() {
               'punctuation.definition.parameters.end.erlang',
               'meta.directive.undef.erlang',
               'punctuation.section.directive.end.erlang' ],
-           regex: '^(\\s*)(-)(\\s*)(undef)(\\s*)(\\()(\\s*)([a-zA-z\\d@_]+)(\\s*)(\\))(\\s*)(\\.)' } ],
+           regex: '^(\\s*)(-)(\\s*)(undef)(\\s*)(\\()(\\s*)([a-zA-Z\\d@_]+)(\\s*)(\\))(\\s*)(\\.)' } ],
       '#macro-usage': 
        [ { token: 
             [ 'keyword.operator.macro.erlang',

--- a/lib/ace/mode/html_completions.js
+++ b/lib/ace/mode/html_completions.js
@@ -286,7 +286,7 @@ var HtmlCompletions = function() {
             
         // HTML entities
         var line = session.getLine(pos.row).substr(0, pos.column);
-        if (/&[A-z]*$/i.test(line))
+        if (/&[a-z]*$/i.test(line))
             return this.getHTMLEntityCompletions(state, session, pos, prefix);
 
         return [];

--- a/lib/ace/mode/rdoc_highlight_rules.js
+++ b/lib/ace/mode/rdoc_highlight_rules.js
@@ -57,7 +57,7 @@ var RDocHighlightRules = function() {
                next : "nospell"
             }, {
                 token : "keyword", // command
-                regex : "\\\\(?:[a-zA-z0-9]+|[^a-zA-z0-9])"
+                regex : "\\\\(?:[a-zA-Z0-9]+|[^a-zA-Z0-9])"
             }, {
                // Obviously these are neither keywords nor operators, but
                // labelling them as such was the easiest way to get them
@@ -90,7 +90,7 @@ var RDocHighlightRules = function() {
                regex : "\\\\(?:name|alias|method|S3method|S4method|item|code|preformatted|kbd|pkg|var|env|option|command|author|email|url|source|cite|acronym|href|code|preformatted|link|eqn|deqn|keyword|usage|examples|dontrun|dontshow|figure|if|ifelse|Sexpr|RdOpts|inputencoding|usepackage)\\b"
            }, {
                token : "keyword", // command
-               regex : "\\\\(?:[a-zA-z0-9]+|[^a-zA-z0-9])",
+               regex : "\\\\(?:[a-zA-Z0-9]+|[^a-zA-Z0-9])",
                next : "start"
            }, {
                token : "paren.keyword.operator",


### PR DESCRIPTION
Mainly re: some changes from `A-z` to `A-Z`.