### PR TITLE
Add rule for `strings` used in apache drill

### DIFF
--- a/lib/ace/mode/sql_highlight_rules.js
+++ b/lib/ace/mode/sql_highlight_rules.js
@@ -78,6 +78,9 @@ var SqlHighlightRules = function() {
             token : "string",           // ' string
             regex : "'.*?'"
         }, {
+            token : "string",           // ` string (apache drill)
+            regex : "`.*?`"
+        }, {
             token : "constant.numeric", // float
             regex : "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b"
         }, {


### PR DESCRIPTION
Hi,

Added an extra rule for formatting literals using ( ` ). This is common in Apache Drill queries

````
SELECT * FROM dfs.`file.json`
````

Hope all is fine with this PR.
Thanks