### PR TITLE
prevent scrolling to the top

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -74,7 +74,7 @@ var TextInput = function(parentNode, host) {
     this.focus = function() {
         if (tempStyle) return text.focus();
         var top = text.style.top;
-        text.style.position = "fixed";
+        text.style.position = "absolute";
         text.style.top = "0px";
         text.focus();
         setTimeout(function() {


### PR DESCRIPTION
prevent windows scrolling to the document's top, when ace is at the bottom of the page ( long page )