### PR TITLE
Refetch prefix when getting completion results

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -225,7 +225,6 @@ var Autocomplete = function() {
         var session = editor.getSession();
         var pos = editor.getCursorPosition();
 
-        var line = session.getLine(pos.row);
         var prefix = util.getCompletionPrefix(editor);
 
         this.base = session.doc.createAnchor(pos.row, pos.column - prefix.length);
@@ -238,10 +237,8 @@ var Autocomplete = function() {
                 if (!err && results)
                     matches = matches.concat(results);
                 // Fetch prefix again, because they may have changed by now
-                var pos = editor.getCursorPosition();
-                var line = session.getLine(pos.row);
                 callback(null, {
-                    prefix: prefix,
+                    prefix: util.getCompletionPrefix(editor),
                     matches: matches,
                     finished: (--total === 0)
                 });


### PR DESCRIPTION
This was a bug introduced with this commit: 
- https://github.com/ajaxorg/ace/commit/fcebd0f662e0434fadf15faaaf4b59ab8950217a

As completers are asynchronous, when the results of one completer comes back, the prefix might have changed, as mentioned in the comment in line 240.

So we need to fetch it again from the editor, this was previously correctly done but accidentally removed with the commit above.