### PR TITLE
HAML Highlighting Rework and Fixes

### DIFF
--- a/demo/kitchen-sink/docs/haml.haml
+++ b/demo/kitchen-sink/docs/haml.haml
@@ -13,7 +13,7 @@
 %ads:{:bleh => 33}
 %p==ddd==
   Date/Time:
-  - now = DateTime.now 
+  - now = DateTime.now
   %strong= now
    = if now  DateTime.parse("December 31, 2006")
     = "Happy new " + "year!"
@@ -29,8 +29,24 @@
     %div.article.title Blah
     %div.article.date 2006-11-05
     %div.article.entry
-      Neil Patrick Harris 
+      Neil Patrick Harris
 
 %div[@user, :greeting]
   %bar[290]/
   ==Hello!==
+
+/ This is a comment
+
+/ This is another comment with line break above
+
+.row
+  .col-md-6
+  .col-md-6
+
+  .col-md-6
+
+.row
+  .col-md-6
+
+
+  .col-md-6

--- a/demo/kitchen-sink/docs/haml.haml
+++ b/demo/kitchen-sink/docs/haml.haml
@@ -1,22 +1,46 @@
 !!!5
 
-# <!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
-# <!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" lang="en"> <![endif]-->
-# <!--[if IE 8]>    <html class="no-js lt-ie9" lang="en"> <![endif]-->
-# <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+/[if IE]
+  %a{ :href => 'http://www.mozilla.com/en-US/firefox/' }
+    %h1 Get Firefox
+
+-# This is a HAML comment. It will not show in the output HTML
+
+-#
+  This is a HAML multiline comment
+  This won't be displayed
+    Nor will this
+                   Nor will this.
+
+/ This is a HTML comment. It will be rendered as HTML
+
+/
+  %p This doesn't render...
+  %div
+    %h1 Because it's commented out!
+
+.row
+  .col-md-6
+
+  .col-md-6
 
 
-/adasdasdad
-%div{:id => "#{@item.type}_#{@item.number}", :class => '#{@item.type} #{@item.urgency}', :phoney => `asdasdasd`}
+#users.row.green
+  #articles{:style => "border: 5px;"}
+  #lists.list-inline
+
+%div#todos.bg-green{:id => "#{@item.type}_#{@item.number}", :class => '#{@item.type} #{@item.urgency}', :phoney => `asdasdasd`}
+
 / file: app/views/movies/index.html.haml
-\d
+
 %ads:{:bleh => 33}
-%p==ddd==
+%p
   Date/Time:
   - now = DateTime.now
   %strong= now
-   = if now  DateTime.parse("December 31, 2006")
+   = if now DateTime.parse("December 31, 2006")
     = "Happy new " + "year!"
+
 %sfd.dfdfg
 #content
  .title
@@ -32,8 +56,7 @@
       Neil Patrick Harris
 
 %div[@user, :greeting]
-  %bar[290]/
-  ==Hello!==
+  %bar[290]
 
 / This is a comment
 

