### PR TITLE
Change image link highlighting for mode-markdown 

### DIFF
--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -110,6 +110,14 @@ var MarkdownHighlightRules = function() {
         }, { // link by reference
             token : ["text", "string", "text", "constant", "text"],
             regex : "(\\[)(" + escaped("]") + ")(\\]\s*\\[)("+ escaped("]") + ")(\\])"
+        }, { // link image 
+            token : ["text", "string", "text", "markup.underline", "string", "text"],
+            regex : "(\\!\\[)(" +                                     // ![
+                    escaped("]") +                                    // alt text
+                    ")(\\]\\()"+                                      // ](
+                    '((?:[^\\)\\s\\\\]|\\\\.|\\s(?=[^"]))*)' +        // image link
+                    '(\\s*"' +  escaped('"') + '"\\s*)?' +            // "title"
+                    "(\\))"                                           // )
         }, { // link by url
             token : ["text", "string", "text", "markup.underline", "string", "text"],
             regex : "(\\[)(" +                                        // [


### PR DESCRIPTION
Image link highlighting in mode-markdown seems to not highlight the leading `!` character. In some cases this looks OK in others maybe not so much. I think it's probably better to have the entire image formatting use the same colors.

Added in explicit image link handling.

This is what it looks like before:

![image](https://user-images.githubusercontent.com/1374013/39971617-23658aa8-56b3-11e8-8b80-7a755faf81f3.png)

and here it is after the change:

![image](https://user-images.githubusercontent.com/1374013/39971619-2ab599c4-56b3-11e8-9eee-c52a4eb62194.png)

The latter seems more consistent. 

To be honest this is minor but several of my users have mentioned this ([here's one](https://github.com/RickStrahl/MarkdownMonster/issues/366)) and looking at the two renderings side by side I do think that the latter looks more consistent.

