### PR TITLE
add option to overwrite matches

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -235,9 +235,13 @@ var Autocomplete = function() {
         var matches = [];
         var total = editor.completers.length;
         editor.completers.forEach(function(completer, i) {
-            completer.getCompletions(editor, session, pos, prefix, function(err, results) {
+            completer.getCompletions(editor, session, pos, prefix, function(err, results, overWriteMatches) {
                 if (!err && results)
+                  if(overWriteMatches){
+                    matches = results;
+                  } else {
                     matches = matches.concat(results);
+                  }
                 // Fetch prefix again, because they may have changed by now
                 callback(null, {
                     prefix: util.getCompletionPrefix(editor),


### PR DESCRIPTION
In the current implementation, there is no option to overwrite existing matches. 

This use case applies when someone wants to switch between loading default ace autocomplete list, and a custom one (i.e. supplied via result in the callback function).