--- a/lib/ace/mode/_test/tokens_haml.json
+++ b/lib/ace/mode/_test/tokens_haml.json
@@ -2,152 +2,209 @@
    "start",
   ["keyword.other.doctype","!!!5"]
 ],[
-   "tag_single"
+   "start"
 ],[
-   "start",
-  ["text","# "],
-  ["comment.start.xml","<!--"],
-  ["comment.xml","[if lt IE 7]> <html class=\"no-js lt-ie9 lt-ie8 lt-ie7\" lang=\"en\"> <![endif]"],
-  ["comment.end.xml","-->"]
+   "embedded_ruby",
+  ["text","# <!--["],
+  ["keyword","if"],
+  ["text"," "],
+  ["identifier","lt"],
+  ["text"," "],
+  ["support.class","IE"],
+  ["text"," "],
+  ["constant.numeric","7"],
+  ["text","]> <"],
+  ["identifier","html"],
+  ["text"," "],
+  ["keyword","class"],
+  ["text","="],
+  ["string","\"no-js lt-ie9 lt-ie8 lt-ie7\""],
+  ["text"," "],
+  ["identifier","lang"],
+  ["text","="],
+  ["string","\"en\""],
+  ["text","> <!["],
+  ["identifier","endif"],
+  ["text","]-->"]
 ],[
-   "start",
-  ["text","# "],
-  ["comment.start.xml","<!--"],
-  ["comment.xml","[if IE 7]>    <html class=\"no-js lt-ie9 lt-ie8\" lang=\"en\"> <![endif]"],
-  ["comment.end.xml","-->"]
+   "embedded_ruby",
+  ["text","# <!--["],
+  ["keyword","if"],
+  ["text"," "],
+  ["support.class","IE"],
+  ["text"," "],
+  ["constant.numeric","7"],
+  ["text","]>    <"],
+  ["identifier","html"],
+  ["text"," "],
+  ["keyword","class"],
+  ["text","="],
+  ["string","\"no-js lt-ie9 lt-ie8\""],
+  ["text"," "],
+  ["identifier","lang"],
+  ["text","="],
+  ["string","\"en\""],
+  ["text","> <!["],
+  ["identifier","endif"],
+  ["text","]-->"]
 ],[
-   "start",
-  ["text","# "],
-  ["comment.start.xml","<!--"],
-  ["comment.xml","[if IE 8]>    <html class=\"no-js lt-ie9\" lang=\"en\"> <![endif]"],
-  ["comment.end.xml","-->"]
+   "embedded_ruby",
+  ["text","# <!--["],
+  ["keyword","if"],
+  ["text"," "],
+  ["support.class","IE"],
+  ["text"," "],
+  ["constant.numeric","8"],
+  ["text","]>    <"],
+  ["identifier","html"],
+  ["text"," "],
+  ["keyword","class"],
+  ["text","="],
+  ["string","\"no-js lt-ie9\""],
+  ["text"," "],
+  ["identifier","lang"],
+  ["text","="],
+  ["string","\"en\""],
+  ["text","> <!["],
+  ["identifier","endif"],
+  ["text","]-->"]
 ],[
-   "start",
-  ["text","# "],
-  ["comment.start.xml","<!--"],
-  ["comment.xml","[if gt IE 8]><!"],
-  ["comment.end.xml","-->"],
-  ["text.xml"," "],
-  ["meta.tag.punctuation.tag-open.xml","<"],
-  ["meta.tag.tag-name.xml","html"],
-  ["text.tag-whitespace.xml"," "],
-  ["entity.other.attribute-name.xml","class"],
-  ["keyword.operator.attribute-equals.xml","="],
-  ["string.attribute-value.xml","\"no-js\""],
-  ["text.tag-whitespace.xml"," "],
-  ["entity.other.attribute-name.xml","lang"],
-  ["keyword.operator.attribute-equals.xml","="],
-  ["string.attribute-value.xml","\"en\""],
-  ["meta.tag.punctuation.tag-close.xml",">"],
-  ["text.xml"," "],
-  ["comment.start.xml","<!--"],
-  ["comment.xml","<![endif]"],
-  ["comment.end.xml","-->"]
+   "embedded_ruby",
+  ["text","# <!--["],
+  ["keyword","if"],
+  ["text"," "],
+  ["identifier","gt"],
+  ["text"," "],
+  ["support.class","IE"],
+  ["text"," "],
+  ["constant.numeric","8"],
+  ["text","]><!--> <"],
+  ["identifier","html"],
+  ["text"," "],
+  ["keyword","class"],
+  ["text","="],
+  ["string","\"no-js\""],
+  ["text"," "],
+  ["identifier","lang"],
+  ["text","="],
+  ["string","\"en\""],
+  ["text","> <!--<!["],
+  ["identifier","endif"],
+  ["text","]-->"]
 ],[
-   "tag_single"
+   "start"
 ],[
    "start"
 ],[
    "start",
-  ["punctuation.section.comment","/adasdasdad"]
+  ["comment.line","/adasdasdad"]
 ],[
-   "start",
+   "embedded_ruby",
   ["meta.tag.haml","%div"],
-  ["punctuation.section","{"],
+  ["text","{"],
   ["constant.other.symbol.ruby",":id"],
   ["text"," => "],
   ["string","\"#{@item.type}_#{@item.number}\""],
-  ["text",", "],
-  ["constant.other.symbol.ruby",":class"],
+  ["text",", :"],
+  ["keyword","class"],
   ["text"," => "],
   ["string","'#{@item.type} #{@item.urgency}'"],
-  ["text",", "],
-  ["constant.other.symbol.ruby",":phoney"],
+  ["text",", :"],
+  ["identifier","phoney"],
   ["text"," => "],
   ["string","`asdasdasd`"],
-  ["punctuation.section","}"]
+  ["text","}"]
 ],[
    "start",
-  ["punctuation.section.comment","/ file: app/views/movies/index.html.haml"]
+  ["comment.line","/ file: app/views/movies/index.html.haml"]
 ],[
    "start",
-  ["character.escape.haml","\\d"]
+  ["text","\\d"]
 ],[
-   "start",
+   "embedded_ruby",
   ["meta.tag.haml","%ads:"],
-  ["punctuation.section","{"],
+  ["text","{"],
   ["constant.other.symbol.ruby",":bleh"],
   ["text"," => "],
   ["constant.numeric","33"],
-  ["punctuation.section","}"]
+  ["text","}"]
 ],[
    "embedded_ruby",
   ["meta.tag.haml","%p"],
   ["text","=="],
-  ["text.xml","ddd"],
+  ["identifier","ddd"],
   ["text","=="]
 ],[
    "start",
-  ["text","  "],
-  ["text.xml","Date/Time:"]
+  ["text","  Date"],
+  ["comment.line","/Time:"]
 ],[
    "embedded_ruby",
   ["text","  - "],
-  ["text.xml","now "],
-  ["text","= "],
+  ["identifier","now"],
+  ["text"," = "],
   ["support.class","DateTime"],
   ["text","."],
   ["identifier","now"],
   ["text"," "]
 ],[
-   "start",
+   "embedded_ruby",
   ["text","  "],
   ["meta.tag.haml","%strong"],
   ["text","= "],
-  ["text.xml","now"]
+  ["identifier","now"]
 ],[
-   "start",
+   "embedded_ruby",
   ["text","   = "],
-  ["text.xml","if now  DateTime.parse("],
+  ["keyword","if"],
+  ["text"," "],
+  ["identifier","now"],
+  ["text","  "],
+  ["support.class","DateTime"],
+  ["text","."],
+  ["identifier","parse"],
+  ["text","("],
   ["string","\"December 31, 2006\""],
-  ["text.xml",")"]
+  ["text",")"]
 ],[
-   "start",
+   "embedded_ruby",
   ["text","    = "],
   ["string","\"Happy new \""],
-  ["text.xml"," + "],
+  ["text"," + "],
   ["string","\"year!\""]
 ],[
    "start",
   ["meta.tag.haml","%sfd"],
   ["keyword.attribute-name.class.haml",".dfdfg"]
 ],[
-   "start",
+   "element_class",
   ["keyword.attribute-name.id.haml","#content"]
 ],[
    "start",
   ["text"," "],
   ["keyword.attribute-name.class.haml",".title"]
 ],[
-   "start",
+   "embedded_ruby",
   ["text","   "],
   ["meta.tag.haml","%h1"],
   ["text","= "],
-  ["text.xml","@title"]
+  ["variable.instance","@title"]
 ],[
-   "start",
+   "embedded_ruby",
   ["text","   = "],
-  ["text.xml","link_to "],
-  ["string","'Home'"],
-  ["text.xml",", home_url"]
-],[
-   "tag_single"
-],[
-   "start",
+  ["support.function","link_to"],
   ["text"," "],
-  ["text.xml","  #contents"]
+  ["string","'Home'"],
+  ["text",", "],
+  ["identifier","home_url"]
 ],[
-   "start",
+   "start"
+],[
+   "element_class",
+  ["text","   "],
+  ["keyword.attribute-name.id.haml","#contents"]
+],[
+   "element_class",
   ["meta.tag.haml","%div"],
   ["keyword.attribute-name.id.haml","#content"]
 ],[
@@ -160,8 +217,7 @@
   ["text","    "],
   ["meta.tag.haml","%div"],
   ["keyword.attribute-name.class.haml",".article.title"],
-  ["text"," "],
-  ["text.xml","Blah"]
+  ["text"," Blah"]
 ],[
    "start",
   ["text","    "],
@@ -176,29 +232,28 @@
   ["keyword.attribute-name.class.haml",".article.entry"]
 ],[
    "start",
-  ["text","      "],
-  ["text.xml","Neil Patrick Harris "]
+  ["text","      Neil Patrick Harris "]
 ],[
-   "tag_single"
+   "start"
 ],[
    "start",
   ["meta.tag.haml","%div"],
-  ["text","["],
-  ["text.xml","@user, "],
+  ["text","[@user, "],
   ["constant.other.symbol.ruby",":greeting"],
-  ["text.xml","]"]
+  ["text","]"]
 ],[
    "start",
   ["text","  "],
   ["meta.tag.haml","%bar"],
   ["text","["],
   ["constant.numeric","290"],
-  ["text.xml","]/"]
+  ["text","]"],
+  ["comment.line","/"]
 ],[
    "embedded_ruby",
   ["text","  =="],
-  ["text.xml","Hello!"],
-  ["text","=="]
+  ["support.class","Hello"],
+  ["text","!=="]
 ],[
    "start"
 ]]

