### PR TITLE
Add missing tool dependency

### DIFF
--- a/tool/package.json
+++ b/tool/package.json
@@ -2,6 +2,7 @@
   "name": "ace-tools",
   "version": "0.1.0",
   "dependencies": {
+    "amd-loader": "~0.0.4",
     "browser-pack": "5.0.1",
     "browserify": "10.2.4",
     "cson": "3.0.1",


### PR DESCRIPTION
Looks like it never made it out of the root `package.json`. 