### PR TITLE
fix: --> might lead to escape problems

### DIFF
--- a/lib/ace/undomanager.js
+++ b/lib/ace/undomanager.js
@@ -558,7 +558,7 @@ function moveDeltasByOne(redoStack, d) {
     d = cloneDelta(d);
     for (var j = redoStack.length; j--;) {
         var deltaSet = redoStack[j];
-        for (var i = deltaSet.length; i--> 0;) {
+        for (var i = deltaSet.length; i-- > 0;) {
             var x = deltaSet[i];
             var xformed = xform(x, d);
             d = xformed[0];


### PR DESCRIPTION
This code can easily get wrongly escaped to `--\x3e` if using a serialize function.
Replacing it with `-- >` will prevent these problems.