--- a/lib/ace/mode/haml_highlight_rules.js
+++ b/lib/ace/mode/haml_highlight_rules.js
@@ -64,7 +64,7 @@ var HamlHighlightRules = function() {
         "element_class": [
             {
                 token: "keyword.attribute-name.class.haml",
-                regex: /\.[\w-]+/,
+                regex: /\.[\w-]+/
             },
             {
                 token: "punctuation.section",

--- a/lib/ace/mode/haml_highlight_rules.js
+++ b/lib/ace/mode/haml_highlight_rules.js
@@ -66,12 +66,6 @@ var HamlHighlightRules = function() {
         },
 
         RubyExports.constantOtherSymbol,
-
-        {
-            token: "text",
-            regex: /\s/,
-            next: "start"
-        },
         {
             token: "empty",
             regex: "$|(?!\\.|#|\\{|\\[|=|-|~|\\/])",

--- a/lib/ace/mode/haml_highlight_rules.js
+++ b/lib/ace/mode/haml_highlight_rules.js
@@ -11,110 +11,130 @@ var HamlHighlightRules = function() {
     // regexp must not have capturing parentheses. Use (?:) instead.
     // regexps are ordered -> the first match is used
     HtmlHighlightRules.call(this);
-    this.$rules.start.unshift(
-        {
-            token : "punctuation.section.comment",
-            regex : /^\s*\/.*/
-        },
-        {
-            token: "string.quoted.double",
-            regex: "==.+?=="
-        },
-        {
-            token: "keyword.other.doctype",
-            regex: "^!!!\\s*(?:[a-zA-Z0-9-_]+)?"
-        },
-        RubyExports.qString,
-        RubyExports.qqString,
-        RubyExports.tString,
-        {
-            token: "character.escape.haml",
-            regex: "^\\s*\\\\."
-        },
-        {
-            token: "text",
-            regex: /^\s*/,
-            next: "tag_single"
-        },
-        RubyExports.constantNumericHex,
-        RubyExports.constantNumericFloat,
 
-        RubyExports.constantOtherSymbol,
-        {
-            token: "text",
-            regex: "=|-|~",
-            next: "embedded_ruby"
-        }
-    );
-    this.$rules.tag_single = [
-        {
-            token: "meta.tag.haml",
-            regex: /(%[\w:\-]+)/
-        },
-        {
-            token: "keyword.attribute-name.class.haml",
-            regex: "\\.[\\w-]+"
-        },
-        {
-            token: "keyword.attribute-name.id.haml",
-            regex: "#[\\w-]+"
-        },
-        {
-            token: "punctuation.section",
-            regex: "\\{",
-            next: "section"
-        },
-
-        RubyExports.constantOtherSymbol,
-        {
-            token: "empty",
-            regex: "$|(?!\\.|#|\\{|\\[|=|-|~|\\/])",
-            next: "start"
-        }
-    ];
-    this.$rules.section = [
-        RubyExports.constantOtherSymbol,
-
-        RubyExports.qString,
-        RubyExports.qqString,
-        RubyExports.tString,
-
-        RubyExports.constantNumericHex,
-        RubyExports.constantNumericFloat,
-        {
-            token: "punctuation.section",
-            regex: "\\}",
-            next: "start"
-        }
-    ];
-
-    this.$rules.embedded_ruby = [
-        RubyExports.constantNumericHex,
-        RubyExports.constantNumericFloat,
-        {
+    this.$rules = {
+        "start": [
+            {
+                token: "comment.block", // multiline HTML comment
+                regex: /^\/$/,
+                next: "comment"
+            },
+            {
+                token: "comment.block", // multiline HAML comment
+                regex: /^\-#$/,
+                next: "comment"
+            },
+            {
+                token: "comment.line", // HTML comment
+                regex: /\/\s*.*/
+            },
+            {
+                token: "comment.line", // HAML comment
+                regex: /-#\s*.*/
+            },
+            {
+                token: "keyword.other.doctype",
+                regex: "^!!!\\s*(?:[a-zA-Z0-9-_]+)?"
+            },
+            RubyExports.qString,
+            RubyExports.qqString,
+            RubyExports.tString,
+            {
+                token: "meta.tag.haml",
+                regex: /(%[\w:\-]+)/
+            },
+            {
+                token: "keyword.attribute-name.class.haml",
+                regex: /\.[\w-]+/
+            },
+            {
+                token: "keyword.attribute-name.id.haml",
+                regex: /#[\w-]+/,
+                next: "element_class"
+            },
+            RubyExports.constantNumericHex,
+            RubyExports.constantNumericFloat,
+            RubyExports.constantOtherSymbol,
+            {
+                token: "text",
+                regex: /=|-|~/,
+                next: "embedded_ruby"
+            }
+        ],
+        "element_class": [
+            {
+                token: "keyword.attribute-name.class.haml",
+                regex: /\.[\w-]+/,
+            },
+            {
+                token: "punctuation.section",
+                regex: /\{/,
+                next: "element_attributes"
+            },
+            RubyExports.constantOtherSymbol,
+            {
+                token: "empty",
+                regex: "$|(?!\\.|#|\\{|\\[|=|-|~|\\/])",
+                next: "start"
+            }
+        ],
+        "element_attributes": [
+            RubyExports.constantOtherSymbol,
+            RubyExports.qString,
+            RubyExports.qqString,
+            RubyExports.tString,
+            RubyExports.constantNumericHex,
+            RubyExports.constantNumericFloat,
+            {
+                token: "punctuation.section",
+                regex: /$|\}/,
+                next: "start"
+            }
+        ],
+        "embedded_ruby": [
+            RubyExports.constantNumericHex,
+            RubyExports.constantNumericFloat,
+            RubyExports.instanceVariable,
+            RubyExports.qString,
+            RubyExports.qqString,
+            RubyExports.tString,
+            {
                 token : "support.class", // class name
                 regex : "[A-Z][a-zA-Z_\\d]+"
-        },
-        {
-            token : new RubyHighlightRules().getKeywords(),
-            regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
-        },
-        {
-            token : ["keyword", "text", "text"],
-            regex : "(?:do|\\{)(?: \\|[^|]+\\|)?$",
-            next  : "start"
-        },
-        {
-            token : ["text"],
-            regex : "^$",
-            next  : "start"
-        },
-        {
-            token : ["text"],
-            regex : "^(?!.*\\|\\s*$)",
-            next  : "start"
-        }
-    ];
+            },
+            {
+                token : new RubyHighlightRules().getKeywords(),
+                regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
+            },
+            {
+                token : ["keyword", "text", "text"],
+                regex : "(?:do|\\{)(?: \\|[^|]+\\|)?$",
+                next  : "start"
+            },
+            {
+                token : ["text"],
+                regex : "^$",
+                next  : "start"
+            },
+            {
+                token : ["text"],
+                regex : "^(?!.*\\|\\s*$)",
+                next  : "start"
+            }
+        ],
+        "comment": [
+            {
+                token: "comment.block",
+                regex: /^$/,
+                next: "start"
+            },
+            {
+                token: "comment.block", // comment spanning the whole line
+                regex: /\s+.*/
+            }
+        ]
+
+    };
 
     this.normalizeRules();
 };

--- a/lib/ace/mode/haml_highlight_rules.js
+++ b/lib/ace/mode/haml_highlight_rules.js
@@ -38,7 +38,7 @@ var HamlHighlightRules = function() {
         },
         RubyExports.constantNumericHex,
         RubyExports.constantNumericFloat,
-        
+
         RubyExports.constantOtherSymbol,
         {
             token: "text",
@@ -64,9 +64,9 @@ var HamlHighlightRules = function() {
             regex: "\\{",
             next: "section"
         },
-        
+
         RubyExports.constantOtherSymbol,
-        
+
         {
             token: "text",
             regex: /\s/,
@@ -74,33 +74,33 @@ var HamlHighlightRules = function() {
         },
         {
             token: "empty",
-            regex: "$|(?!\\.|#|\\{|\\[|=|-|~|\\/)",
+            regex: "$|(?!\\.|#|\\{|\\[|=|-|~|\\/])",
             next: "start"
         }
     ];
     this.$rules.section = [
         RubyExports.constantOtherSymbol,
-        
+
         RubyExports.qString,
         RubyExports.qqString,
         RubyExports.tString,
-        
+
         RubyExports.constantNumericHex,
         RubyExports.constantNumericFloat,
         {
             token: "punctuation.section",
             regex: "\\}",
             next: "start"
-        } 
+        }
     ];
-    
-    this.$rules.embedded_ruby = [ 
+
+    this.$rules.embedded_ruby = [
         RubyExports.constantNumericHex,
         RubyExports.constantNumericFloat,
         {
                 token : "support.class", // class name
                 regex : "[A-Z][a-zA-Z_\\d]+"
-        },    
+        },
         {
             token : new RubyHighlightRules().getKeywords(),
             regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
@@ -109,12 +109,12 @@ var HamlHighlightRules = function() {
             token : ["keyword", "text", "text"],
             regex : "(?:do|\\{)(?: \\|[^|]+\\|)?$",
             next  : "start"
-        }, 
+        },
         {
             token : ["text"],
             regex : "^$",
             next  : "start"
-        }, 
+        },
         {
             token : ["text"],
             regex : "^(?!.*\\|\\s*$)",

--- a/lib/ace/mode/ruby_highlight_rules.js
+++ b/lib/ace/mode/ruby_highlight_rules.js
@@ -65,6 +65,11 @@ var constantNumericFloat = exports.constantNumericFloat = {
     regex : "[+-]?\\d(?:\\d|_(?=\\d))*(?:(?:\\.\\d(?:\\d|_(?=\\d))*)?(?:[eE][+-]?\\d+)?)?\\b"
 };
 
+var instanceVariable = exports.instanceVariable = {
+    token : "variable.instance", // instance variable
+    regex : "@{1,2}[a-zA-Z_\\d]+"
+};
+
 var RubyHighlightRules = function() {
 
     var builtinFunctions = (


### PR DESCRIPTION
This PR is a rework of the HAML syntax highlighting. It also includes some fixes and new highlighting:

- [x] Fixes an issue with HTML comments not being highlighted if they had line breaks between them.
- [x] Fixes an issue where `%`, `#`, and `.` tags were not being highlighted in a similar way to the issue above, when indented.
- [x] Adds highlighting for HAML comments (`-#`).
- [x] Adds highlighting for block HAML and HTML comments.
- [x] Adds highlighting for embedded Ruby instance variables (.ie `@user`).

The `demo/docs/haml.haml` file has also been updated to reflect this PR.

There are still some issues that I will try to address soon such as:

- Comment slash character `/` begins highlighting when used as text. (i.e Date/Time)