### PR TITLE
JS Mode: Contextualize "from" keyword highlighting

### DIFF
--- a/lib/ace/mode/javascript_highlight_rules.js
+++ b/lib/ace/mode/javascript_highlight_rules.js
@@ -55,7 +55,7 @@ var JavaScriptHighlightRules = function(options) {
         "keyword":
             "const|yield|import|get|set|async|await|" +
             "break|case|catch|continue|default|delete|do|else|finally|for|function|" +
-            "if|in|of|instanceof|new|return|switch|throw|try|typeof|let|var|while|with|debugger|from|" +
+            "if|in|of|instanceof|new|return|switch|throw|try|typeof|let|var|while|with|debugger|" +
             // invalid or reserved
             "__parent__|__count__|escape|unescape|with|__proto__|" +
             "class|enum|extends|super|export|implements|private|public|interface|package|protected|static",
@@ -154,6 +154,10 @@ var JavaScriptHighlightRules = function(options) {
                 ],
                 regex : "(:)(\\s*)(function)(\\s*)(\\()",
                 next: "function_arguments"
+            }, {
+                // from "module-path" (this is the only case where 'from' should be a keyword)
+                token : "keyword",
+                regex : "from(?=\\s*('|\"))"
             }, {
                 token : "keyword",
                 regex : "(?:" + kwBeforeRe + ")\\b",


### PR DESCRIPTION
As pointed out by @nightwing in #3255, `from` is a contextual keyword and should ideally only be highlighted within module declarations. This PR improves upon #3255 by only highlighting `from` when it comes before a single-quoted or double-quoted string, as this usage of `from` is only valid within module declarations.