### PR TITLE
Java: Add Java 9 module-related keywords

### DIFF
--- a/lib/ace/mode/_test/tokens_java.json
+++ b/lib/ace/mode/_test/tokens_java.json
@@ -87,6 +87,28 @@
   ["text",";"]
 ],[
    "start",
+  ["text","        "],
+  ["keyword","int"],
+  ["text"," "],
+  ["identifier","exports"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant.numeric","10"],
+  ["text",";"]
+],[
+   "start",
+  ["text","        "],
+  ["keyword","int"],
+  ["text"," "],
+  ["identifier","requires"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant.numeric","20"],
+  ["text",";"]
+],[
+   "start",
   ["text","    "],
   ["rparen","}"]
 ],[

--- a/lib/ace/mode/_test/tokens_java.json
+++ b/lib/ace/mode/_test/tokens_java.json
@@ -109,6 +109,17 @@
   ["text",";"]
 ],[
    "start",
+  ["text","        "],
+  ["keyword","int"],
+  ["text"," "],
+  ["identifier","open"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant.numeric","30"],
+  ["text",";"]
+],[
+   "start",
   ["text","    "],
   ["rparen","}"]
 ],[

--- a/lib/ace/mode/java_highlight_rules.js
+++ b/lib/ace/mode/java_highlight_rules.js
@@ -100,7 +100,7 @@ var JavaHighlightRules = function() {
                         next: "start"
                     }, {
                         // From Section 3.9 of http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf
-                        regex: "requires|transitive|exports|opens|to|uses|provides|with",
+                        regex: "\\b(requires|transitive|exports|opens|to|uses|provides|with)\\b",
                         token: "keyword" 
                     }]
                 }, {

--- a/lib/ace/mode/java_highlight_rules.js
+++ b/lib/ace/mode/java_highlight_rules.js
@@ -19,6 +19,7 @@ var JavaHighlightRules = function() {
     "char|final|interface|static|void|" +
     "class|finally|long|strictfp|volatile|" +
     "const|float|native|super|while|" +
+    "open|module|requires|transitive|exports|opens|to|uses|provides|with|" + // From Section 3.9 of http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf
     "var"
     );
 

--- a/lib/ace/mode/java_highlight_rules.js
+++ b/lib/ace/mode/java_highlight_rules.js
@@ -100,7 +100,7 @@ var JavaHighlightRules = function() {
                         token: "paren.rparen",
                         next: "start"
                     }, {
-                    	// /From Section 3.9 of http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf
+                        // From Section 3.9 of http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf
                         regex: "requires|transitive|exports|opens|to|uses|provides|with",
                         token: "keyword" 
                     }]

--- a/lib/ace/mode/java_highlight_rules.js
+++ b/lib/ace/mode/java_highlight_rules.js
@@ -19,7 +19,7 @@ var JavaHighlightRules = function() {
     "char|final|interface|static|void|" +
     "class|finally|long|strictfp|volatile|" +
     "const|float|native|super|while|" +
-    "open|module|requires|transitive|exports|opens|to|uses|provides|with|" + // From Section 3.9 of http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf
+    "open|module|" + // "module" or "open module"
     "var"
     );
 
@@ -89,6 +89,37 @@ var JavaHighlightRules = function() {
             }, {
                 token : "constant.language.boolean",
                 regex : "(?:true|false)\\b"
+            },             {
+                regex: "module(?=\\s*\\w)",
+                token: "keyword",
+                next: [{
+                    regex: "{",
+                    token: "paren.lparen",
+                    next: [{
+                        regex: "}",
+                        token: "paren.rparen",
+                        next: "start"
+                    }, {
+                    	// /From Section 3.9 of http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf
+                        regex: "requires|transitive|exports|opens|to|uses|provides|with",
+                        token: "keyword" 
+                    }]
+                }, {
+                    token : "text",
+                    regex : "\\s+"
+                }, {
+                    token : "identifier",
+                    regex : "\\w+"
+                }, {
+                    token : "punctuation.operator",
+                    regex : "."
+                }, {
+                    token : "text",
+                    regex : "\\s+"
+                }, {
+                    regex: "", // exit if there is anything else
+                    next: "start"
+                }]
             }, {
                 token : keywordMapper,
                 // TODO: Unicode escape sequences
@@ -119,8 +150,10 @@ var JavaHighlightRules = function() {
         ]
     };
 
+    
     this.embedRules(DocCommentHighlightRules, "doc-",
         [ DocCommentHighlightRules.getEndRule("start") ]);
+    this.normalizeRules();
 };
 
 oop.inherits(JavaHighlightRules, TextHighlightRules);

--- a/lib/ace/mode/java_highlight_rules.js
+++ b/lib/ace/mode/java_highlight_rules.js
@@ -19,7 +19,6 @@ var JavaHighlightRules = function() {
     "char|final|interface|static|void|" +
     "class|finally|long|strictfp|volatile|" +
     "const|float|native|super|while|" +
-    "open|module|" + // "module" or "open module"
     "var"
     );
 
@@ -89,8 +88,8 @@ var JavaHighlightRules = function() {
             }, {
                 token : "constant.language.boolean",
                 regex : "(?:true|false)\\b"
-            },             {
-                regex: "module(?=\\s*\\w)",
+            }, {
+                regex: "(open(?:\\s+))?module(?=\\s*\\w)",
                 token: "keyword",
                 next: [{
                     regex: "{",


### PR DESCRIPTION
Registered the ten new Java 9 restricted keywords as keywords.
From Section 3.9 of http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf:
> A further ten character sequences are restricted keywords: open, module,
requires, transitive, exports, opens, to, uses, provides, and with.

## Keywords vs restricted keywords
Note that these are *restricted* keywords, it means that ideally they should be highlighted as keywords only when in `module-info.java`. From the Section 3.9 referenced above:
> These
character sequences are tokenized as keywords solely where they appear as
terminals in the ModuleDeclaration and ModuleDirective productions (§7.7). They
are tokenized as identifiers everywhere else, for compatibility with programs
written prior to Java SE 9. There is one exception: immediately to the right of
the character sequence requires in the ModuleDirective production, the character
sequence transitive is tokenized as a keyword unless it is followed by a separator,
in which case it is tokenized as an identifier.

It makes this change similar to https://github.com/ajaxorg/ace/pull/3467 where `var` is not a keyword, but a `reserved type name`

## Screenshot
This is what `module-info.java` looks like with this change:
<img width="583" alt="screen shot 2018-03-26 at 4 40 51 pm" src="https://user-images.githubusercontent.com/644582/37932403-69cb931a-3116-11e8-8ee3-8ddd3ca03f43.png">
