### PR TITLE
don't measure font size while scrolling

### DIFF
--- a/lib/ace/layer/font_metrics.js
+++ b/lib/ace/layer/font_metrics.js
@@ -33,6 +33,7 @@ define(function(require, exports, module) {
 var oop = require("../lib/oop");
 var dom = require("../lib/dom");
 var lang = require("../lib/lang");
+var event = require("../lib/event");
 var useragent = require("../lib/useragent");
 var EventEmitter = require("../lib/event_emitter").EventEmitter;
 
@@ -117,8 +118,10 @@ var FontMetrics = exports.FontMetrics = function(parentEl) {
         if (this.$pollSizeChangesTimer || this.$observer)
             return this.$pollSizeChangesTimer;
         var self = this;
-        return this.$pollSizeChangesTimer = setInterval(function() {
+        
+        return this.$pollSizeChangesTimer = event.onIdle(function cb() {
             self.checkForSizeChanges();
+            event.onIdle(cb, 500);
         }, 500);
     };
     

--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -384,6 +384,27 @@ if (typeof window == "object" && window.postMessage && !useragent.isOldIE) {
     };
 }
 
+exports.$idleBlocked = false;
+exports.onIdle = function(cb, timeout) {
+    return setTimeout(function handler() {
+        if (!exports.$idleBlocked) {
+            cb();
+        } else {
+            setTimeout(handler, 100);
+        }
+    }, timeout);
+};
+
+exports.$idleBlockId = null;
+exports.blockIdle = function(delay) {
+    if (exports.$idleBlockId)
+        clearTimeout(exports.$idleBlockId);
+        
+    exports.$idleBlocked = true;
+    exports.$idleBlockId = setTimeout(function() {
+        exports.$idleBlocked = false;
+    }, delay || 100);
+};
 
 exports.nextFrame = typeof window == "object" && (window.requestAnimationFrame
     || window.mozRequestAnimationFrame

--- a/lib/ace/renderloop.js
+++ b/lib/ace/renderloop.js
@@ -52,20 +52,22 @@ var RenderLoop = function(onRender, win) {
 
 
     this.schedule = function(change) {
-        //this.onRender(change);
-        //return;
         this.changes = this.changes | change;
-        if (!this.pending && this.changes) {
-            this.pending = true;
+        if (this.changes) {
             var _self = this;
-            event.nextFrame(function() {
-                _self.pending = false;
-                var changes;
-                while (changes = _self.changes) {
+            
+            event.nextFrame(function(ts) {
+                var changes = _self.changes;
+
+                if (changes) {
+                    event.blockIdle(100);
                     _self.changes = 0;
                     _self.onRender(changes);
                 }
-            }, this.window);
+                
+                if (_self.changes)
+                    _self.schedule();
+            });
         }
     };
 


### PR DESCRIPTION
In browser which don't support ResizeListeners yet (e.g. Firefox) we poll for font size changes every 500ms. If this happens during scrolling then scrolling can become laggy.

This PR introduces an idle event which is guaranteed to not interfere with scrolling.