### PR TITLE
Move functions to top of blocks to fix parsing error.

### DIFF
--- a/lib/ace/mode/xml/dom.js
+++ b/lib/ace/mode/xml/dom.js
@@ -17,13 +17,13 @@ function copy(src,dest){
 ^\w+\.prototype\.([_\w]+)\s*=\s*(\S.*?(?=[;\r\n]));?
  */
 function _extends(Class,Super){
+	var t = function(){};
 	var pt = Class.prototype;
 	if(Object.create){
-		var ppt = Object.create(Super.prototype)
+		var ppt = Object.create(Super.prototype);
 		pt.__proto__ = ppt;
 	}
 	if(!(pt instanceof Super)){
-		function t(){};
 		t.prototype = Super.prototype;
 		t = new t();
 		copy(pt,t);
@@ -31,14 +31,14 @@ function _extends(Class,Super){
 	}
 	if(pt.constructor != Class){
 		if(typeof Class != 'function'){
-			console.error("unknow Class:"+Class)
+			console.error("unknown Class:"+Class);
 		}
-		pt.constructor = Class
+		pt.constructor = Class;
 	}
 }
 var htmlns = 'http://www.w3.org/1999/xhtml' ;
 // Node Types
-var NodeType = {}
+var NodeType = {};
 var ELEMENT_NODE                = NodeType.ELEMENT_NODE                = 1;
 var ATTRIBUTE_NODE              = NodeType.ATTRIBUTE_NODE              = 2;
 var TEXT_NODE                   = NodeType.TEXT_NODE                   = 3;
@@ -53,7 +53,7 @@ var DOCUMENT_FRAGMENT_NODE      = NodeType.DOCUMENT_FRAGMENT_NODE      = 11;
 var NOTATION_NODE               = NodeType.NOTATION_NODE               = 12;
 
 // ExceptionCode
-var ExceptionCode = {}
+var ExceptionCode = {};
 var ExceptionMessage = {};
 var INDEX_SIZE_ERR              = ExceptionCode.INDEX_SIZE_ERR              = ((ExceptionMessage[1]="Index size error"),1);
 var DOMSTRING_SIZE_ERR          = ExceptionCode.DOMSTRING_SIZE_ERR          = ((ExceptionMessage[2]="DOMString size error"),2);
@@ -100,14 +100,14 @@ NodeList.prototype = {
 	 * The number of nodes in the list. The range of valid child node indices is 0 to length-1 inclusive.
 	 * @standard level1
 	 */
-	length:0, 
+	length:0,
 	/**
 	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns null.
 	 * @standard level1
-	 * @param index  unsigned long 
+	 * @param index  unsigned long
 	 *   Index into the collection.
 	 * @return Node
-	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index. 
+	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 */
 	item: function(index) {
 		return this[index] || null;
@@ -115,7 +115,7 @@ NodeList.prototype = {
 };
 function LiveNodeList(node,refresh){
 	this._node = node;
-	this._refresh = refresh
+	this._refresh = refresh;
 	_updateLiveList(this);
 }
 function _updateLiveList(list){
@@ -135,10 +135,10 @@ LiveNodeList.prototype.item = function(i){
 
 _extends(LiveNodeList,NodeList);
 /**
- * 
+ *
  * Objects implementing the NamedNodeMap interface are used to represent collections of nodes that can be accessed by name. Note that NamedNodeMap does not inherit from NodeList; NamedNodeMaps are not maintained in any particular order. Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal index, but this is simply to allow convenient enumeration of the contents of a NamedNodeMap, and does not imply that the DOM specifies an order to these Nodes.
  * NamedNodeMap objects in the DOM are live.
- * used for attributes or DocumentType entities 
+ * used for attributes or DocumentType entities
  */
 function NamedNodeMap() {
 };
@@ -168,9 +168,9 @@ function _addNamedNode(el,list,newAttr,oldAttr){
 function _removeNamedNode(el,list,attr){
 	var i = _findNodeIndex(list,attr);
 	if(i>=0){
-		var lastIndex = list.length-1
+		var lastIndex = list.length-1;
 		while(i<lastIndex){
-			list[i] = list[++i]
+			list[i] = list[++i];
 		}
 		list.length = lastIndex;
 		if(el){
@@ -181,7 +181,7 @@ function _removeNamedNode(el,list,attr){
 			}
 		}
 	}else{
-		throw new DOMException(NOT_FOUND_ERR,new Error())
+		throw new DOMException(NOT_FOUND_ERR,new Error());
 	}
 }
 NamedNodeMap.prototype = {
@@ -224,10 +224,10 @@ NamedNodeMap.prototype = {
 		var attr = this.getNamedItem(key);
 		_removeNamedNode(this._ownerElement,this,attr);
 		return attr;
-		
-		
+
+
 	},// raises: NOT_FOUND_ERR,NO_MODIFICATION_ALLOWED_ERR
-	
+
 	//for level2
 	removeNamedItemNS:function(namespaceURI,localName){
 		var attr = this.getNamedItemNS(namespaceURI,localName);
@@ -290,7 +290,7 @@ DOMImplementation.prototype = {
 		node.systemId = systemId;
 		// Introduced in DOM Level 2:
 		//readonly attribute DOMString        internalSubset;
-		
+
 		//TODO:..
 		//  readonly attribute NamedNodeMap     entities;
 		//  readonly attribute NamedNodeMap     notations;
@@ -320,10 +320,10 @@ Node.prototype = {
 	prefix : null,
 	localName : null,
 	// Modified in DOM Level 2:
-	insertBefore:function(newChild, refChild){//raises 
+	insertBefore:function(newChild, refChild){//raises
 		return _insertBefore(this,newChild,refChild);
 	},
-	replaceChild:function(newChild, oldChild){//raises 
+	replaceChild:function(newChild, oldChild){//raises
 		this.insertBefore(newChild,oldChild);
 		if(oldChild){
 			this.removeChild(oldChild);
@@ -407,7 +407,7 @@ function _xmlEncoder(c){
          c == '>' && '&gt;' ||
          c == '&' && '&amp;' ||
          c == '"' && '&quot;' ||
-         '&#'+c.charCodeAt()+';'
+         '&#'+c.charCodeAt()+';';
 }
 
 
@@ -446,7 +446,7 @@ function _onRemoveAttribute(doc,el,newAttr,remove){
 	var ns = newAttr.namespaceURI ;
 	if(ns == 'http://www.w3.org/2000/xmlns/'){
 		//update namespace
-		delete el._nsMap[newAttr.prefix?newAttr.localName:'']
+		delete el._nsMap[newAttr.prefix?newAttr.localName:''];
 	}
 }
 function _onUpdateChild(doc,el,newChild){
@@ -472,7 +472,7 @@ function _onUpdateChild(doc,el,newChild){
 /**
  * attributes;
  * children;
- * 
+ *
  * writeable properties:
  * nodeValue,Attr:value,CharacterData:data
  * prefix
@@ -514,8 +514,8 @@ function _insertBefore(parentNode,newChild,nextChild){
 
 	newFirst.previousSibling = pre;
 	newLast.nextSibling = nextChild;
-	
-	
+
+
 	if(pre){
 		pre.nextSibling = newFirst;
 	}else{
@@ -564,8 +564,8 @@ Document.prototype = {
 	doctype :  null,
 	documentElement :  null,
 	_inc : 1,
-	
-	insertBefore :  function(newChild, refChild){//raises 
+
+	insertBefore :  function(newChild, refChild){//raises
 		if(newChild.nodeType == DOCUMENT_FRAGMENT_NODE){
 			var child = newChild.firstChild;
 			while(child){
@@ -578,7 +578,7 @@ Document.prototype = {
 		if(this.documentElement == null && newChild.nodeType == 1){
 			this.documentElement = newChild;
 		}
-		
+
 		return _insertBefore(this,newChild,refChild),(newChild.ownerDocument = this),newChild;
 	},
 	removeChild :  function(oldChild){
@@ -601,10 +601,10 @@ Document.prototype = {
 					return true;
 				}
 			}
-		})
+		});
 		return rtv;
 	},
-	
+
 	//document factory method:
 	createElement :	function(tagName){
 		var node = new Element();
@@ -625,19 +625,19 @@ Document.prototype = {
 	createTextNode :	function(data){
 		var node = new Text();
 		node.ownerDocument = this;
-		node.appendData(data)
+		node.appendData(data);
 		return node;
 	},
 	createComment :	function(data){
 		var node = new Comment();
 		node.ownerDocument = this;
-		node.appendData(data)
+		node.appendData(data);
 		return node;
 	},
 	createCDATASection :	function(data){
 		var node = new CDATASection();
 		node.ownerDocument = this;
-		node.appendData(data)
+		node.appendData(data);
 		return node;
 	},
 	createProcessingInstruction :	function(target,data){
@@ -722,13 +722,13 @@ Element.prototype = {
 	setAttribute : function(name, value){
 		var attr = this.ownerDocument.createAttribute(name);
 		attr.value = attr.nodeValue = "" + value;
-		this.setAttributeNode(attr)
+		this.setAttributeNode(attr);
 	},
 	removeAttribute : function(name){
-		var attr = this.getAttributeNode(name)
+		var attr = this.getAttributeNode(name);
 		attr && this.removeAttributeNode(attr);
 	},
-	
+
 	//four real opeartion method
 	appendChild:function(newChild){
 		if(newChild.nodeType === DOCUMENT_FRAGMENT_NODE){
@@ -751,7 +751,7 @@ Element.prototype = {
 		var old = this.getAttributeNodeNS(namespaceURI, localName);
 		old && this.removeAttributeNode(old);
 	},
-	
+
 	hasAttributeNS : function(namespaceURI, localName){
 		return this.getAttributeNodeNS(namespaceURI, localName)!=null;
 	},
@@ -762,12 +762,12 @@ Element.prototype = {
 	setAttributeNS : function(namespaceURI, qualifiedName, value){
 		var attr = this.ownerDocument.createAttributeNS(namespaceURI, qualifiedName);
 		attr.value = attr.nodeValue = "" + value;
-		this.setAttributeNode(attr)
+		this.setAttributeNode(attr);
 	},
 	getAttributeNodeNS : function(namespaceURI, localName){
 		return this.attributes.getNamedItemNS(namespaceURI, localName);
 	},
-	
+
 	getElementsByTagName : function(tagName){
 		return new LiveNodeList(this,function(base){
 			var ls = [];
@@ -816,13 +816,12 @@ CharacterData.prototype = {
 	},
 	insertData: function(offset,text) {
 		this.replaceData(offset,0,text);
-	
 	},
 	appendChild:function(newChild){
 		//if(!(newChild instanceof CharacterData)){
-			throw new Error(ExceptionMessage[3])
+			throw new Error(ExceptionMessage[3]);
 		//}
-		return Node.prototype.appendChild.apply(this,arguments)
+		return Node.prototype.appendChild.apply(this,arguments);
 	},
 	deleteData: function(offset, count) {
 		this.replaceData(offset,count,"");
@@ -873,27 +872,27 @@ _extends(CDATASection,CharacterData);
 
 
 function DocumentType() {
-};
+}
 DocumentType.prototype.nodeType = DOCUMENT_TYPE_NODE;
 _extends(DocumentType,Node);
 
 function Notation() {
-};
+}
 Notation.prototype.nodeType = NOTATION_NODE;
 _extends(Notation,Node);
 
 function Entity() {
-};
+}
 Entity.prototype.nodeType = ENTITY_NODE;
 _extends(Entity,Node);
 
 function EntityReference() {
-};
+}
 EntityReference.prototype.nodeType = ENTITY_REFERENCE_NODE;
 _extends(EntityReference,Node);
 
 function DocumentFragment() {
-};
+}
 DocumentFragment.prototype.nodeName =	"#document-fragment";
 DocumentFragment.prototype.nodeType =	DOCUMENT_FRAGMENT_NODE;
 _extends(DocumentFragment,Node);
@@ -919,7 +918,7 @@ function serializeToString(node,buf){
 		var len = attrs.length;
 		var child = node.firstChild;
 		var nodeName = node.tagName;
-		var isHTML = htmlns === node.namespaceURI
+		var isHTML = htmlns === node.namespaceURI;
 		buf.push('<',nodeName);
 		for(var i=0;i<len;i++){
 			serializeToString(attrs.item(i),buf);
@@ -1054,12 +1053,12 @@ function cloneNode(doc,node,deep){
 	case ELEMENT_NODE:
 		var attrs	= node.attributes;
 		var attrs2	= node2.attributes = new NamedNodeMap();
-		var len = attrs.length
+		var len = attrs.length;
 		attrs2._ownerElement = node2;
 		for(var i=0;i<len;i++){
 			node2.setAttributeNode(cloneNode(doc,attrs.item(i),true));
 		}
-		break;;
+		break;
 	case ATTRIBUTE_NODE:
 		deep = true;
 	}
@@ -1074,9 +1073,26 @@ function cloneNode(doc,node,deep){
 }
 
 function __set__(object,key,value){
-	object[key] = value
+	object[key] = value;
 }
 //do dynamic
+function getTextContent(node){
+	switch(node.nodeType){
+	case 1:
+	case 11:
+		var buf = [];
+		node = node.firstChild;
+		while(node){
+			if(node.nodeType!==7 && node.nodeType !==8){
+				buf.push(getTextContent(node));
+			}
+			node = node.nextSibling;
+		}
+		return buf.join('');
+	default:
+		return node.nodeValue;
+	}
+}
 try{
 	if(Object.defineProperty){
 		Object.defineProperty(LiveNodeList.prototype,'length',{
@@ -1107,29 +1123,12 @@ try{
 					this.nodeValue = data;
 				}
 			}
-		})
-		
-		function getTextContent(node){
-			switch(node.nodeType){
-			case 1:
-			case 11:
-				var buf = [];
-				node = node.firstChild;
-				while(node){
-					if(node.nodeType!==7 && node.nodeType !==8){
-						buf.push(getTextContent(node));
-					}
-					node = node.nextSibling;
-				}
-				return buf.join('');
-			default:
-				return node.nodeValue;
-			}
-		}
+		});
+
 		__set__ = function(object,key,value){
 			//console.log(value)
-			object['$$'+key] = value
-		}
+			object['$$'+key] = value;
+		};
 	}
 }catch(e){//ie8
 }


### PR DESCRIPTION
Closure Compiler is now throwing fatal errors due to the ’t’ and
‘getTextContent’ functions being declared in the middle of blocks.
Also adds a bunch of missing semicolons.