### PR TITLE
BUG when autuOutdent in lua mode

### DIFF
--- a/lib/ace/mode/lua.js
+++ b/lib/ace/mode/lua.js
@@ -138,7 +138,7 @@ oop.inherits(Mode, TextMode);
         var tabLength = session.getTabString().length;
         var expectedIndent = prevIndent + tabLength * getNetIndentLevel(prevTokens);
         var curIndent = this.$getIndent(session.getLine(row)).length;
-        if (curIndent < expectedIndent) {
+        if (curIndent <= expectedIndent) {
             // User already outdented //
             return;
         }


### PR DESCRIPTION
In example lua code,

    function guessnumber(a)
    if a>1 then
        print 'hello'
        if a>2 then
            print(234)
        else
            print(123)
        end
    else

when move cursor to the last `else` end press `enter` keyboard, the last `else` keyword will auto outdent to the line begin(without any ident spaces).