### PR TITLE
Update command substitute

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -4433,8 +4433,17 @@ dom.importCssString(".normal-mode .ace_cursor{\
         onClose(prompt(shortText, ''));
       }
     }
+    
     function splitBySlash(argString) {
-      var slashes = findUnescapedSlashes(argString) || [];
+      return splitBySeparator(argString, '/');
+    }
+  
+    function findUnescapedSlashes(argString) {
+      return findUnescapedSeparators(argString, '/');
+    }
+
+    function splitBySeparator(argString, separator) {
+      var slashes = findUnescapedSeparators(argString, separator) || [];
       if (!slashes.length) return [];
       var tokens = [];
       // in case of strings like foo/bar
@@ -4446,12 +4455,15 @@ dom.importCssString(".normal-mode .ace_cursor{\
       return tokens;
     }
 
-    function findUnescapedSlashes(str) {
+    function findUnescapedSeparators(str, separator) {
+      if (!separator)
+        separator = '/';
+
       var escapeNextChar = false;
       var slashes = [];
       for (var i = 0; i < str.length; i++) {
         var c = str.charAt(i);
-        if (!escapeNextChar && c == '/') {
+        if (!escapeNextChar && c == separator) {
           slashes.push(i);
         }
         escapeNextChar = !escapeNextChar && (c == '\\');
@@ -4869,7 +4881,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
         } else {
           result.line = this.parseLineSpec_(cm, inputStream);
           if (result.line !== undefined && inputStream.eat(',')) {
-            result.lineEnd = this.parseLineSpec_(cm, inputStream);
+            result.lineEnd = this.parseLineSpec_(cm, inputStream, result.line);
           }
         }
 
@@ -4883,7 +4895,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
 
         return result;
       },
-      parseLineSpec_: function(cm, inputStream) {
+      parseLineSpec_: function(cm, inputStream, prevLine) {
         var numberMatch = inputStream.match(/^(\d+)/);
         if (numberMatch) {
           return parseInt(numberMatch[1], 10) - 1;
@@ -4899,6 +4911,14 @@ dom.importCssString(".normal-mode .ace_cursor{\
               return mark.find().line;
             }
             throw new Error('Mark not set');
+          case '+':
+            if (prevLine) { 
+              var match = inputStream.match(/^\d+/);
+              if (match) {
+                return prevLine + parseInt(match[0], 10);
+              }
+            }
+            throw new Error('Require prevLine');
           default:
             inputStream.backUp(1);
             return undefined;
@@ -5268,7 +5288,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
               'any other getSearchCursor implementation.');
         }
         var argString = params.argString;
-        var tokens = argString ? splitBySlash(argString) : [];
+        var tokens = argString ? splitBySeparator(argString, argString[0]) : [];
         var regexPart, replacePart = '', trailing, flagsPart, count;
         var confirm = false; // Whether to confirm each replace.
         var global = false; // True to replace all instances on a line, false to replace only 1.


### PR DESCRIPTION
Update command substitute by wiki http://vim.wikia.com/wiki/Search_and_replace

Add `#` separator (`:s#foo#bar#`) 

Add `+` in range (`:100,+5` like `:100,105`)