### PR TITLE
Add undefined check before taking range in highlightTags

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -609,7 +609,8 @@ var Editor = function(renderer, session) {
             var range = new Range(row, column, row, column+token.value.length);
             
             //remove range if different
-            if (session.$tagHighlight && range.compareRange(session.$backMarkers[session.$tagHighlight].range)!==0) {
+            var sbm = session.$backMarkers[session.$tagHighlight];
+            if (session.$tagHighlight && sbm != undefined && range.compareRange(sbm.range)!==0) {
                 session.removeMarker(session.$tagHighlight);
                 session.$tagHighlight = null;
             }


### PR DESCRIPTION
I also ran into the TypeError in #2946 and thought it was reasonable defensive fix to add an undefined check. It feels like it's indicative of a bug elsewhere but I don't have the code familiarity or time to chase it down. I thought I'd put this up as a PR in case someone finds it worthwhile in the meantime! If it's not the right long term solution feel free to close.