### PR TITLE
Better handling for uglified files

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -377,6 +377,21 @@
     box-shadow: 0 1px 1px rgba(255, 255, 255, 0.2);
 }
 
+.ace_inline_button {
+    border: 1px solid lightgray;
+    display: inline-block;
+    margin: -1px 8px;
+    padding: 0 5px;
+    pointer-events: auto;
+    cursor: pointer;
+}
+.ace_inline_button:hover {
+    border-color: gray;
+    background: rgba(200,200,200,0.2);
+    display: inline-block;
+    pointer-events: auto;
+}
+
 .ace_fold-widget.ace_invalid {
     background-color: #FFB4B4;
     border-color: #DE5555;

--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -801,7 +801,9 @@ Editor.$uid = 0;
         var line = session.getLine(selection.start.row);
         
         var needle = line.substring(startColumn, endColumn);
-        if (!/[\w\d]/.test(needle))
+        // maximum allowed size for regular expressions in 32000, 
+        // but getting close to it has significant impact on the performance
+        if (needle.length > 5000 || !/[\w\d]/.test(needle))
             return;
 
         var re = this.$search.$assembleRegExp({
@@ -2663,7 +2665,7 @@ config.defineOptions(Editor.prototype, "editor", {
     },
     keyboardHandler: {
         set: function(val) { this.setKeyboardHandler(val); },
-        get: function() { return this.keybindingId; },
+        get: function() { return this.$keybindingId; },
         handlesSet: true
     },
     value: {

--- a/lib/ace/layer/text.js
+++ b/lib/ace/layer/text.js
@@ -55,6 +55,7 @@ var Text = function(parentEl) {
     this.TAB_CHAR = "\u2014"; //"\u21E5";
     this.SPACE_CHAR = "\xB7";
     this.$padding = 0;
+    this.MAX_LINE_LENGTH = 10000;
 
     this.$updateEolChar = function() {
         var EOL_CHAR = this.session.doc.getNewLineCharacter() == "\n"
@@ -449,8 +450,18 @@ var Text = function(parentEl) {
         for (var i = 1; i < tokens.length; i++) {
             token = tokens[i];
             value = token.value;
+            if (screenColumn + value.length > this.MAX_LINE_LENGTH)
+                return this.$renderOverflowMessage(stringBuilder, screenColumn, token, value);
             screenColumn = this.$renderToken(stringBuilder, screenColumn, token, value);
         }
+    };
+    
+    this.$renderOverflowMessage = function(stringBuilder, screenColumn, token, value) {
+        this.$renderToken(stringBuilder, screenColumn, token,
+            value.slice(0, this.MAX_LINE_LENGTH - screenColumn));
+        stringBuilder.push(
+            "<span class='ace_inline_button ace_keyword ace_toggle_wrap'>&lt;click to see more...&gt;</span>"
+        );
     };
 
     // row is either first row of foldline or not in fold

--- a/lib/ace/mouse/fold_handler.js
+++ b/lib/ace/mouse/fold_handler.js
@@ -30,6 +30,7 @@
 
 define(function(require, exports, module) {
 "use strict";
+var dom = require("../lib/dom");
 
 function FoldHandler(editor) {
 
@@ -46,6 +47,14 @@ function FoldHandler(editor) {
                 session.expandFold(fold);
 
             e.stop();
+        }
+        
+        var target = e.domEvent && e.domEvent.target;
+        if (target && dom.hasCssClass(target, "ace_inline_button")) {
+            if (dom.hasCssClass(target, "ace_toggle_wrap")) {
+                session.setOption("wrap", true);
+                editor.renderer.scrollCursorIntoView();
+            }
         }
     });
 

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -1078,6 +1078,9 @@ var VirtualRenderer = function(container, theme) {
         var charCount = this.session.getScreenWidth();
         if (this.showInvisibles && !this.session.$useWrapMode)
             charCount += 1;
+            
+        if (this.$textLayer && charCount > this.$textLayer.MAX_LINE_LENGTH)
+            charCount = this.$textLayer.MAX_LINE_LENGTH + 30;
 
         return Math.max(this.$size.scrollerWidth - 2 * this.$padding, Math.round(charCount * this.characterWidth));
     };


### PR DESCRIPTION

- adds maximum word highlight length of 5000, since chrome often freezes with large regexps
- adds a maximum line length of 10000 similar to monaco editor

![image](https://user-images.githubusercontent.com/341801/35280906-09e7cd6e-006b-11e8-9664-713e056fc940.png)
