### PR TITLE
save + restore state when using heredocs

### DIFF
--- a/lib/ace/mode/sh_highlight_rules.js
+++ b/lib/ace/mode/sh_highlight_rules.js
@@ -123,7 +123,7 @@ var ShHighlightRules = function() {
             onMatch : function(value, currentState, stack) {
                 var next = value[2] == '-' ? "indentedHeredoc" : "heredoc";
                 var tokens = value.split(this.splitRegex);
-                stack.push(next, tokens[4]);
+                stack.push(next, tokens[4], currentState);
                 return [
                     {type:"constant", value: tokens[1]},
                     {type:"text", value: tokens[2]},

--- a/lib/ace/mode/sh_highlight_rules.js
+++ b/lib/ace/mode/sh_highlight_rules.js
@@ -139,6 +139,7 @@ var ShHighlightRules = function() {
                             stack.shift();
                             stack.shift();
                             this.next = stack[0] || "start";
+                            stack.shift();
                             return "support.class";
                         }
                         this.next = "";
@@ -156,6 +157,7 @@ var ShHighlightRules = function() {
                             stack.shift();
                             stack.shift();
                             this.next = stack[0] || "start";
+                            stack.shift();
                             return "support.class";
                         }
                         this.next = "";


### PR DESCRIPTION
This should fix an issue where modes that embed `sh` highlight rules can transition into an unexpected state after closing the heredoc.

The existing code seems to already attempt to restore an old saved state; however, as far as I can tell the state is never actually 'saved' when the heredoc is entered. That seems unintentional to me but it's possible I'm missing something?