### PR TITLE
Properly hightlight comments when using atnt-style assembler

### DIFF
--- a/lib/ace/mode/assembly_x86.js
+++ b/lib/ace/mode/assembly_x86.js
@@ -49,7 +49,7 @@ var Mode = function() {
 oop.inherits(Mode, TextMode);
 
 (function() {
-    this.lineCommentStart = ";";
+    this.lineCommentStart = [";", "#"];
     this.$id = "ace/mode/assembly_x86";
 }).call(Mode.prototype);
 


### PR DESCRIPTION
As per the title.