### PR TITLE
Added arialabelledby to textarea 

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -66,11 +66,12 @@ var clipboard = require("./clipboard");
  *
  * @param {VirtualRenderer} renderer Associated `VirtualRenderer` that draws everything
  * @param {EditSession} session The `EditSession` to refer to
- *
+ * @param options The options used to create the Editor. See ../ext/options.js
+ * @param arialabelledby The identifier of the element that will describe this textarea for accessibility technologies.
  *
  * @constructor
  **/
-var Editor = function(renderer, session, options) {
+var Editor = function(renderer, session, options, arialabelledby) {
     var container = renderer.getContainerElement();
     this.container = container;
     this.renderer = renderer;
@@ -78,7 +79,7 @@ var Editor = function(renderer, session, options) {
 
     this.commands = new CommandManager(useragent.isMac ? "mac" : "win", defaultCommands);
     if (typeof document == "object") {
-        this.textInput = new TextInput(renderer.getTextAreaContainer(), this);
+        this.textInput = new TextInput(renderer.getTextAreaContainer(), this, arialabelledby);
         this.renderer.textarea = this.textInput.getElement();
         // TODO detect touch event support
         this.$mouseHandler = new MouseHandler(this);

--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -40,7 +40,7 @@ var USE_IE_MIME_TYPE =  useragent.isIE;
 var HAS_FOCUS_ARGS = useragent.isChrome > 63;
 
 var TextInputIOS = require("./textinput_ios").TextInput;
-var TextInput = function(parentNode, host) {
+var TextInput = function(parentNode, host, arialabelledby) {
     if (useragent.isIOS)
         return TextInputIOS.call(this, parentNode, host);
     
@@ -51,6 +51,7 @@ var TextInput = function(parentNode, host) {
     text.setAttribute("autocorrect", "off");
     text.setAttribute("autocapitalize", "off");
     text.setAttribute("spellcheck", false);
+    text.setAttribute("aria-labelledby", arialabelledby);
 
     text.style.opacity = "0";
     parentNode.insertBefore(text, parentNode.firstChild);


### PR DESCRIPTION
Accessibility technology should have a way to call out what the Ace Editor component is. Adding a way to set the arialabelledby attribute on the textarea will allow devs to set the label for the textarea.