### PR TITLE
fix bug of lua mode of dirty get state when folding lua code

### DIFF
--- a/lib/ace/mode/folding/lua.js
+++ b/lib/ace/mode/folding/lua.js
@@ -59,7 +59,9 @@ oop.inherits(FoldMode, BaseFoldMode);
                 if (session.getTokenAt(row, match.index + 1).type === "keyword")
                     return "start";
             } else if (match[2]) {
+                var savedBgTokenizerCurrentLine = session.bgTokenizer.currentLine;
                 var type = session.bgTokenizer.getState(row) || "";
+                session.bgTokenizer.currentLine = savedBgTokenizerCurrentLine;
                 if (type[0] == "bracketedComment" || type[0] == "bracketedString")
                     return "start";
             } else {
@@ -74,7 +76,9 @@ oop.inherits(FoldMode, BaseFoldMode);
             if (session.getTokenAt(row, match.index + 1).type === "keyword")
                 return "end";
         } else if (match[0][0] === "]") {
+            var savedBgTokenizerCurrentLine = session.bgTokenizer.currentLine;
             var type = session.bgTokenizer.getState(row - 1) || "";
+            session.bgTokenizer.currentLine = savedBgTokenizerCurrentLine;
             if (type[0] == "bracketedComment" || type[0] == "bracketedString")
                 return "end";
         } else


### PR DESCRIPTION
session.bgTokenizer.getState(row) this `getState` function is dirty and not pure function, because it will change the state of bgTokenizer(change the currentLine), then affect the next frame tokenizer