### PR TITLE
allow passing options to ace.edit

### DIFF
--- a/lib/ace/ace.js
+++ b/lib/ace/ace.js
@@ -71,9 +71,10 @@ if (typeof define === "function")
 /**
  * Embeds the Ace editor into the DOM, at the element provided by `el`.
  * @param {String | DOMElement} el Either the id of an element, or the element itself
+ * @param {Object } options Options for the editor
  *
  **/
-exports.edit = function(el) {
+exports.edit = function(el, options) {
     if (typeof el == "string") {
         var _id = el;
         el = document.getElementById(_id);
@@ -97,8 +98,7 @@ exports.edit = function(el) {
 
     var doc = exports.createEditSession(value);
 
-    var editor = new Editor(new Renderer(el));
-    editor.setSession(doc);
+    var editor = new Editor(new Renderer(el), doc, options);
 
     var env = {
         document: doc,

--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -70,7 +70,7 @@ var clipboard = require("./clipboard");
  *
  * @constructor
  **/
-var Editor = function(renderer, session) {
+var Editor = function(renderer, session, options) {
     var container = renderer.getContainerElement();
     this.container = container;
     this.renderer = renderer;
@@ -106,8 +106,10 @@ var Editor = function(renderer, session) {
         _self._$emitInputEvent.schedule(31);
     });
 
-    this.setSession(session || new EditSession(""));
+    this.setSession(session || options && options.session || new EditSession(""));
     config.resetOptions(this);
+    if (options)
+        this.setOptions(options);
     config._signal("editor", this);
 };
 
@@ -2670,6 +2672,18 @@ config.defineOptions(Editor.prototype, "editor", {
         set: function(val) { this.setKeyboardHandler(val); },
         get: function() { return this.keybindingId; },
         handlesSet: true
+    },
+    value: {
+        set: function(val) { this.session.setValue(val); },
+        get: function() { return this.getValue(); },
+        handlesSet: true,
+        hidden: true
+    },
+    session: {
+        set: function(val) { this.setSession(val); },
+        get: function() { return this.session; },
+        handlesSet: true,
+        hidden: true
     },
 
     hScrollBarAlwaysVisible: "renderer",

--- a/lib/ace/lib/app_config.js
+++ b/lib/ace/lib/app_config.js
@@ -43,7 +43,10 @@ var optionsProvider = {
     getOptions: function(optionNames) {
         var result = {};
         if (!optionNames) {
-            optionNames = Object.keys(this.$options);
+            var options = this.$options;
+            optionNames = Object.keys(options).filter(function(key) {
+                return !options[key].hidden;
+            });
         } else if (!Array.isArray(optionNames)) {
             result = optionNames;
             optionNames = Object.keys(result);


### PR DESCRIPTION
`editor = ace.edit(domNode, {foo: "bar"})` looks better than `editor = ace.edit(domNode); editor .setOptions({foo: "bar"})`