### PR TITLE
lucene: highlight rules improvements

### DIFF
--- a/lib/ace/mode/_test/text_lucene.txt
+++ b/lib/ace/mode/_test/text_lucene.txt
@@ -37,3 +37,20 @@ field:["a b c" TO def]
 field:{"a b c" TO def}
 field:{foo TO "bar"}
 field:{20180101 TO 20190202}
+field:{"2018-01-01" TO "2019-02-02"}
+\+escaped
+\-escaped
+esc\&aped
+esc\|aped
+\!escaped
+\(escaped\)
+\{escaped\}
+\[escaped\]
+escaped\^4
+\"escaped\"
+escaped\~0.4
+escaped\*
+escaped\?
+esc\:aped
+esc\\aped
+esc\ aped:foo

--- a/lib/ace/mode/_test/text_lucene.txt
+++ b/lib/ace/mode/_test/text_lucene.txt
@@ -54,3 +54,4 @@ escaped\?
 esc\:aped
 esc\\aped
 esc\ aped:foo
+"foo\"bar"

--- a/lib/ace/mode/_test/text_lucene.txt
+++ b/lib/ace/mode/_test/text_lucene.txt
@@ -1,16 +1,39 @@
-test: recognises AND as keyword
-test: recognises OR as keyword
-test: recognises NOT as keyword
-test: recognises "hello this is dog" as string
-test: recognises -"hello this is dog" as negation with string
-test: recognises ~100 as text with proximity
-test: recognises "hello this is dog"~100 as string with proximity
-test: recognises raw:"hello this is dog" as keyword
-test: recognises raw:foo as"keyword'
-test: recognises "(" as opening parenthesis
-test: recognises ")" as closing parenthesis
-test: recognises foo* as text with asterisk
-test: recognises foo? as text with interro
-test: recognises single word as text
  foo
- 
+foo: foo AND bar
+foo AND bar
+foo OR bar
+foo NOT bar
+"foo bar"
+bar "foo bar"
+bar -foo
+bar -"foo bar"
+-foo
+-"foo bar"
+bar foo~100
+foo~100
+foo~100 bar
+"foo bar"~10
+foo~
+bar foo~
+foo~ bar
+foo~0.8
+field:foo
+field:foo bar
+field:"foo bar"
+(foo AND bar)
+(field:foo AND field:"bar baz")
+foo*
+f?o
+f*o
++foo
++"foo bar"
+foo?
+?oo
+foo
+field:(-foo +bar +"foo bar")
+field:{foo TO bar}
+field:[foo TO bar]
+field:["a b c" TO def]
+field:{"a b c" TO def}
+field:{foo TO "bar"}
+field:{20180101 TO 20190202}

--- a/lib/ace/mode/_test/tokens_lucene.json
+++ b/lib/ace/mode/_test/tokens_lucene.json
@@ -327,5 +327,8 @@
   ["keyword","esc\\ aped:"],
   ["term","foo"]
 ],[
+   "start",
+  ["string","\"foo\\\"bar\""]
+],[
    "start"
 ]]

