### PR TITLE
ext-emmet: Adopt newer emmet's API

### DIFF
--- a/lib/ace/ext/emmet.js
+++ b/lib/ace/ext/emmet.js
@@ -47,7 +47,8 @@ AceEmmetEditor.prototype = {
         this.indentation = editor.session.getTabString();
         if (!emmet)
             emmet = window.emmet;
-        emmet.require("resources").setVariable("indentation", this.indentation);
+        var resources = emmet.resources || emmet.require("resources");
+        resources.setVariable("indentation", this.indentation);
         this.$syntax = null;
         this.$syntax = this.getSyntax();
     },
@@ -212,13 +213,14 @@ AceEmmetEditor.prototype = {
      * @return {String}
      */
     getProfileName: function() {
+        var resources = emmet.resources || emmet.require("resources");
         switch (this.getSyntax()) {
           case "css": return "css";
           case "xml":
           case "xsl":
             return "xml";
           case "html":
-            var profile = emmet.require("resources").getVariable("profile");
+            var profile = resources.getVariable("profile");
             // no forced profile, guess from content html or xhtml?
             if (!profile)
                 profile = this.ace.session.getLines(0,2).join("").search(/<!DOCTYPE[^>]+XHTML/i) != -1 ? "xhtml": "html";
@@ -266,9 +268,9 @@ AceEmmetEditor.prototype = {
         var base = 1000;
         var zeroBase = 0;
         var lastZero = null;
-        var range = emmet.require('range');
-        var ts = emmet.require('tabStops');
-        var settings = emmet.require('resources').getVocabulary("user");
+        var ts = emmet.tabStops || emmet.require('tabStops');
+        var resources = emmet.resources || emmet.require("resources");
+        var settings = resources.getVocabulary("user");
         var tabstopOptions = {
             tabstop: function(data) {
                 var group = parseInt(data.group, 10);
@@ -287,7 +289,7 @@ AceEmmetEditor.prototype = {
                 var result = '${' + group + (placeholder ? ':' + placeholder : '') + '}';
 
                 if (isZero) {
-                    lastZero = range.create(data.start, result);
+                    lastZero = [data.start, result];
                 }
 
                 return result;
@@ -304,7 +306,8 @@ AceEmmetEditor.prototype = {
         if (settings.variables['insert_final_tabstop'] && !/\$\{0\}$/.test(value)) {
             value += '${0}';
         } else if (lastZero) {
-            value = emmet.require('utils').replaceSubstring(value, '${0}', lastZero);
+            var common = emmet.utils ? emmet.utils.common : emmet.require('utils');
+            value = common.replaceSubstring(value, '${0}', lastZero[0], lastZero[1]);
         }
         
         return value;
@@ -346,7 +349,7 @@ exports.commands = new HashHandler();
 exports.runEmmetCommand = function runEmmetCommand(editor) {
     try {
         editorProxy.setupContext(editor);
-        var actions = emmet.require("actions");
+        var actions = emmet.actions || emmet.require("actions");
     
         if (this.action == "expand_abbreviation_with_tab") {
             if (!editor.selection.isEmpty())


### PR DESCRIPTION
emmet had dropped their own `define` and `require` at v1.1.
`emmet.require` is no longer available and they changed the way to export API.

The following shows the changes over API exports:
* emmet.require("resources"): emmet.resources
* emmet.require("tabStops"): emmet.tabStops
* emmet.require("utils").replaceSubstring:  emmet.utils.common.replaceSubstring
* emmet.require("actions"): emmet.actions

The usage of emmet.require("range") is dropped since this is not public and
replaceSubstring works fine without range.

Note that the backward compatibility is strictly maintained.
This change can be used with older releases of emmet.

## Related issues
* #2800