### PR TITLE
fix bug of operator '&' and '|' in lua mode

### DIFF
--- a/lib/ace/mode/lua/luaparse.js
+++ b/lib/ace/mode/lua/luaparse.js
@@ -564,7 +564,7 @@ define(function(require, exports, module) {
 
       // \* / ^ % , { } ] ( ) ; # - +
       case 42: case 47: case 94: case 37: case 44: case 123: case 125:
-      case 93: case 40: case 41: case 59: case 35: case 45: case 43:
+      case 93: case 40: case 41: case 59: case 35: case 45: case 43: case 38: case 124:
         return scanPunctuator(input.charAt(index));
     }
 
@@ -1708,6 +1708,7 @@ define(function(require, exports, module) {
         case 42: case 47: case 37: return 7; // * / %
         case 43: case 45: return 6; // + -
         case 60: case 62: return 3; // < >
+        case 38: case 124: return 7; // & |
       }
     } else if (2 === length) {
       switch (charCode) {


### PR DESCRIPTION
fix luamode bug of '&' and '|'
if (1 & 2) or (1 | 2) then
return
end