### PR TITLE
Switch to insertAdjacentHTML in marker rendering process

### DIFF
--- a/lib/ace/layer/marker.js
+++ b/lib/ace/layer/marker.js
@@ -62,7 +62,7 @@ var Marker = function(parentEl) {
 
         this.config = config;
 
-
+        this.element.innerHTML = '';
         var html = [];
         for (var key in this.markers) {
             var marker = this.markers[key];
@@ -93,7 +93,7 @@ var Marker = function(parentEl) {
                 this.drawSingleLineMarker(html, range, marker.clazz + " ace_start" + " ace_br15", config);
             }
         }
-        this.element.innerHTML = html.join("");
+        this.element.insertAdjacentHTML('afterbegin', html.join(""));
     };
 
     this.$getTop = function(row, layerConfig) {


### PR DESCRIPTION
Associated issue: https://github.com/ajaxorg/ace/issues/3135

This change retains modifications made to the marker layer's DOM.

Currently, Ace renders its markers by concatenating each individual marker's HTML (string builder approach) and doing a final call to assign to the marker layer's innerHTML. This means that if any marker makes changes to the layer from within the update (for example by using appendChild or ReactDOM.render), the final assignment to innerHTML completely overrides the DOM change.

This 2-line change frees developers from being forced into rendering [dynamic]Markers using the string builder technique and permits other rendering options, most notably React.

Here is a codepen showing off what can be done with this change (it uses a custom Ace build based on the PR):
https://codepen.io/oatssss/pen/oYxJQV