### PR TITLE
Add image link parsing to the Markdown link parsing RegEx

### DIFF
--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -137,10 +137,10 @@ var MarkdownHighlightRules = function() {
             regex : "(\\[)(" + escaped("]") + ")(\\]\\s*\\[)("+ escaped("]") + ")(\\])"
         }, { // link by url
             token : ["text", "string", "text", "markup.underline", "string", "text"],
-            regex : "(\\[)(" +                                        // [
-                    escaped("]") +                                    // link text
+            regex : "(\\!?\\[)(" +                                        // [
+                    escaped("]") +                                    // link text or alt text
                     ")(\\]\\()"+                                      // ](
-                    '((?:[^\\)\\s\\\\]|\\\\.|\\s(?=[^"]))*)' +        // href
+                    '((?:[^\\)\\s\\\\]|\\\\.|\\s(?=[^"]))*)' +        // href or image
                     '(\\s*"' +  escaped('"') + '"\\s*)?' +            // "title"
                     "(\\))"                                           // )
         }, { // strong ** __


### PR DESCRIPTION
Image link highlighting in mode-markdown seems to not highlight the leading `!` character. In some cases this looks OK in others maybe not so much. I think it's probably better to have the entire image formatting use the same colors.

Added in explicit image link handling.

This is what it looks like before:

![image](https://user-images.githubusercontent.com/1374013/39971617-23658aa8-56b3-11e8-8b80-7a755faf81f3.png)

and here it is after the change:

![image](https://user-images.githubusercontent.com/1374013/39971619-2ab599c4-56b3-11e8-9eee-c52a4eb62194.png)

The latter seems more consistent. 

To be honest this is minor but several of my users have mentioned this ([here's one](https://github.com/RickStrahl/MarkdownMonster/issues/366)) and looking at the two renderings side by side I do think that the latter looks more consistent.

Note: Resubmitted as a new PR due a face palm on my end on the previous PR #3667. Sorry for the noise.