### PR TITLE
Fixed Windows OS / IE unicode IME not working

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -386,6 +386,12 @@ var TextInput = function(parentNode, host) {
             (!!useragent.isChrome && useragent.isChrome >= 53) ||
             (!!useragent.isWebKit && useragent.isWebKit >= 603);
 
+        if (!needsOnInput) {
+            if (useragent.isWin && useragent.isIE) {
+                needsOnInput = true;
+            }
+        }
+
         if (needsOnInput) {
           onInput();
         }


### PR DESCRIPTION
I am korean. Therefore, the language I use is Korean.
When I entered the Window 7 OS and IE 11, I was not properly typed because I did not process the letters IME.

However, I solved the problem by putting the code in the onCompositionEnd function of 'textinput.js' in the corresponding path' ace/lib/ace/lib/ace/keyboard

However, I have tested Hangul in Mac OS Chrome browser and IE 11 in Window 7 OS.

Therefore, if the language of other countries is used by Ace, there is no question whether there is a problem.

What do you think?

I want to talk to you about this matter.