### PR TITLE
Remove unused dummy mode

### DIFF
--- a/lib/ace/ext/modelist.js
+++ b/lib/ace/ext/modelist.js
@@ -72,8 +72,6 @@ var supportedModes = {
     Dockerfile:  ["^Dockerfile"],
     Dot:         ["dot"],
     Drools:      ["drl"],
-    Dummy:       ["dummy"],
-    DummySyntax: ["dummy"],
     Eiffel:      ["e|ge"],
     EJS:         ["ejs"],
     Elixir:      ["ex|exs"],


### PR DESCRIPTION
Dummy mode doesn't exist in lib/ace/mode/ but exists in this list which can cause some problems