### PR TITLE
fix minified --> escape problem

### DIFF
--- a/lib/ace/undomanager.js
+++ b/lib/ace/undomanager.js
@@ -558,7 +558,7 @@ function moveDeltasByOne(redoStack, d) {
     d = cloneDelta(d);
     for (var j = redoStack.length; j--;) {
         var deltaSet = redoStack[j];
-        for (var i = deltaSet.length; i-- > 0;) {
+        for (var i = deltaSet.length - 1; i >= 0; i--) {
             var x = deltaSet[i];
             var xformed = xform(x, d);
             d = xformed[0];


### PR DESCRIPTION
This is closely related to this PR https://github.com/ajaxorg/ace/pull/3591

This problem still exists in minified ace builds. This is not an ace problem itself of course, but some tools which do static analysis of files (like in my case) still break trying to work with ace build output. Also I find this for-loop much easier to understand after the change.