### PR TITLE
focus editor created by ext/textarea only if the original textarea was focused

### DIFF
--- a/lib/ace/ext/textarea.js
+++ b/lib/ace/ext/textarea.js
@@ -156,6 +156,7 @@ function setupContainer(element, getValue) {
 }
 
 exports.transformTextarea = function(element, options) {
+    var isFocused = element.autofocus || document.activeElement == element;
     var session;
     var container = setupContainer(element, function() {
         return session.getValue();
@@ -218,7 +219,8 @@ exports.transformTextarea = function(element, options) {
     session = editor.getSession();
 
     session.setValue(element.value || element.innerHTML);
-    editor.focus();
+    if (isFocused)
+        editor.focus();
 
     // Add the settingPanel opener to the editor's div.
     container.appendChild(settingOpener);


### PR DESCRIPTION
fixes https://github.com/ajaxorg/ace/issues/3602