### PR TITLE
Add option to allow keyboard navigation to move into soft tabs

### DIFF
--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -299,6 +299,7 @@ var showHScrollEl = document.getElementById("show_hscroll");
 var showVScrollEl = document.getElementById("show_vscroll");
 var animateScrollEl = document.getElementById("animate_scroll");
 var softTabEl = document.getElementById("soft_tab");
+var navigateWithinSoftTabEl = document.getElementById("navigate_within_soft_tab");
 var behavioursEl = document.getElementById("enable_behaviours");
 
 fillDropdown(docEl, doclist.all);
@@ -368,6 +369,7 @@ function updateUIEditorOptions() {
     saveOption(showHScrollEl, editor.renderer.getHScrollBarAlwaysVisible());
     saveOption(animateScrollEl, editor.getAnimatedScroll());
     saveOption(softTabEl, session.getUseSoftTabs());
+    saveOption(navigateWithinSoftTabEl, session.getNavigateWithinSoftTabs());
     saveOption(behavioursEl, editor.getBehavioursEnabled());
 }
 
@@ -460,6 +462,10 @@ bindCheckbox("animate_scroll", function(checked) {
 
 bindCheckbox("soft_tab", function(checked) {
     env.editor.session.setUseSoftTabs(checked);
+});
+
+bindCheckbox("navigate_within_soft_tab", function(checked) {
+    env.editor.session.setNavigateWithinSoftTabs(checked);
 });
 
 bindCheckbox("enable_behaviours", function(checked) {

--- a/kitchen-sink.html
+++ b/kitchen-sink.html
@@ -183,6 +183,13 @@
     </tr>
     <tr>
       <td >
+        <label for="navigate_within_soft_tab">Navigate within soft tabs</label>
+      </td><td>
+        <input type="checkbox" id="navigate_within_soft_tab">
+      </td>
+    </tr>
+    <tr>
+      <td >
         <label for="highlight_selected_word">Highlight selected word</label>
       </td>
       <td>

--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -484,6 +484,21 @@ var EditSession = function(text, mode) {
         return this.$useSoftTabs && (position.column % this.$tabSize === 0);
     };
 
+    /**
+     * Set whether keyboard navigation of soft tabs moves the cursor within the soft tab, rather than over
+     * @param {Boolean} navigateWithinSoftTabs Value indicating whether or not to navigate within soft tabs
+     **/
+    this.setNavigateWithinSoftTabs = function (navigateWithinSoftTabs) {
+        this.setOption("navigateWithinSoftTabs", navigateWithinSoftTabs)
+    }
+    /**
+     * Returns `true` if keyboard navigation moves the cursor within soft tabs, `false` if it moves the cursor over soft tabs.
+     * @returns {Boolean}
+     **/
+    this.getNavigateWithinSoftTabs = function() {
+        return this.$navigateWithinSoftTabs;
+    }
+
     this.$overwrite = false;
     /**
      * Pass in `true` to enable overwrites in your session, or `false` to disable.
@@ -2555,6 +2570,7 @@ config.defineOptions(EditSession.prototype, "session", {
         initialValue: 4,
         handlesSet: true
     },
+    navigateWithinSoftTabs: {initialValue: false},
     overwrite: {
         set: function(val) {this._signal("changeOverwrite");},
         initialValue: false

--- a/lib/ace/editor_navigation_test.js
+++ b/lib/ace/editor_navigation_test.js
@@ -145,6 +145,29 @@ module.exports = {
         editor.navigateUp();
         assert.position(editor.getCursorPosition(), 0, 1);
     },
+
+    "test: navigate within soft tabs based on setting": function() {
+        var editor = new Editor(new MockRenderer(), new EditSession(["        "]));
+
+        editor.getSession().setUseSoftTabs(true);
+        editor.getSession().setTabSize(4);
+
+        editor.navigateTo(0, 0);
+        editor.navigateRight();
+        assert.position(editor.getCursorPosition(), 0, 4);
+
+        editor.navigateLeft();
+        assert.position(editor.getCursorPosition(), 0, 0);
+
+        editor.getSession().setNavigateWithinSoftTabs(true);
+
+        editor.navigateRight();
+        assert.position(editor.getCursorPosition(), 0, 1);
+
+        editor.navigateTo(0, 4);
+        editor.navigateLeft();
+        assert.position(editor.getCursorPosition(), 0, 3);
+    },
     
     "test: typing text should update the desired column": function() {
         var editor = new Editor(new MockRenderer(), new EditSession(["1234", "1234567890"]));

--- a/lib/ace/selection.js
+++ b/lib/ace/selection.js
@@ -465,6 +465,24 @@ var Selection = function(session) {
     };
 
     /**
+     *
+     * Returns `true` if moving the character next to the cursor in the specified direction is a soft tab.
+     * @param {Object} cursor the current cursor position
+     * @param {Number} tabSize the tab size
+     * @param {Number} direction 1 for right, -1 for left
+    */
+    this.wouldMoveIntoSoftTab = function(cursor, tabSize, direction) {
+        var start = cursor.column;
+        var end = cursor.column + tabSize;
+
+        if (direction < 0) {
+            start = cursor.column - tabSize;
+            end = cursor.column;
+        }
+        return this.session.isTabStop(cursor) && this.doc.getLine(cursor.row).slice(start, end).split(" ").length-1 == tabSize
+    }
+
+    /**
     *
     * Moves the cursor left one column.
     **/
@@ -482,10 +500,11 @@ var Selection = function(session) {
         }
         else {
             var tabSize = this.session.getTabSize();
-            if (this.session.isTabStop(cursor) && this.doc.getLine(cursor.row).slice(cursor.column-tabSize, cursor.column).split(" ").length-1 == tabSize)
+            if (this.wouldMoveIntoSoftTab(cursor, tabSize, -1) && !this.session.getNavigateWithinSoftTabs()) {
                 this.moveCursorBy(0, -tabSize);
-            else
+            } else {
                 this.moveCursorBy(0, -1);
+            }
         }
     };
 
@@ -507,10 +526,11 @@ var Selection = function(session) {
         else {
             var tabSize = this.session.getTabSize();
             var cursor = this.lead;
-            if (this.session.isTabStop(cursor) && this.doc.getLine(cursor.row).slice(cursor.column, cursor.column+tabSize).split(" ").length-1 == tabSize)
+            if (this.wouldMoveIntoSoftTab(cursor, tabSize, 1) && !this.session.getNavigateWithinSoftTabs()) {
                 this.moveCursorBy(0, tabSize);
-            else
+            } else {
                 this.moveCursorBy(0, 1);
+            }
         }
     };
 

--- a/tool/perf-test.html
+++ b/tool/perf-test.html
@@ -228,6 +228,13 @@
     </tr>
     <tr>
       <td >
+        <label for="navigate_within_soft_tab">Navigate within soft tabs</label>
+      </td><td>
+        <input type="checkbox" id="navigate_within_soft_tab">
+      </td>
+    </tr>
+    <tr>
+      <td >
         <label for="highlight_selected_word">Highlight selected word</label>
       </td>
       <td>


### PR DESCRIPTION
Hello,

This is a pull request the adds an option to allow keyboard navigation to move within soft tabs, rather than over them, as was mentioned in #1721. This option defaults to off, so by default, there is no change to the existing behavior of ace.

This is my first pull request to ace, and I have signed the individual CLA. 

I am submitting this pull request because I have been using ace in a personal project for a little while, but I have been unable to get used to the behavior of skipping over soft tabs, and I always end up overshooting my target. I've given it a fair shot, but especially since I still use other editors that don't skip over soft tabs, I have been unable to rewire my muscle memory.

This change includes documentation comments, a test, and updates to the kitchen sink and performance test pages. However, I could not determine if I was supposed to rebuild the HTML documentation, or if that was only done before a release. I am happy to make any changes or perform additional work to get this pull request accepted. Thank you for your time.