### PR TITLE
Recognize 'signature' in module header

### DIFF
--- a/lib/ace/mode/haskell_highlight_rules.js
+++ b/lib/ace/mode/haskell_highlight_rules.js
@@ -55,7 +55,7 @@ var HaskellHighlightRules = function() {
          { token: 'constant.language.empty-list.haskell',
            regex: '\\[\\]' },
          { token: 'keyword.other.haskell',
-           regex: '\\bmodule\\b',
+           regex: '\\b(module|signature)\\b',
            push:
             [ { token: 'keyword.other.haskell', regex: '\\bwhere\\b', next: 'pop' },
               { include: '#module_name' },


### PR DESCRIPTION
In recent versions of GHC there are `signature` modules. From a highlightning perspective these differ from regular modules only in the `signature` keyword.