### PR TITLE
Workaround for accent key composition in Chrome 53+

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -403,6 +403,10 @@ var TextInput = function(parentNode, host) {
         if (e.type == "compositionend" && c.range) {
             host.selection.setRange(c.range);
         }
+        // Workaround for #3027, #3045, #3097, #3100
+        if (useragent.isChrome && useragent.isChrome >= 53) {
+          onInput();
+        }
     };
     
     


### PR DESCRIPTION
Should fix #3027, #3045, #3097, #3100. Fix was identified by @hoge1e3
in #3045