### PR TITLE
Skip over contents of a \verb in LaTeX code folding

### DIFF
--- a/lib/ace/mode/folding/latex.js
+++ b/lib/ace/mode/folding/latex.js
@@ -78,6 +78,26 @@ oop.inherits(FoldMode, BaseFoldMode);
         }
     };
 
+    this.skipVerb = function (stream) {
+        var row = stream['$row'];
+        var separator = stream.stepForward().value;
+
+        if (stream['$row'] != row) {
+            stream.stepBackward();
+            return;
+        }
+
+        var token;
+        while (token = stream.stepForward()) {
+            if (stream['$row'] != row) {
+                stream.stepBackward();
+                break;
+            } else if (token.value.startsWith(separator)) {
+                break;
+            }
+        }
+    }
+
     this.latexBlock = function(session, row, column, returnRange) {
         var keywords = {
             "\\begin": 1,
@@ -110,6 +130,12 @@ oop.inherits(FoldMode, BaseFoldMode);
         while(token = stream.step()) {
             if (!token || !(token.type == "storage.type" || token.type == "constant.character.escape"))
                 continue;
+
+            if (token.value == "\\verb") {
+                this.skipVerb(stream);
+                continue;
+            }
+
             var level = keywords[token.value];
             if (!level)
                 continue;
@@ -152,6 +178,11 @@ oop.inherits(FoldMode, BaseFoldMode);
             if (token.type !== "storage.type")
                 continue;
             var level = keywordLevels[token.value] || 0;
+
+            if (token.value == "\\verb") {
+                this.skipVerb(stream);
+                continue;
+            }
 
             if (level >= 9) {
                 if (!stackDepth)


### PR DESCRIPTION
## Summary

The `\verb` command starts an inline verbatim environment, which is given a delimiter and used like so:

```
\verb|I am verbatim| I am not
```

All commands within the `\verb` should be ignored for the purposes of code folding.  This patch does that. 

## Concrete example

The "one" section can now fold (in HEAD it gives a range error):

```
\section{one}

\verb \begin{foo}

\section{two}
```

This still doesn't fold (as is correct), because the `\verb` is terminated by the following space:

```
\section{one}

\verb \begin{foo} \begin{foo}

\section{two}
```