### PR TITLE
Polish tmtheme

### DIFF
--- a/tool/tmtheme.js
+++ b/tool/tmtheme.js
@@ -87,21 +87,34 @@ var fallbackScopes = {
     "variable": "entity.name.function"
 };
 
+// Taken from .ace-tm
+var defaultGlobals = {
+    "printMargin": "#e8e8e8",
+    "background": "#ffffff",
+    "foreground": "#000000",
+    "gutter": "#f0f0f0",
+    "selection": "rgb(181, 213, 255)",
+    "step": "rgb(198, 219, 174)",
+    "bracket": "rgb(192, 192, 192)",
+    "active_line": "rgba(0, 0, 0, 0.07)",
+    "cursor": "#000000",
+    "invisible": "rgb(191, 191, 191)"
+}
+
 function extractStyles(theme) {
     var globalSettings = theme.settings[0].settings;
 
     var colors = {
-        "printMargin": "#e8e8e8",
-        "background": parseColor(globalSettings.background),
-        "foreground": parseColor(globalSettings.foreground),
-        "gutter": "#e8e8e8",
-        "selection": parseColor(globalSettings.selection),
-        "step": "rgb(198, 219, 174)",
-        "bracket": parseColor(globalSettings.invisibles),
-        "active_line": parseColor(globalSettings.lineHighlight),
-        "cursor": parseColor(globalSettings.caret),
-
-        "invisible": "color: " + parseColor(globalSettings.invisibles) + ";"
+        "printMargin": defaultGlobals.printMargin,
+        "background": parseColor(globalSettings.background) || defaultGlobals.background,
+        "foreground": parseColor(globalSettings.foreground) || defaultGlobals.foreground,
+        "gutter": defaultGlobals.gutter,
+        "selection": parseColor(globalSettings.selection) || defaultGlobals.selection,
+        "step": defaultGlobals.step,
+        "bracket": parseColor(globalSettings.invisibles) || defaultGlobals.bracket,
+        "active_line": parseColor(globalSettings.lineHighlight) || defaultGlobals.active_line,
+        "cursor": parseColor(globalSettings.caret) || defaultGlobals.cursor,
+        "invisible": "color: " + (parseColor(globalSettings.invisibles) || defaultGlobals.invisible) + ";"
     };
 
     for (var i=1; i<theme.settings.length; i++) {

--- a/tool/tmtheme.js
+++ b/tool/tmtheme.js
@@ -98,8 +98,9 @@ var defaultGlobals = {
     "bracket": "rgb(192, 192, 192)",
     "active_line": "rgba(0, 0, 0, 0.07)",
     "cursor": "#000000",
-    "invisible": "rgb(191, 191, 191)"
-}
+    "invisible": "rgb(191, 191, 191)",
+    "fold": "#6b72e6"
+};
 
 function extractStyles(theme) {
     var globalSettings = theme.settings[0].settings;
@@ -145,6 +146,8 @@ function extractStyles(theme) {
         var foldSource = colors["entity.name.function"] || colors.keyword;
         if (foldSource) {
             colors.fold = foldSource.match(/\:([^;]+)/)[1];
+        } else {
+            colors.fold = defaultGlobals.fold;
         }
     }
     

--- a/tool/tmtheme.js
+++ b/tool/tmtheme.js
@@ -352,7 +352,7 @@ function convertTheme(name, tmThemePath, outputDirectory) {
     })
 }
 
-if (process.argv.length > 1) {
+if (process.argv.length > 2) {
     var args = process.argv.splice(2);
     if (args.length < 3) {
         console.error("Usage: node tmtheme.js [theme_name, path/to/theme.tmTheme path/to/output/directory]");

--- a/tool/tmtheme.js
+++ b/tool/tmtheme.js
@@ -176,6 +176,7 @@ function luma(color) {
 }
 
 function parseColor(color) {
+    if (!color.length) return null;
     if (color.length == 4)
         color = color.replace(/[a-fA-F\d]/g, "$&$&");
     if (color.length == 7)

--- a/tool/tmtheme.js
+++ b/tool/tmtheme.js
@@ -368,19 +368,20 @@ if (process.argv.length > 2) {
     }
 }
 
-var sortedUnsupportedScopes = {};
-for (var u in unsupportedScopes) {
-    var value = unsupportedScopes[u];
-    if (sortedUnsupportedScopes[value] === undefined) {
-        sortedUnsupportedScopes[value] = [];
+if (Object.keys(unsupportedScopes).length > 0) {
+    var sortedUnsupportedScopes = {};
+    for (var u in unsupportedScopes) {
+        var value = unsupportedScopes[u];
+        if (sortedUnsupportedScopes[value] === undefined) {
+            sortedUnsupportedScopes[value] = [];
+        }
+        sortedUnsupportedScopes[value].push(u);
     }
-    sortedUnsupportedScopes[value].push(u);
+    console.log("I found these unsupported scopes:");
+    console.log(sortedUnsupportedScopes);
+    console.log("It's safe to ignore these, but they may affect your syntax highlighting if your mode depends on any of these rules.");
+    console.log("Refer to the docs on ace.ajax.org for information on how to add a scope to the CSS generator.");
 }
-
-console.log("I found these unsupported scopes:");
-console.log(sortedUnsupportedScopes);
-console.log("It's safe to ignore these, but they may affect your syntax highlighting if your mode depends on any of these rules.");
-console.log("Refer to the docs on ace.ajax.org for information on how to add a scope to the CSS generator.");
 
 
 /*** TODO: generate images for indent guides in node


### PR DESCRIPTION
I did a few things while trying to import a custom tmTheme.

- d4ba6ba:[`process.argv`](https://nodejs.org/docs/latest/api/process.html#process_process_argv) returns a minimum of two entries for an executed script. The conditional was looking for one, but the `splice` below it had the right number.
- 03c7b27: There's some logic at the end that doesn't need to run if there are no `unsupportedScopes`.
- `parseStyles`: Several of the default themes were breaking when I tried to run `node tmtheme.js`. I've tested these fixes on everything available in the repo (`crimson_editor.tmTheme` and `eclipse.tmTheme` aren't included)
    - 32f69cc and 809b47d: Because the setup assumes a theme will define all the settings, it was fairly brittle. I added a `null` return from `parseColor` and some defaults (pulled from `.ace-tm`) so that the theme will still generate.
    - 592873e:`fold` had some fallbacks that might not be defined (`entity.name.function` or `keyword`), so I added a default value there.