### PR TITLE
Add Java 10 `var` keyword

### DIFF
--- a/lib/ace/mode/java_highlight_rules.js
+++ b/lib/ace/mode/java_highlight_rules.js
@@ -18,7 +18,8 @@ var JavaHighlightRules = function() {
     "catch|extends|int|short|try|" +
     "char|final|interface|static|void|" +
     "class|finally|long|strictfp|volatile|" +
-    "const|float|native|super|while"
+    "const|float|native|super|while|" +
+    "var"
     );
 
     var buildinConstants = ("null|Infinity|NaN|undefined");


### PR DESCRIPTION
Java 10 is just 4 months away from a public release, and one of the new features is the addition of a `var` context-sensitive keyword ([JEP 286](http://openjdk.java.net/jeps/286), available in [early-access builds](http://jdk.java.net/10/)).

I suppose the ideal scenario would be highlighting it only when it is used as a variable type and not as a name. This would match the "context-sensitive" part of the JEP, but I don't think this detail is important nor trivial to implement.
