### PR TITLE
[Fix] wrong characters highlighted when caption differs from value

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -453,7 +453,7 @@ var FilteredList = function(array, filterText) {
         var upper = needle.toUpperCase();
         var lower = needle.toLowerCase();
         loop: for (var i = 0, item; item = items[i]; i++) {
-            var caption = item.value || item.caption || item.snippet;
+            var caption = item.caption || item.value || item.snippet;
             if (!caption) continue;
             var lastIndex = -1;
             var matchMask = 0;


### PR DESCRIPTION
## Issue

Autocompleter usually highlights the matching characters in bold font. When a custom-made completer provides both `caption` and `value` (caption longer than value), the highlight is applied to the wrong (non-matching) characters in the `caption` (https://github.com/ajaxorg/ace/blob/29be0850e38130a29ade6694c4a9b8604b8cae23/lib/ace/autocomplete/popup.js#L188).
This is because `matchMask` was created based on the length of `value`. However, when a caption is provided, it takes precedence over the value (https://github.com/ajaxorg/ace/blob/29be0850e38130a29ade6694c4a9b8604b8cae23/lib/ace/autocomplete/popup.js#L182).

## Example:

The callback of `getCompletions(editor, session, pos, "so", callback)` is called with:
```
[
    {
        "caption": "Example::Klass#some_method",
        "value":   "me_method",
        "score":   1000,
        "meta":    "instance method"
    }
]
```
The highlight is applied to "<b>Ex</b>ample::Klass#some_method" instead of "Example::Klass#<b>so</b>me_method".

## Fix

This fix makes the function `filterCompletions` respect the same precedence of `caption` over `value` as in the autocomplete popup.

I don't know if more places in the code need to be adapted, like e.g. line 455, can someone with more ace experience check this?