### PR TITLE
Ext/Searchbox: remove forgotten debugger

### DIFF
--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -85,7 +85,6 @@ var SearchBox = function(editor, range, showReplaceForm) {
     };
     
     this.setSession = function(e) {
-        debugger
         this.searchRange = null;
         this.$syncOptions(true);
     }


### PR DESCRIPTION
it's introduced with in a hotfix PR here https://github.com/ajaxorg/ace/pull/3329