--- a/lib/ace/mode/_test/tokens_lucene.json
+++ b/lib/ace/mode/_test/tokens_lucene.json
@@ -1,92 +1,245 @@
 [[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
+  ["text"," "],
+  ["string.unquoted","foo"]
+],[
+   "start",
+  ["keyword","foo:"],
+  ["text"," "],
+  ["string.unquoted","foo"],
+  ["text"," "],
   ["keyword.operator","AND"],
-  ["text"," as keyword"]
+  ["text"," "],
+  ["string.unquoted","bar"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
+  ["string.unquoted","foo"],
+  ["text"," "],
+  ["keyword.operator","AND"],
+  ["text"," "],
+  ["string.unquoted","bar"]
+],[
+   "start",
+  ["string.unquoted","foo"],
+  ["text"," "],
   ["keyword.operator","OR"],
-  ["text"," as keyword"]
+  ["text"," "],
+  ["string.unquoted","bar"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
+  ["string.unquoted","foo"],
+  ["text"," "],
   ["keyword.operator","NOT"],
-  ["text"," as keyword"]
+  ["text"," "],
+  ["string.unquoted","bar"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
-  ["string","\"hello this is dog\""],
-  ["text"," as string"]
+  ["string","\"foo bar\""]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
+  ["string.unquoted","bar"],
+  ["text"," "],
+  ["string","\"foo bar\""]
+],[
+   "start",
+  ["string.unquoted","bar"],
+  ["text"," "],
   ["constant.character.negation","-"],
-  ["string","\"hello this is dog\""],
-  ["text"," as negation with string"]
+  ["string.unquoted","foo"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
+  ["string.unquoted","bar"],
+  ["text"," "],
+  ["constant.character.negation","-"],
+  ["string","\"foo bar\""]
+],[
+   "start",
+  ["constant.character.negation","-"],
+  ["string.unquoted","foo"]
+],[
+   "start",
+  ["constant.character.negation","-"],
+  ["string","\"foo bar\""]
+],[
+   "start",
+  ["string.unquoted","bar"],
+  ["text"," "],
+  ["string.unquoted","foo"],
+  ["constant.character.proximity","~100"]
+],[
+   "start",
+  ["string.unquoted","foo"],
+  ["constant.character.proximity","~100"]
+],[
+   "start",
+  ["string.unquoted","foo"],
   ["constant.character.proximity","~100"],
-  ["text"," as text with proximity"]
+  ["text"," "],
+  ["string.unquoted","bar"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
-  ["string","\"hello this is dog\""],
-  ["constant.character.proximity","~100"],
-  ["text"," as string with proximity"]
+  ["string","\"foo bar\""],
+  ["constant.character.proximity","~10"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
-  ["keyword","raw:"],
-  ["string","\"hello this is dog\""],
-  ["text"," as keyword"]
+  ["string.unquoted","foo"],
+  ["constant.character.proximity","~"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
-  ["keyword","raw:"],
-  ["text","foo as\"keyword'"]
+  ["string.unquoted","bar"],
+  ["text"," "],
+  ["string.unquoted","foo"],
+  ["constant.character.proximity","~"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
-  ["string","\"(\""],
-  ["text"," as opening parenthesis"]
+  ["string.unquoted","foo"],
+  ["constant.character.proximity","~"],
+  ["text"," "],
+  ["string.unquoted","bar"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises "],
-  ["string","\")\""],
-  ["text"," as closing parenthesis"]
+  ["string.unquoted","foo"],
+  ["constant.character.proximity","~0.8"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises foo"],
-  ["constant.character.asterisk","*"],
-  ["text"," as text with asterisk"]
+  ["keyword","field:"],
+  ["string.unquoted","foo"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises foo"],
+  ["keyword","field:"],
+  ["string.unquoted","foo"],
+  ["text"," "],
+  ["string.unquoted","bar"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["string","\"foo bar\""]
+],[
+   "start",
+  ["paren.lparen","("],
+  ["string.unquoted","foo"],
+  ["text"," "],
+  ["keyword.operator","AND"],
+  ["text"," "],
+  ["string.unquoted","bar"],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["paren.lparen","("],
+  ["keyword","field:"],
+  ["string.unquoted","foo"],
+  ["text"," "],
+  ["keyword.operator","AND"],
+  ["text"," "],
+  ["keyword","field:"],
+  ["string","\"bar baz\""],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["string.unquoted","foo"],
+  ["constant.character.asterisk","*"]
+],[
+   "start",
+  ["string.unquoted","f"],
   ["constant.character.interro","?"],
-  ["text"," as text with interro"]
+  ["string.unquoted","o"]
 ],[
    "start",
-  ["keyword","test:"],
-  ["text"," recognises single word as text"]
+  ["string.unquoted","f"],
+  ["constant.character.asterisk","*"],
+  ["string.unquoted","o"]
 ],[
    "start",
-  ["text"," foo"]
+  ["constant.character.required","+"],
+  ["string.unquoted","foo"]
 ],[
    "start",
-  ["text"," "]
+  ["constant.character.required","+"],
+  ["string","\"foo bar\""]
+],[
+   "start",
+  ["string.unquoted","foo"],
+  ["constant.character.interro","?"]
+],[
+   "start",
+  ["constant.character.interro","?"],
+  ["string.unquoted","oo"]
+],[
+   "start",
+  ["string.unquoted","foo"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["paren.lparen","("],
+  ["constant.character.negation","-"],
+  ["string.unquoted","foo"],
+  ["text"," "],
+  ["constant.character.required","+"],
+  ["string.unquoted","bar"],
+  ["text"," "],
+  ["constant.character.required","+"],
+  ["string","\"foo bar\""],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["paren.lparen","{"],
+  ["string.unquoted","foo"],
+  ["text"," "],
+  ["keyword.operator","TO"],
+  ["text"," "],
+  ["string.unquoted","bar"],
+  ["paren.rparen","}"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["paren.lparen","["],
+  ["string.unquoted","foo"],
+  ["text"," "],
+  ["keyword.operator","TO"],
+  ["text"," "],
+  ["string.unquoted","bar"],
+  ["paren.rparen","]"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["paren.lparen","["],
+  ["string","\"a b c\""],
+  ["text"," "],
+  ["keyword.operator","TO"],
+  ["text"," "],
+  ["string.unquoted","def"],
+  ["paren.rparen","]"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["paren.lparen","{"],
+  ["string","\"a b c\""],
+  ["text"," "],
+  ["keyword.operator","TO"],
+  ["text"," "],
+  ["string.unquoted","def"],
+  ["paren.rparen","}"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["paren.lparen","{"],
+  ["string.unquoted","foo"],
+  ["text"," "],
+  ["keyword.operator","TO"],
+  ["text"," "],
+  ["string","\"bar\""],
+  ["paren.rparen","}"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["paren.lparen","{"],
+  ["string.unquoted","20180101"],
+  ["text"," "],
+  ["keyword.operator","TO"],
+  ["text"," "],
+  ["string.unquoted","20190202"],
+  ["paren.rparen","}"]
+],[
+   "start"
 ]]

--- a/lib/ace/mode/_test/tokens_lucene.json
+++ b/lib/ace/mode/_test/tokens_lucene.json
@@ -1,115 +1,115 @@
 [[
    "start",
   ["text"," "],
-  ["string.unquoted","foo"]
+  ["term","foo"]
 ],[
    "start",
   ["keyword","foo:"],
   ["text"," "],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","AND"],
   ["text"," "],
-  ["string.unquoted","bar"]
+  ["term","bar"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","AND"],
   ["text"," "],
-  ["string.unquoted","bar"]
+  ["term","bar"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","OR"],
   ["text"," "],
-  ["string.unquoted","bar"]
+  ["term","bar"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","NOT"],
   ["text"," "],
-  ["string.unquoted","bar"]
+  ["term","bar"]
 ],[
    "start",
   ["string","\"foo bar\""]
 ],[
    "start",
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["text"," "],
   ["string","\"foo bar\""]
 ],[
    "start",
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["text"," "],
   ["constant.character.negation","-"],
-  ["string.unquoted","foo"]
+  ["term","foo"]
 ],[
    "start",
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["text"," "],
   ["constant.character.negation","-"],
   ["string","\"foo bar\""]
 ],[
    "start",
   ["constant.character.negation","-"],
-  ["string.unquoted","foo"]
+  ["term","foo"]
 ],[
    "start",
   ["constant.character.negation","-"],
   ["string","\"foo bar\""]
 ],[
    "start",
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["text"," "],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.proximity","~100"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.proximity","~100"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.proximity","~100"],
   ["text"," "],
-  ["string.unquoted","bar"]
+  ["term","bar"]
 ],[
    "start",
   ["string","\"foo bar\""],
   ["constant.character.proximity","~10"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.proximity","~"]
 ],[
    "start",
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["text"," "],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.proximity","~"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.proximity","~"],
   ["text"," "],
-  ["string.unquoted","bar"]
+  ["term","bar"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.proximity","~0.8"]
 ],[
    "start",
   ["keyword","field:"],
-  ["string.unquoted","foo"]
+  ["term","foo"]
 ],[
    "start",
   ["keyword","field:"],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
-  ["string.unquoted","bar"]
+  ["term","bar"]
 ],[
    "start",
   ["keyword","field:"],
@@ -117,17 +117,17 @@
 ],[
    "start",
   ["paren.lparen","("],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","AND"],
   ["text"," "],
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["paren.rparen",")"]
 ],[
    "start",
   ["paren.lparen","("],
   ["keyword","field:"],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","AND"],
   ["text"," "],
@@ -136,46 +136,46 @@
   ["paren.rparen",")"]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.asterisk","*"]
 ],[
    "start",
-  ["string.unquoted","f"],
+  ["term","f"],
   ["constant.character.interro","?"],
-  ["string.unquoted","o"]
+  ["term","o"]
 ],[
    "start",
-  ["string.unquoted","f"],
+  ["term","f"],
   ["constant.character.asterisk","*"],
-  ["string.unquoted","o"]
+  ["term","o"]
 ],[
    "start",
   ["constant.character.required","+"],
-  ["string.unquoted","foo"]
+  ["term","foo"]
 ],[
    "start",
   ["constant.character.required","+"],
   ["string","\"foo bar\""]
 ],[
    "start",
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["constant.character.interro","?"]
 ],[
    "start",
   ["constant.character.interro","?"],
-  ["string.unquoted","oo"]
+  ["term","oo"]
 ],[
    "start",
-  ["string.unquoted","foo"]
+  ["term","foo"]
 ],[
    "start",
   ["keyword","field:"],
   ["paren.lparen","("],
   ["constant.character.negation","-"],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["constant.character.required","+"],
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["text"," "],
   ["constant.character.required","+"],
   ["string","\"foo bar\""],
@@ -184,21 +184,21 @@
    "start",
   ["keyword","field:"],
   ["paren.lparen","{"],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","TO"],
   ["text"," "],
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["paren.rparen","}"]
 ],[
    "start",
   ["keyword","field:"],
   ["paren.lparen","["],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","TO"],
   ["text"," "],
-  ["string.unquoted","bar"],
+  ["term","bar"],
   ["paren.rparen","]"]
 ],[
    "start",
@@ -208,7 +208,7 @@
   ["text"," "],
   ["keyword.operator","TO"],
   ["text"," "],
-  ["string.unquoted","def"],
+  ["term","def"],
   ["paren.rparen","]"]
 ],[
    "start",
@@ -218,13 +218,13 @@
   ["text"," "],
   ["keyword.operator","TO"],
   ["text"," "],
-  ["string.unquoted","def"],
+  ["term","def"],
   ["paren.rparen","}"]
 ],[
    "start",
   ["keyword","field:"],
   ["paren.lparen","{"],
-  ["string.unquoted","foo"],
+  ["term","foo"],
   ["text"," "],
   ["keyword.operator","TO"],
   ["text"," "],
@@ -234,12 +234,98 @@
    "start",
   ["keyword","field:"],
   ["paren.lparen","{"],
-  ["string.unquoted","20180101"],
+  ["term","20180101"],
   ["text"," "],
   ["keyword.operator","TO"],
   ["text"," "],
-  ["string.unquoted","20190202"],
+  ["term","20190202"],
   ["paren.rparen","}"]
+],[
+   "start",
+  ["keyword","field:"],
+  ["paren.lparen","{"],
+  ["string","\"2018-01-01\""],
+  ["text"," "],
+  ["keyword.operator","TO"],
+  ["text"," "],
+  ["string","\"2019-02-02\""],
+  ["paren.rparen","}"]
+],[
+   "start",
+  ["constant.language.escape","\\+"],
+  ["term","escaped"]
+],[
+   "start",
+  ["constant.language.escape","\\-"],
+  ["term","escaped"]
+],[
+   "start",
+  ["term","esc"],
+  ["constant.language.escape","\\&"],
+  ["term","aped"]
+],[
+   "start",
+  ["term","esc"],
+  ["constant.language.escape","\\|"],
+  ["term","aped"]
+],[
+   "start",
+  ["constant.language.escape","\\!"],
+  ["term","escaped"]
+],[
+   "start",
+  ["constant.language.escape","\\("],
+  ["term","escaped"],
+  ["constant.language.escape","\\)"]
+],[
+   "start",
+  ["constant.language.escape","\\{"],
+  ["term","escaped"],
+  ["constant.language.escape","\\}"]
+],[
+   "start",
+  ["constant.language.escape","\\["],
+  ["term","escaped"],
+  ["constant.language.escape","\\]"]
+],[
+   "start",
+  ["term","escaped"],
+  ["constant.language.escape","\\^"],
+  ["term","4"]
+],[
+   "start",
+  ["constant.language.escape","\\\""],
+  ["term","escaped"],
+  ["constant.language.escape","\\\""]
+],[
+   "start",
+  ["term","escaped"],
+  ["constant.language.escape","\\~"],
+  ["term","0"],
+  ["text","."],
+  ["term","4"]
+],[
+   "start",
+  ["term","escaped"],
+  ["constant.language.escape","\\*"]
+],[
+   "start",
+  ["term","escaped"],
+  ["constant.language.escape","\\?"]
+],[
+   "start",
+  ["term","esc"],
+  ["constant.language.escape","\\:"],
+  ["term","aped"]
+],[
+   "start",
+  ["term","esc"],
+  ["constant.language.escape","\\\\"],
+  ["term","aped"]
+],[
+   "start",
+  ["keyword","esc\\ aped:"],
+  ["term","foo"]
 ],[
    "start"
 ]]

--- a/lib/ace/mode/lucene_highlight_rules.js
+++ b/lib/ace/mode/lucene_highlight_rules.js
@@ -6,41 +6,58 @@ var lang = require("../lib/lang");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 
 var LuceneHighlightRules = function() {
-    this.$rules = {
-        "start" : [
-            {
-                token : "constant.character.negation",
-                regex : "[\\-]"
-            }, {
-                token : "constant.character.interro",
-                regex : "[\\?]"
-            }, {
-                token : "constant.character.asterisk",
-                regex : "[\\*]"
-            }, {
-                token: 'constant.character.proximity',
-                regex: '~[0-9]+\\b'
-            }, {
-                token : 'keyword.operator',
-                regex: '(?:AND|OR|NOT)\\b'
-            }, {
-                token : "paren.lparen",
-                regex : "[\\(]"
-            }, {
-                token : "paren.rparen",
-                regex : "[\\)]"
-            }, {
-                token : "keyword",
-                regex : "[\\S]+:"
-            }, {
-                token : "string",           // " string
-                regex : '".*?"'
-            }, {
-                token : "text",
-                regex : "\\s+"
-            }
-        ]
-    };
+  this.$rules = {
+    "start" : [
+      {
+        token: "constant.character.negation",
+        regex: "\\-"
+      },
+      {
+        token: "constant.character.interro",
+        regex: "\\?"
+      },
+      {
+        token: "constant.character.required",
+        regex: "\\+"
+      },
+      {
+        token: "constant.character.asterisk",
+        regex: "\\*"
+      },
+      {
+        token: 'constant.character.proximity',
+        regex: '~(?:0\\.[0-9]+|[0-9]+)?'
+      },
+      {
+        token: 'keyword.operator',
+        regex: '(AND|OR|NOT|TO)\\b'
+      },
+      {
+        token: "paren.lparen",
+        regex: "[\\(\\{\\[]"
+      },
+      {
+        token: "paren.rparen",
+        regex: "[\\)\\}\\]]"
+      },
+      {
+        token: "keyword",
+        regex: "\\S+:"
+      },
+      {
+        token: "string",           // " string
+        regex: '"[^"]*"'
+      },
+      {
+        token: "string.unquoted",
+        regex: "\\w+"
+      },
+      {
+        token: "text",
+        regex: "\\s+"
+      }
+    ]
+  };
 };
 
 oop.inherits(LuceneHighlightRules, TextHighlightRules);

--- a/lib/ace/mode/lucene_highlight_rules.js
+++ b/lib/ace/mode/lucene_highlight_rules.js
@@ -6,58 +6,47 @@ var lang = require("../lib/lang");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 
 var LuceneHighlightRules = function() {
-  this.$rules = {
-    "start" : [
-      {
-        token: "constant.character.negation",
-        regex: "\\-"
-      },
-      {
-        token: "constant.character.interro",
-        regex: "\\?"
-      },
-      {
-        token: "constant.character.required",
-        regex: "\\+"
-      },
-      {
-        token: "constant.character.asterisk",
-        regex: "\\*"
-      },
-      {
-        token: 'constant.character.proximity',
-        regex: '~(?:0\\.[0-9]+|[0-9]+)?'
-      },
-      {
-        token: 'keyword.operator',
-        regex: '(AND|OR|NOT|TO)\\b'
-      },
-      {
-        token: "paren.lparen",
-        regex: "[\\(\\{\\[]"
-      },
-      {
-        token: "paren.rparen",
-        regex: "[\\)\\}\\]]"
-      },
-      {
-        token: "keyword",
-        regex: "\\S+:"
-      },
-      {
-        token: "string",           // " string
-        regex: '"[^"]*"'
-      },
-      {
-        token: "string.unquoted",
-        regex: "\\w+"
-      },
-      {
-        token: "text",
-        regex: "\\s+"
-      }
-    ]
-  };
+    this.$rules = {
+        "start" : [
+            {
+                token: "constant.character.negation",
+                regex: "\\-"
+            }, {
+                token: "constant.character.interro",
+                regex: "\\?"
+            }, {
+                token: "constant.character.required",
+                regex: "\\+"
+            }, {
+                token: "constant.character.asterisk",
+                regex: "\\*"
+            }, {
+                token: 'constant.character.proximity',
+                regex: '~(?:0\\.[0-9]+|[0-9]+)?'
+            }, {
+                token: 'keyword.operator',
+                regex: '(AND|OR|NOT|TO)\\b'
+            }, {
+                token: "paren.lparen",
+                regex: "[\\(\\{\\[]"
+            }, {
+                token: "paren.rparen",
+                regex: "[\\)\\}\\]]"
+            }, {
+                token: "keyword",
+                regex: "\\S+:"
+            }, {
+                token: "string",           // " string
+                regex: '"[^"]*"'
+            }, {
+                token: "string.unquoted",
+                regex: "\\w+"
+            }, {
+                token: "text",
+                regex: "\\s+"
+            }
+        ]
+    };
 };
 
 oop.inherits(LuceneHighlightRules, TextHighlightRules);

--- a/lib/ace/mode/lucene_highlight_rules.js
+++ b/lib/ace/mode/lucene_highlight_rules.js
@@ -9,6 +9,9 @@ var LuceneHighlightRules = function() {
     this.$rules = {
         "start" : [
             {
+                token: "constant.language.escape",
+                regex: /\\[\+\-&\|!\(\)\{\}\[\]^"~\*\?:\\]/
+            }, {
                 token: "constant.character.negation",
                 regex: "\\-"
             }, {
@@ -34,12 +37,12 @@ var LuceneHighlightRules = function() {
                 regex: "[\\)\\}\\]]"
             }, {
                 token: "keyword",
-                regex: "\\S+:"
+                regex: "(?:[^\\s:]+|\\\\ )*[^\\\\]:"
             }, {
                 token: "string",           // " string
                 regex: '"[^"]*"'
             }, {
-                token: "string.unquoted",
+                token: "term",
                 regex: "\\w+"
             }, {
                 token: "text",

--- a/lib/ace/mode/lucene_highlight_rules.js
+++ b/lib/ace/mode/lucene_highlight_rules.js
@@ -40,7 +40,7 @@ var LuceneHighlightRules = function() {
                 regex: "(?:[^\\s:]+|\\\\ )*[^\\\\]:"
             }, {
                 token: "string",           // " string
-                regex: '"[^"]*"'
+                regex: '"(?:\\\\"|[^"])*"'
             }, {
                 token: "term",
                 regex: "\\w+"


### PR DESCRIPTION
This is an attempt at fixing/improving the lucene syntax highlighting rules.

I've done the following:

* added `{a TO b}`
* added `[a TO b]`
* added fuzzy searching (`foo~` and `foo~0.8`, extends the existing proximity rule)
* added `+` (e.g. `+foo +"foo bar"`)
* added `string.unquoted` as `\w+` to avoid parsing `" abc"` as one text token, instead you now get two: `" "` as a text token and `"abc"` as a string.unquoted token
* replaced test text and updated generated tokens

@nightwing would you mind taking a look over this? i haven't changed highlight rules before so its very possible i've done something wrong or left potentially overmatching rules.

for example my `string.unquoted` is essentially `\w+`. Seeing as it is low in the array, though, does that mean if something else matches first (which is after it in the string), the unquoted string will be marked as the default token (text)?