### PR TITLE
Added two tmthemes gruvbox dark (hard) and light (hard)

### DIFF
--- a/lib/ace/theme/gruvbox_dark_hard.css
+++ b/lib/ace/theme/gruvbox_dark_hard.css
@@ -1,0 +1,159 @@
+.ace-gruvbox-dark-hard .ace_gutter {
+  background: #1d2021;
+  color: rgb(132,126,106)
+}
+
+.ace-gruvbox-dark-hard .ace_print-margin {
+  width: 1px;
+  background: #e8e8e8
+}
+
+.ace-gruvbox-dark-hard {
+  background-color: #1d2021;
+  color: rgba(235, 219, 178, 0.50)
+}
+
+.ace-gruvbox-dark-hard .ace_cursor {
+  color: #a89984
+}
+
+.ace-gruvbox-dark-hard .ace_marker-layer .ace_selection {
+  background: #3c3836
+}
+
+.ace-gruvbox-dark-hard.ace_multiselect .ace_selection.ace_start {
+  box-shadow: 0 0 3px 0px #1d2021;
+  border-radius: 2px
+}
+
+.ace-gruvbox-dark-hard .ace_marker-layer .ace_step {
+  background: rgb(198, 219, 174)
+}
+
+.ace-gruvbox-dark-hard .ace_marker-layer .ace_bracket {
+  margin: -1px 0 0 -1px;
+  border: 1px solid rgba(235, 219, 178, 0.15)
+}
+
+.ace-gruvbox-dark-hard .ace_marker-layer .ace_active-line {
+  background: #3c3836
+}
+
+.ace-gruvbox-dark-hard .ace_gutter-active-line {
+  background-color: #3c3836
+}
+
+.ace-gruvbox-dark-hard .ace_marker-layer .ace_selected-word {
+  border: 1px solid #3c3836
+}
+
+.ace-gruvbox-dark-hard .ace_fold {
+  background-color: #b8bb26;
+  border-color: rgba(235, 219, 178, 0.50)
+}
+
+.ace-gruvbox-dark-hard .ace_keyword {
+  color: #fb4934
+}
+
+.ace-gruvbox-dark-hard .ace_keyword.ace_operator {
+  color: #8ec07c
+}
+
+.ace-gruvbox-dark-hard .ace_keyword.ace_other.ace_unit {
+  color: #b16286
+}
+
+.ace-gruvbox-dark-hard .ace_constant {
+  color: #d3869b
+}
+
+.ace-gruvbox-dark-hard .ace_constant.ace_numeric {
+  color: #d3869b
+}
+
+.ace-gruvbox-dark-hard .ace_constant.ace_character.ace_escape {
+  color: #fb4934
+}
+
+.ace-gruvbox-dark-hard .ace_constant.ace_other {
+  color: #d3869b
+}
+
+.ace-gruvbox-dark-hard .ace_support.ace_function {
+  color: #8ec07c
+}
+
+.ace-gruvbox-dark-hard .ace_support.ace_constant {
+  color: #d3869b
+}
+
+.ace-gruvbox-dark-hard .ace_support.ace_constant.ace_property-value {
+  color: #f9f5d7
+}
+
+.ace-gruvbox-dark-hard .ace_support.ace_class {
+  color: #fabd2f
+}
+
+.ace-gruvbox-dark-hard .ace_support.ace_type {
+  color: #fabd2f
+}
+
+.ace-gruvbox-dark-hard .ace_storage {
+  color: #fb4934
+}
+
+.ace-gruvbox-dark-hard .ace_invalid {
+  color: #f9f5d7;
+  background-color: #fb4934
+}
+
+.ace-gruvbox-dark-hard .ace_string {
+  color: #b8bb26
+}
+
+.ace-gruvbox-dark-hard .ace_string.ace_regexp {
+  color: #b8bb26
+}
+
+.ace-gruvbox-dark-hard .ace_comment {
+  font-style: italic;
+  color: #928374
+}
+
+.ace-gruvbox-dark-hard .ace_variable {
+  color: #83a598
+}
+
+.ace-gruvbox-dark-hard .ace_variable.ace_language {
+  color: #d3869b
+}
+
+.ace-gruvbox-dark-hard .ace_variable.ace_parameter {
+  color: #f9f5d7
+}
+
+.ace-gruvbox-dark-hard .ace_meta.ace_tag {
+  color: #f9f5d7
+}
+
+.ace-gruvbox-dark-hard .ace_entity.ace_other.ace_attribute-name {
+  color: #fabd2f
+}
+
+.ace-gruvbox-dark-hard .ace_entity.ace_name.ace_function {
+  color: #b8bb26
+}
+
+.ace-gruvbox-dark-hard .ace_entity.ace_name.ace_tag {
+  color: #83a598
+}
+
+.ace-gruvbox-dark-hard .ace_markup.ace_heading {
+  color: #b8bb26
+}
+
+.ace-gruvbox-dark-hard .ace_markup.ace_list {
+  color: #83a598
+}

--- a/lib/ace/theme/gruvbox_dark_hard.js
+++ b/lib/ace/theme/gruvbox_dark_hard.js
@@ -1,0 +1,39 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+define(function(require, exports, module) {
+
+exports.isDark = true;
+exports.cssClass = "ace-gruvbox-dark-hard";
+exports.cssText = require("../requirejs/text!./gruvbox_dark_hard.css");
+
+var dom = require("../lib/dom");
+dom.importCssString(exports.cssText, exports.cssClass);
+});

--- a/lib/ace/theme/gruvbox_light_hard.css
+++ b/lib/ace/theme/gruvbox_light_hard.css
@@ -1,0 +1,159 @@
+.ace-gruvbox-light-hard .ace_gutter {
+  background: #f9f5d7;
+  color: rgb(155,151,135)
+}
+
+.ace-gruvbox-light-hard .ace_print-margin {
+  width: 1px;
+  background: #e8e8e8
+}
+
+.ace-gruvbox-light-hard {
+  background-color: #f9f5d7;
+  color: rgba(60, 56, 54, 0.50)
+}
+
+.ace-gruvbox-light-hard .ace_cursor {
+  color: #7c6f64
+}
+
+.ace-gruvbox-light-hard .ace_marker-layer .ace_selection {
+  background: #ebdbb2
+}
+
+.ace-gruvbox-light-hard.ace_multiselect .ace_selection.ace_start {
+  box-shadow: 0 0 3px 0px #f9f5d7;
+  border-radius: 2px
+}
+
+.ace-gruvbox-light-hard .ace_marker-layer .ace_step {
+  background: rgb(198, 219, 174)
+}
+
+.ace-gruvbox-light-hard .ace_marker-layer .ace_bracket {
+  margin: -1px 0 0 -1px;
+  border: 1px solid rgba(60, 56, 54, 0.15)
+}
+
+.ace-gruvbox-light-hard .ace_marker-layer .ace_active-line {
+  background: #ebdbb2
+}
+
+.ace-gruvbox-light-hard .ace_gutter-active-line {
+  background-color: #ebdbb2
+}
+
+.ace-gruvbox-light-hard .ace_marker-layer .ace_selected-word {
+  border: 1px solid #ebdbb2
+}
+
+.ace-gruvbox-light-hard .ace_fold {
+  background-color: #79740e;
+  border-color: rgba(60, 56, 54, 0.50)
+}
+
+.ace-gruvbox-light-hard .ace_keyword {
+  color: #9d0006
+}
+
+.ace-gruvbox-light-hard .ace_keyword.ace_operator {
+  color: #427b58
+}
+
+.ace-gruvbox-light-hard .ace_keyword.ace_other.ace_unit {
+  color: #b16286
+}
+
+.ace-gruvbox-light-hard .ace_constant {
+  color: #8f3f71
+}
+
+.ace-gruvbox-light-hard .ace_constant.ace_numeric {
+  color: #8f3f71
+}
+
+.ace-gruvbox-light-hard .ace_constant.ace_character.ace_escape {
+  color: #9d0006
+}
+
+.ace-gruvbox-light-hard .ace_constant.ace_other {
+  color: #8f3f71
+}
+
+.ace-gruvbox-light-hard .ace_support.ace_function {
+  color: #427b58
+}
+
+.ace-gruvbox-light-hard .ace_support.ace_constant {
+  color: #8f3f71
+}
+
+.ace-gruvbox-light-hard .ace_support.ace_constant.ace_property-value {
+  color: #1d2021
+}
+
+.ace-gruvbox-light-hard .ace_support.ace_class {
+  color: #b57614
+}
+
+.ace-gruvbox-light-hard .ace_support.ace_type {
+  color: #b57614
+}
+
+.ace-gruvbox-light-hard .ace_storage {
+  color: #9d0006
+}
+
+.ace-gruvbox-light-hard .ace_invalid {
+  color: #1d2021;
+  background-color: #9d0006
+}
+
+.ace-gruvbox-light-hard .ace_string {
+  color: #79740e
+}
+
+.ace-gruvbox-light-hard .ace_string.ace_regexp {
+  color: #79740e
+}
+
+.ace-gruvbox-light-hard .ace_comment {
+  font-style: italic;
+  color: #928374
+}
+
+.ace-gruvbox-light-hard .ace_variable {
+  color: #076678
+}
+
+.ace-gruvbox-light-hard .ace_variable.ace_language {
+  color: #8f3f71
+}
+
+.ace-gruvbox-light-hard .ace_variable.ace_parameter {
+  color: #1d2021
+}
+
+.ace-gruvbox-light-hard .ace_meta.ace_tag {
+  color: #1d2021
+}
+
+.ace-gruvbox-light-hard .ace_entity.ace_other.ace_attribute-name {
+  color: #b57614
+}
+
+.ace-gruvbox-light-hard .ace_entity.ace_name.ace_function {
+  color: #79740e
+}
+
+.ace-gruvbox-light-hard .ace_entity.ace_name.ace_tag {
+  color: #076678
+}
+
+.ace-gruvbox-light-hard .ace_markup.ace_heading {
+  color: #79740e
+}
+
+.ace-gruvbox-light-hard .ace_markup.ace_list {
+  color: #076678
+}

--- a/lib/ace/theme/gruvbox_light_hard.js
+++ b/lib/ace/theme/gruvbox_light_hard.js
@@ -1,0 +1,39 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+define(function(require, exports, module) {
+
+exports.isDark = false;
+exports.cssClass = "ace-gruvbox-light-hard";
+exports.cssText = require("../requirejs/text!./gruvbox_light_hard.css");
+
+var dom = require("../lib/dom");
+dom.importCssString(exports.cssText, exports.cssClass);
+});

--- a/tool/tmtheme.js
+++ b/tool/tmtheme.js
@@ -288,6 +288,8 @@ var themes = {
     "solarized_light": "Solarized-light",
     "katzenmilch": "Katzenmilch",
     "kuroir": "Kuroir Theme",
+    "gruvbox_dark_hard": "gruvboxDarkHard",
+    "gruvbox_light_hard": "gruvboxLightHard",
     //"textmate": "Textmate (Mac Classic)",
     "tomorrow": "Tomorrow",
     "tomorrow_night": "Tomorrow-Night",

--- a/tool/tmthemes/gruvboxDarkHard.tmTheme
+++ b/tool/tmthemes/gruvboxDarkHard.tmTheme
@@ -1,0 +1,1509 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>comment</key>
+    <string>Based on gruvbox for Vim (https://github.com/morhetz/gruvbox)</string>
+    <key>originalAuthor</key>
+    <string>Pavel Pertsev (https://github.com/morhetz)</string>
+    <key>author</key>
+    <string>Brian Reilly (https://github.com/Briles/gruvbox)</string>
+    <key>name</key>
+    <string>gruvbox (Dark) (Hard)</string>
+    <key>colorSpaceName</key>
+    <string>sRGB</string>
+    <key>settings</key>
+    <array>
+      <dict>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#1d2021</string>
+          <key>caret</key>
+          <string>#a89984</string>
+          <key>foreground</key>
+          <string>#ebdbb280</string>
+          <key>invisibles</key>
+          <string>#ebdbb226</string>
+          <key>lineHighlight</key>
+          <string>#3c3836</string>
+          <key>selection</key>
+          <string>#3c3836</string>
+          <key>inactiveSelection</key>
+          <string>#3c3836</string>
+          <key>guide</key>
+          <string>#ebdbb226</string>
+          <key>activeGuide</key>
+          <string>#ebdbb280</string>
+          <key>stackGuide</key>
+          <string>#ebdbb240</string>
+          <key>bracketContentsOptions</key>
+          <string>underline</string>
+          <key>bracketContentsForeground</key>
+          <string>#bdae93</string>
+          <key>bracketsOptions</key>
+          <string>underline</string>
+          <key>bracketsForeground</key>
+          <string>#bdae93</string>
+          <key>gutterForeground</key>
+          <string>#928374</string>
+          <key>highlight</key>
+          <string>#f9f5d7</string>
+          <key>highlightForeground</key>
+          <string>#f9f5d7</string>
+          <key>findHighlight</key>
+          <string>#d79921</string>
+          <key>findHighlightForeground</key>
+          <string>#1d2021</string>
+          <key>tagsOptions</key>
+          <string>underline</string>
+          <key>selectionBorder</key>
+          <string>#3c3836</string>
+          <key>popupCss</key>
+          <string>
+            html {
+              background-color: #111313;
+              color: #f9f5d7;
+              padding: 12px;
+            }
+
+            a {
+              color: #8ec07c;
+            }
+
+            .error, .deleted {
+              color: #fb4934;
+            }
+
+            .success, .inserted, .name {
+              color: #b8bb26;
+            }
+
+            .warning, .modified {
+              color: #fabd2f;
+            }
+
+            .type {
+              color: #fabd2f;
+              font-style: italic;
+            }
+
+            .param {
+              color: #f9f5d7;
+            }
+
+            .current {
+              text-decoration: underline;
+            }
+          </string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Text and Source Base Colors</string>
+        <key>scope</key>
+        <string>meta.group, meta.method-call.source.cs, meta.method.attribute.source.cs, meta.method.body.java, meta.method.body.source.cs, meta.method.source.cs, none, source, text</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Punctuation</string>
+        <key>scope</key>
+        <string>entity.quasi.element meta.group.braces, keyword.operator keyword.operator.neon, keyword.operator operator.neon, keyword.operator.accessor, keyword.other.accessor, meta.attribute-selector keyword.operator.stylus, meta.brace, meta.delimiter, meta.group.braces, meta.punctuation.separator, meta.separator, punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Comments</string>
+        <key>scope</key>
+        <string>comment, comment text, markup.strikethrough, punctuation.definition.comment, punctuation.whitespace.comment, string.comment, text.cancelled</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>italic</string>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Keywords Inside Comments</string>
+        <key>scope</key>
+        <string>comment.keyword, comment.keyword.punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d5c4a1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>DocBlockr &amp; Other Keywords Inside Comments</string>
+        <key>scope</key>
+        <string>comment.parameter, comment.punctuation, comment.string, comment.type, keyword.other.phpdoc.php, punctuation.definition.keyword.javadoc, source.groovy keyword.other.documentation, source.java keyword.other.documentation, storage.type.annotation.coffeescript, storage.type.class.jsdoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Entity</string>
+        <key>scope</key>
+        <string>constant.language.name, entity.name.type, entity.other.inherited-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Template String Punctuation</string>
+        <key>scope</key>
+        <string>constant.other.placeholder, entity.name.tag.mustache, entity.tag.tagbraces, punctuation.definition.string.template, punctuation.definition.template-expression, punctuation.quasi, punctuation.section.embedded, string.interpolated, variable.other.interpolation.scss</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Keywords</string>
+        <key>scope</key>
+        <string>js.embedded.control.flow keyword.operator.js, keyword, keyword.control, keyword.operator.logical.python, meta.at-rule.media support.function.misc, meta.prolog.haml, meta.tag.sgml.doctype.html, storage.type.function.jade, storage.type.function.pug, storage.type.import.haxe, storage.type.import.include.jade, storage.type.import.include.pug, support.keyword.timing-direction, variable.documentroot</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS At-Rule Punctuation (@) &amp; At-Rule Vendor Prefixes</string>
+        <key>scope</key>
+        <string>keyword.control.at-rule support.type.property-vendor, punctuation.definition.keyword</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cc241d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Operators</string>
+        <key>scope</key>
+        <string>keyword.control.new, keyword.control.operator, keyword.operator, keyword.other.arrow, keyword.other.double-colon, punctuation.operator</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Constants Punctuation</string>
+        <key>scope</key>
+        <string>constant.other.color punctuation.definition.constant, constant.other.symbol punctuation.definition.constant, constant.other.unit, keyword.other.unit, punctuation.section.flowtype, support.constant.unicode-range.prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Storage</string>
+        <key>scope</key>
+        <string>storage, storage.type.annotation, storage.type.primitive</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>storage.modifier.import, storage.modifier.package, storage.type.import, variable.import, variable.package</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Function Keyword</string>
+        <key>scope</key>
+        <string>entity.quasi.tag.name, meta.function storage.type.matlab, storage.type.function</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Variables</string>
+        <key>scope</key>
+        <string>entity.name.val.declaration, entity.name.variable, meta.definition.variable, storage.type.variable, support.type.custom-property, support.type.variable-name, variable, variable.interpolation variable, variable.other.interpolation variable, variable.parameter.dosbatch, variable.parameter.output.function.matlab, variable.parameter.sass</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Variable - Punctuation</string>
+        <key>scope</key>
+        <string>keyword.other.custom-property.prefix, punctuation.definition.custom-property, punctuation.definition.variable, support.constant.custom-property-name.prefix, variable.interpolation, variable.other.dollar punctuation.dollar, variable.other.object.dollar punctuation.dollar</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#458588</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Function Declaration - Punctuation</string>
+        <key>scope</key>
+        <string>entity.name.function punctuation.dollar</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#98971a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Object Properties</string>
+        <key>scope</key>
+        <string>meta.property.object</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Object Literal Properties</string>
+        <key>scope</key>
+        <string>constant.other.object.key string, meta.object-literal.key</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Parameters</string>
+        <key>scope</key>
+        <string>meta.parameters, variable.parameter</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>SASS Import URL</string>
+        <key>scope</key>
+        <string>variable.parameter.url</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Language Constants</string>
+        <key>scope</key>
+        <string>constant, constant.numeric, constant.other, constant.other.color, constant.other.symbol, support.constant, support.constant.color, support.constant.font-name, support.constant.media, support.constant.prototype, variable.language</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d3869b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Language Constants Punctuation</string>
+        <key>scope</key>
+        <string>variable.language punctuation.definition.variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>User-Defined Constants</string>
+        <key>scope</key>
+        <string>entity.name.constant, variable.other.constant</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Escaped Characters</string>
+        <key>scope</key>
+        <string>constant.character.escape, constant.character.escaped, constant.character.quoted, constant.other.character-class.escape</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Invalids and Illegals</string>
+        <key>scope</key>
+        <string>invalid</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+          <key>background</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Inner Scopes of Invalids and Illegals</string>
+        <key>scope</key>
+        <string>invalid keyword.other.custom-property.prefix, invalid support.type.custom-property.name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Errors</string>
+        <key>scope</key>
+        <string>message.error</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Strings</string>
+        <key>scope</key>
+        <string>meta.object-literal.key string, string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON Keys</string>
+        <key>scope</key>
+        <string>meta.structure.dictionary.key.json string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Text</string>
+        <key>scope</key>
+        <string>source.regexp, string.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Start &amp; End Punctuation</string>
+        <key>scope</key>
+        <string>string.regexp punctuation.definition.string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Character Class Punctuation ([])</string>
+        <key>scope</key>
+        <string>keyword.control.set.regexp, punctuation.definition.character-class, string.regexp.character-class.ruby</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d3869b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Capturing Group</string>
+        <key>scope</key>
+        <string>string.regexp.group</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Assertions</string>
+        <key>scope</key>
+        <string>constant.other.assertion.regexp, punctuation.definition.group.assertion.regexp, punctuation.definition.group.capture.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Character Class</string>
+        <key>scope</key>
+        <string>constant.other.character-class.escape.backslash.regexp, keyword.control.character-class.regexp, string.regexp.character-class constant.character.escape</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Quantifiers &amp; Operators</string>
+        <key>scope</key>
+        <string>string.regexp.arbitrary-repetition, string.regexp.arbitrary-repetition punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Hyperlinks</string>
+        <key>scope</key>
+        <string>constant.other.reference.link, string.other.link</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Hyperlink Punctuation</string>
+        <key>scope</key>
+        <string>meta.image.inline punctuation.definition.string, meta.link.inline punctuation.definition.string, meta.link.reference punctuation.definition.constant, meta.link.reference.literal punctuation.definition.constant, meta.link.reference.literal punctuation.definition.string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#689d6a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup Tag Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Heading</string>
+        <key>scope</key>
+        <string>markup.heading</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Heading Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.heading, punctuation.definition.identity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#98971a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Bold Text</string>
+        <key>scope</key>
+        <string>markup.bold</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe8019</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Bold Text Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.bold</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d65d0e</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Italic Text</string>
+        <key>scope</key>
+        <string>markup.italic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Italic Text Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.italic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cc241d</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Inline Code</string>
+        <key>scope</key>
+        <string>markup.raw.inline</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Inline Code Punctuation</string>
+        <key>scope</key>
+        <string>markup.raw.inline punctuation.definition.raw</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Quoted</string>
+        <key>scope</key>
+        <string>markup.quote</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d3869b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Quoted Punctuation</string>
+        <key>scope</key>
+        <string>markup.quote punctuation.definition.blockquote</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown List</string>
+        <key>scope</key>
+        <string>markup.list</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown List Punctuation</string>
+        <key>scope</key>
+        <string>markup.list punctuation.definition.list_item</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#458588</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Separators</string>
+        <key>scope</key>
+        <string>meta.separator.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Support</string>
+        <key>scope</key>
+        <string>meta.function-call.constructor variable.type, support.class, support.type, variable.other.class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Supporting Type - Dollar Punctuation</string>
+        <key>scope</key>
+        <string>support.class punctuation.dollar</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Function Calls</string>
+        <key>scope</key>
+        <string>entity.name.function.jade, entity.name.function.pug, keyword.other.special-method, meta.function-call variable.function, meta.function-call variable.other.dollar.only punctuation.dollar, support.function</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Method Calls</string>
+        <key>scope</key>
+        <string>meta.function-call.method support.function, meta.function-call.method variable.function, meta.function-call.static variable.function, meta.method-call, meta.method-call support.function, meta.method-call variable.function, support.function.mutator</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#689d6a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Special Variables</string>
+        <key>scope</key>
+        <string>support.module</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d3869b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Entities</string>
+        <key>scope</key>
+        <string>entity.name.accessor, entity.name.function, entity.name.label, entity.name.section</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Modules</string>
+        <key>scope</key>
+        <string>entity.name.module</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe8019</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; CSS ID</string>
+        <key>scope</key>
+        <string>constant.id.tag, entity.name.tag.id, entity.other.attribute-name.id</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe8019</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; CSS ID Punctuation (#)</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name.id punctuation.definition.entity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d65d0e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; CSS Class</string>
+        <key>scope</key>
+        <string>entity.name.tag.class, entity.other.attribute-name.class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; CSS Class Punctuation (.)</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name.class punctuation.definition.entity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Attribute Selector Attribute Name</string>
+        <key>scope</key>
+        <string>meta.attribute-selector entity.other.attribute-name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; XML Entity Punctuation</string>
+        <key>scope</key>
+        <string>constant.character.entity punctuation.definition.constant, constant.character.entity punctuation.definition.entity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.class, entity.name.type.class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup Tag</string>
+        <key>scope</key>
+        <string>entity.name.function.neon, entity.name.namespace.wildcard, entity.name.tag, entity.tag, keyword.control.untitled, keyword.doctype.xml, keyword.operator support.other.neon, punctuation.definition.prolog.haml, source.less keyword.control.html.elements</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML Attribute Names</string>
+        <key>scope</key>
+        <string>entity.name.attribute-name, entity.other.attribute-name, meta.section.attributes.haml constant.other.symbol.ruby</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Pseudo Elements/Classes &amp; Vendor Prefixes</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name.placeholder punctuation.definition.entity, entity.other.attribute-name.pseudo-class, entity.other.attribute-name.pseudo-element, entity.other.attribute-name.tag.pseudo-class, entity.other.attribute-name.tag.pseudo-element, entity.other.pseudo-class, entity.other.pseudo-element, support.type.vendor-prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Animations / Keyframes</string>
+        <key>scope</key>
+        <string>entity.function-name.stylus, entity.other.animation-keyframe.stylus, entity.other.animation-name, keyword.language.function.misc.stylus, meta.at-rule.keyframes entity.name.function, variable.other.animation-name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Author-Defined Names</string>
+        <key>scope</key>
+        <string>entity.other.namespace-prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>meta.class.body, meta.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Image &amp; Hyperlink</string>
+        <key>scope</key>
+        <string>meta.image, meta.link</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d3869b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Image &amp; Hyperlink Punctuation</string>
+        <key>scope</key>
+        <string>meta.image punctuation.definition.metadata, meta.link punctuation.definition.metadata</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>meta.require</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Function Call Braces</string>
+        <key>scope</key>
+        <string>constant.name.attribute.tag.jade, constant.name.attribute.tag.pug, meta.brace.round, meta.function-call meta.group punctuation.definition.group, punctuation.definition.method-parameters, punctuation.definition.parameters</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Property Names</string>
+        <key>scope</key>
+        <string>meta.property-name, support.type.property-name, support.type.shape.definition support.constant.property-value</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Property Name Vendor Prefixes</string>
+        <key>scope</key>
+        <string>meta.property-name support.type.vendor-prefix, support.type.property-name.media support.type.vendor-prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#98971a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Property Values</string>
+        <key>scope</key>
+        <string>constant.string.sass, meta.property-value, support.constant.property-value</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Property Value Vendor Prefixes</string>
+        <key>scope</key>
+        <string>meta.property-value support.type.vendor-prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Foreground Text</string>
+        <key>scope</key>
+        <string>source.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a89984</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Header Text From</string>
+        <key>scope</key>
+        <string>meta.diff.header.from-file</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Header Text From Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.from-file</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#458588</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Header Text To</string>
+        <key>scope</key>
+        <string>meta.diff.header.to-file</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d3869b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Header Text To Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.to-file</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Additions &amp; Deletions Stats</string>
+        <key>scope</key>
+        <string>meta.diff.range, meta.toc-list.line-number</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Additions &amp; Deletions Stats Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.range.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>FiF Line Number</string>
+        <key>scope</key>
+        <string>constant.numeric.line-number</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>FiF Line Number Matched</string>
+        <key>scope</key>
+        <string>constant.numeric.line-number.match</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>FiF Filename</string>
+        <key>scope</key>
+        <string>entity.name.filename</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter &amp; Diff Deleted</string>
+        <key>scope</key>
+        <string>markup.deleted, punctuation.definition.deleted</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter &amp; Diff Inserted</string>
+        <key>scope</key>
+        <string>markup.inserted, punctuation.definition.inserted</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter &amp; Diff Changed</string>
+        <key>scope</key>
+        <string>markup.changed, punctuation.definition.changed</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter ignored</string>
+        <key>scope</key>
+        <string>markup.ignored</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter untracked</string>
+        <key>scope</key>
+        <string>markup.untracked</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Tag</string>
+        <key>scope</key>
+        <string>brackethighlighter.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Curly</string>
+        <key>scope</key>
+        <string>brackethighlighter.curly</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Round</string>
+        <key>scope</key>
+        <string>brackethighlighter.round</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Square</string>
+        <key>scope</key>
+        <string>brackethighlighter.square</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Angle</string>
+        <key>scope</key>
+        <string>brackethighlighter.angle</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Quote</string>
+        <key>scope</key>
+        <string>brackethighlighter.quote</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Unmatched</string>
+        <key>scope</key>
+        <string>brackethighlighter.unmatched</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>SublimeLinter Error</string>
+        <key>scope</key>
+        <string>sublimelinter.mark.error</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>SublimeLinter Gutter Mark</string>
+        <key>scope</key>
+        <string>sublimelinter.gutter-mark</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>SublimeLinter Warning</string>
+        <key>scope</key>
+        <string>sublimelinter.mark.warning</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HexViewer Upper Byte Nibble</string>
+        <key>scope</key>
+        <string>raw.nibble.upper</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HexViewer Lower Byte Nibble</string>
+        <key>scope</key>
+        <string>raw.nibble.lower</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HexViewer Highlight</string>
+        <key>scope</key>
+        <string>hexviewer.highlight</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+          <key>background</key>
+          <string>#fabd2f</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HexViewer Edited Highlight</string>
+        <key>scope</key>
+        <string>hexviewer.highlight.edited</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+          <key>background</key>
+          <string>#fe8019</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Raw New Line: Carriage Return</string>
+        <key>scope</key>
+        <string>glyph.carriage-return</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ebdbb226</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Raw New Line: New Line Glyph</string>
+        <key>scope</key>
+        <string>glyph.new-line</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ebdbb226</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Header</string>
+        <key>scope</key>
+        <string>keyword.control.header.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b8bb26</string>
+          <key>background</key>
+          <string>#2e3234</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Notes</string>
+        <key>scope</key>
+        <string>notes.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#bdae93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Punctuation</string>
+        <key>scope</key>
+        <string>text.todo punctuation.definition.bold, text.todo punctuation.definition.italic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7c6f64</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Task Pending</string>
+        <key>scope</key>
+        <string>meta.item.todo.pending</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Task Pending Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.bullet.pending.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Task Completed Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.bullet.completed.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8ec07c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Task Cancelled Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.bullet.cancelled.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag Critical</string>
+        <key>scope</key>
+        <string>string.other.tag.todo.critical</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fb4934</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag High</string>
+        <key>scope</key>
+        <string>string.other.tag.todo.high</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe8019</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag Low</string>
+        <key>scope</key>
+        <string>string.other.tag.todo.low</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag Today</string>
+        <key>scope</key>
+        <string>string.other.tag.todo.today</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fabd2f</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag</string>
+        <key>scope</key>
+        <string>meta.tag.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d3869b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: URL</string>
+        <key>scope</key>
+        <string>punctuation.definition.url, todo.url</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#83a598</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Separator</string>
+        <key>scope</key>
+        <string>meta.punctuation.archive.todo, meta.punctuation.separator.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>italic</string>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/tool/tmthemes/gruvboxLightHard.tmTheme
+++ b/tool/tmthemes/gruvboxLightHard.tmTheme
@@ -1,0 +1,1509 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>comment</key>
+    <string>Based on gruvbox for Vim (https://github.com/morhetz/gruvbox)</string>
+    <key>originalAuthor</key>
+    <string>Pavel Pertsev (https://github.com/morhetz)</string>
+    <key>author</key>
+    <string>Brian Reilly (https://github.com/Briles/gruvbox)</string>
+    <key>name</key>
+    <string>gruvbox (Light) (Hard)</string>
+    <key>colorSpaceName</key>
+    <string>sRGB</string>
+    <key>settings</key>
+    <array>
+      <dict>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#f9f5d7</string>
+          <key>caret</key>
+          <string>#7c6f64</string>
+          <key>foreground</key>
+          <string>#3c383680</string>
+          <key>invisibles</key>
+          <string>#3c383626</string>
+          <key>lineHighlight</key>
+          <string>#ebdbb2</string>
+          <key>selection</key>
+          <string>#ebdbb2</string>
+          <key>inactiveSelection</key>
+          <string>#ebdbb2</string>
+          <key>guide</key>
+          <string>#3c383626</string>
+          <key>activeGuide</key>
+          <string>#3c383680</string>
+          <key>stackGuide</key>
+          <string>#3c383640</string>
+          <key>bracketContentsOptions</key>
+          <string>underline</string>
+          <key>bracketContentsForeground</key>
+          <string>#665c54</string>
+          <key>bracketsOptions</key>
+          <string>underline</string>
+          <key>bracketsForeground</key>
+          <string>#665c54</string>
+          <key>gutterForeground</key>
+          <string>#928374</string>
+          <key>highlight</key>
+          <string>#1d2021</string>
+          <key>highlightForeground</key>
+          <string>#1d2021</string>
+          <key>findHighlight</key>
+          <string>#d79921</string>
+          <key>findHighlightForeground</key>
+          <string>#f9f5d7</string>
+          <key>tagsOptions</key>
+          <string>underline</string>
+          <key>selectionBorder</key>
+          <string>#ebdbb2</string>
+          <key>popupCss</key>
+          <string>
+            html {
+              background-color: #f6efc1;
+              color: #1d2021;
+              padding: 12px;
+            }
+
+            a {
+              color: #427b58;
+            }
+
+            .error, .deleted {
+              color: #9d0006;
+            }
+
+            .success, .inserted, .name {
+              color: #79740e;
+            }
+
+            .warning, .modified {
+              color: #b57614;
+            }
+
+            .type {
+              color: #b57614;
+              font-style: italic;
+            }
+
+            .param {
+              color: #1d2021;
+            }
+
+            .current {
+              text-decoration: underline;
+            }
+          </string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Text and Source Base Colors</string>
+        <key>scope</key>
+        <string>meta.group, meta.method-call.source.cs, meta.method.attribute.source.cs, meta.method.body.java, meta.method.body.source.cs, meta.method.source.cs, none, source, text</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Punctuation</string>
+        <key>scope</key>
+        <string>entity.quasi.element meta.group.braces, keyword.operator keyword.operator.neon, keyword.operator operator.neon, keyword.operator.accessor, keyword.other.accessor, meta.attribute-selector keyword.operator.stylus, meta.brace, meta.delimiter, meta.group.braces, meta.punctuation.separator, meta.separator, punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Comments</string>
+        <key>scope</key>
+        <string>comment, comment text, markup.strikethrough, punctuation.definition.comment, punctuation.whitespace.comment, string.comment, text.cancelled</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>italic</string>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Keywords Inside Comments</string>
+        <key>scope</key>
+        <string>comment.keyword, comment.keyword.punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#504945</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>DocBlockr &amp; Other Keywords Inside Comments</string>
+        <key>scope</key>
+        <string>comment.parameter, comment.punctuation, comment.string, comment.type, keyword.other.phpdoc.php, punctuation.definition.keyword.javadoc, source.groovy keyword.other.documentation, source.java keyword.other.documentation, storage.type.annotation.coffeescript, storage.type.class.jsdoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Entity</string>
+        <key>scope</key>
+        <string>constant.language.name, entity.name.type, entity.other.inherited-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Template String Punctuation</string>
+        <key>scope</key>
+        <string>constant.other.placeholder, entity.name.tag.mustache, entity.tag.tagbraces, punctuation.definition.string.template, punctuation.definition.template-expression, punctuation.quasi, punctuation.section.embedded, string.interpolated, variable.other.interpolation.scss</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Keywords</string>
+        <key>scope</key>
+        <string>js.embedded.control.flow keyword.operator.js, keyword, keyword.control, keyword.operator.logical.python, meta.at-rule.media support.function.misc, meta.prolog.haml, meta.tag.sgml.doctype.html, storage.type.function.jade, storage.type.function.pug, storage.type.import.haxe, storage.type.import.include.jade, storage.type.import.include.pug, support.keyword.timing-direction, variable.documentroot</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS At-Rule Punctuation (@) &amp; At-Rule Vendor Prefixes</string>
+        <key>scope</key>
+        <string>keyword.control.at-rule support.type.property-vendor, punctuation.definition.keyword</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cc241d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Operators</string>
+        <key>scope</key>
+        <string>keyword.control.new, keyword.control.operator, keyword.operator, keyword.other.arrow, keyword.other.double-colon, punctuation.operator</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Constants Punctuation</string>
+        <key>scope</key>
+        <string>constant.other.color punctuation.definition.constant, constant.other.symbol punctuation.definition.constant, constant.other.unit, keyword.other.unit, punctuation.section.flowtype, support.constant.unicode-range.prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Storage</string>
+        <key>scope</key>
+        <string>storage, storage.type.annotation, storage.type.primitive</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>storage.modifier.import, storage.modifier.package, storage.type.import, variable.import, variable.package</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Function Keyword</string>
+        <key>scope</key>
+        <string>entity.quasi.tag.name, meta.function storage.type.matlab, storage.type.function</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Variables</string>
+        <key>scope</key>
+        <string>entity.name.val.declaration, entity.name.variable, meta.definition.variable, storage.type.variable, support.type.custom-property, support.type.variable-name, variable, variable.interpolation variable, variable.other.interpolation variable, variable.parameter.dosbatch, variable.parameter.output.function.matlab, variable.parameter.sass</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Variable - Punctuation</string>
+        <key>scope</key>
+        <string>keyword.other.custom-property.prefix, punctuation.definition.custom-property, punctuation.definition.variable, support.constant.custom-property-name.prefix, variable.interpolation, variable.other.dollar punctuation.dollar, variable.other.object.dollar punctuation.dollar</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#458588</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Function Declaration - Punctuation</string>
+        <key>scope</key>
+        <string>entity.name.function punctuation.dollar</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#98971a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Object Properties</string>
+        <key>scope</key>
+        <string>meta.property.object</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Object Literal Properties</string>
+        <key>scope</key>
+        <string>constant.other.object.key string, meta.object-literal.key</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Parameters</string>
+        <key>scope</key>
+        <string>meta.parameters, variable.parameter</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>SASS Import URL</string>
+        <key>scope</key>
+        <string>variable.parameter.url</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Language Constants</string>
+        <key>scope</key>
+        <string>constant, constant.numeric, constant.other, constant.other.color, constant.other.symbol, support.constant, support.constant.color, support.constant.font-name, support.constant.media, support.constant.prototype, variable.language</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8f3f71</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Language Constants Punctuation</string>
+        <key>scope</key>
+        <string>variable.language punctuation.definition.variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>User-Defined Constants</string>
+        <key>scope</key>
+        <string>entity.name.constant, variable.other.constant</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Escaped Characters</string>
+        <key>scope</key>
+        <string>constant.character.escape, constant.character.escaped, constant.character.quoted, constant.other.character-class.escape</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Invalids and Illegals</string>
+        <key>scope</key>
+        <string>invalid</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+          <key>background</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Inner Scopes of Invalids and Illegals</string>
+        <key>scope</key>
+        <string>invalid keyword.other.custom-property.prefix, invalid support.type.custom-property.name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Errors</string>
+        <key>scope</key>
+        <string>message.error</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Strings</string>
+        <key>scope</key>
+        <string>meta.object-literal.key string, string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON Keys</string>
+        <key>scope</key>
+        <string>meta.structure.dictionary.key.json string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Text</string>
+        <key>scope</key>
+        <string>source.regexp, string.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Start &amp; End Punctuation</string>
+        <key>scope</key>
+        <string>string.regexp punctuation.definition.string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Character Class Punctuation ([])</string>
+        <key>scope</key>
+        <string>keyword.control.set.regexp, punctuation.definition.character-class, string.regexp.character-class.ruby</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8f3f71</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Capturing Group</string>
+        <key>scope</key>
+        <string>string.regexp.group</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Assertions</string>
+        <key>scope</key>
+        <string>constant.other.assertion.regexp, punctuation.definition.group.assertion.regexp, punctuation.definition.group.capture.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Character Class</string>
+        <key>scope</key>
+        <string>constant.other.character-class.escape.backslash.regexp, keyword.control.character-class.regexp, string.regexp.character-class constant.character.escape</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regular Expressions Quantifiers &amp; Operators</string>
+        <key>scope</key>
+        <string>string.regexp.arbitrary-repetition, string.regexp.arbitrary-repetition punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Hyperlinks</string>
+        <key>scope</key>
+        <string>constant.other.reference.link, string.other.link</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Hyperlink Punctuation</string>
+        <key>scope</key>
+        <string>meta.image.inline punctuation.definition.string, meta.link.inline punctuation.definition.string, meta.link.reference punctuation.definition.constant, meta.link.reference.literal punctuation.definition.constant, meta.link.reference.literal punctuation.definition.string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#689d6a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup Tag Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Heading</string>
+        <key>scope</key>
+        <string>markup.heading</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Heading Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.heading, punctuation.definition.identity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#98971a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Bold Text</string>
+        <key>scope</key>
+        <string>markup.bold</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#af3a03</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Bold Text Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.bold</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d65d0e</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Italic Text</string>
+        <key>scope</key>
+        <string>markup.italic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Italic Text Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.italic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cc241d</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Inline Code</string>
+        <key>scope</key>
+        <string>markup.raw.inline</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Inline Code Punctuation</string>
+        <key>scope</key>
+        <string>markup.raw.inline punctuation.definition.raw</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Quoted</string>
+        <key>scope</key>
+        <string>markup.quote</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8f3f71</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Quoted Punctuation</string>
+        <key>scope</key>
+        <string>markup.quote punctuation.definition.blockquote</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown List</string>
+        <key>scope</key>
+        <string>markup.list</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown List Punctuation</string>
+        <key>scope</key>
+        <string>markup.list punctuation.definition.list_item</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#458588</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Separators</string>
+        <key>scope</key>
+        <string>meta.separator.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Support</string>
+        <key>scope</key>
+        <string>meta.function-call.constructor variable.type, support.class, support.type, variable.other.class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Supporting Type - Dollar Punctuation</string>
+        <key>scope</key>
+        <string>support.class punctuation.dollar</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Function Calls</string>
+        <key>scope</key>
+        <string>entity.name.function.jade, entity.name.function.pug, keyword.other.special-method, meta.function-call variable.function, meta.function-call variable.other.dollar.only punctuation.dollar, support.function</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Method Calls</string>
+        <key>scope</key>
+        <string>meta.function-call.method support.function, meta.function-call.method variable.function, meta.function-call.static variable.function, meta.method-call, meta.method-call support.function, meta.method-call variable.function, support.function.mutator</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#689d6a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Special Variables</string>
+        <key>scope</key>
+        <string>support.module</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8f3f71</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Entities</string>
+        <key>scope</key>
+        <string>entity.name.accessor, entity.name.function, entity.name.label, entity.name.section</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Modules</string>
+        <key>scope</key>
+        <string>entity.name.module</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#af3a03</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; CSS ID</string>
+        <key>scope</key>
+        <string>constant.id.tag, entity.name.tag.id, entity.other.attribute-name.id</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#af3a03</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; CSS ID Punctuation (#)</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name.id punctuation.definition.entity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d65d0e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; CSS Class</string>
+        <key>scope</key>
+        <string>entity.name.tag.class, entity.other.attribute-name.class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; CSS Class Punctuation (.)</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name.class punctuation.definition.entity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Attribute Selector Attribute Name</string>
+        <key>scope</key>
+        <string>meta.attribute-selector entity.other.attribute-name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML &amp; XML Entity Punctuation</string>
+        <key>scope</key>
+        <string>constant.character.entity punctuation.definition.constant, constant.character.entity punctuation.definition.entity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.class, entity.name.type.class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup Tag</string>
+        <key>scope</key>
+        <string>entity.name.function.neon, entity.name.namespace.wildcard, entity.name.tag, entity.tag, keyword.control.untitled, keyword.doctype.xml, keyword.operator support.other.neon, punctuation.definition.prolog.haml, source.less keyword.control.html.elements</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML Attribute Names</string>
+        <key>scope</key>
+        <string>entity.name.attribute-name, entity.other.attribute-name, meta.section.attributes.haml constant.other.symbol.ruby</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Pseudo Elements/Classes &amp; Vendor Prefixes</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name.placeholder punctuation.definition.entity, entity.other.attribute-name.pseudo-class, entity.other.attribute-name.pseudo-element, entity.other.attribute-name.tag.pseudo-class, entity.other.attribute-name.tag.pseudo-element, entity.other.pseudo-class, entity.other.pseudo-element, support.type.vendor-prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Animations / Keyframes</string>
+        <key>scope</key>
+        <string>entity.function-name.stylus, entity.other.animation-keyframe.stylus, entity.other.animation-name, keyword.language.function.misc.stylus, meta.at-rule.keyframes entity.name.function, variable.other.animation-name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Author-Defined Names</string>
+        <key>scope</key>
+        <string>entity.other.namespace-prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>meta.class.body, meta.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Image &amp; Hyperlink</string>
+        <key>scope</key>
+        <string>meta.image, meta.link</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8f3f71</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown Image &amp; Hyperlink Punctuation</string>
+        <key>scope</key>
+        <string>meta.image punctuation.definition.metadata, meta.link punctuation.definition.metadata</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>meta.require</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Function Call Braces</string>
+        <key>scope</key>
+        <string>constant.name.attribute.tag.jade, constant.name.attribute.tag.pug, meta.brace.round, meta.function-call meta.group punctuation.definition.group, punctuation.definition.method-parameters, punctuation.definition.parameters</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Property Names</string>
+        <key>scope</key>
+        <string>meta.property-name, support.type.property-name, support.type.shape.definition support.constant.property-value</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Property Name Vendor Prefixes</string>
+        <key>scope</key>
+        <string>meta.property-name support.type.vendor-prefix, support.type.property-name.media support.type.vendor-prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#98971a</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Property Values</string>
+        <key>scope</key>
+        <string>constant.string.sass, meta.property-value, support.constant.property-value</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Property Value Vendor Prefixes</string>
+        <key>scope</key>
+        <string>meta.property-value support.type.vendor-prefix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Foreground Text</string>
+        <key>scope</key>
+        <string>source.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7c6f64</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Header Text From</string>
+        <key>scope</key>
+        <string>meta.diff.header.from-file</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Header Text From Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.from-file</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#458588</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Header Text To</string>
+        <key>scope</key>
+        <string>meta.diff.header.to-file</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8f3f71</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Header Text To Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.to-file</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b16286</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Additions &amp; Deletions Stats</string>
+        <key>scope</key>
+        <string>meta.diff.range, meta.toc-list.line-number</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Additions &amp; Deletions Stats Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.range.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d79921</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>FiF Line Number</string>
+        <key>scope</key>
+        <string>constant.numeric.line-number</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>FiF Line Number Matched</string>
+        <key>scope</key>
+        <string>constant.numeric.line-number.match</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>FiF Filename</string>
+        <key>scope</key>
+        <string>entity.name.filename</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter &amp; Diff Deleted</string>
+        <key>scope</key>
+        <string>markup.deleted, punctuation.definition.deleted</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter &amp; Diff Inserted</string>
+        <key>scope</key>
+        <string>markup.inserted, punctuation.definition.inserted</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter &amp; Diff Changed</string>
+        <key>scope</key>
+        <string>markup.changed, punctuation.definition.changed</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter ignored</string>
+        <key>scope</key>
+        <string>markup.ignored</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GitGutter untracked</string>
+        <key>scope</key>
+        <string>markup.untracked</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Tag</string>
+        <key>scope</key>
+        <string>brackethighlighter.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Curly</string>
+        <key>scope</key>
+        <string>brackethighlighter.curly</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Round</string>
+        <key>scope</key>
+        <string>brackethighlighter.round</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Square</string>
+        <key>scope</key>
+        <string>brackethighlighter.square</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Angle</string>
+        <key>scope</key>
+        <string>brackethighlighter.angle</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Quote</string>
+        <key>scope</key>
+        <string>brackethighlighter.quote</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Bracket Unmatched</string>
+        <key>scope</key>
+        <string>brackethighlighter.unmatched</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>SublimeLinter Error</string>
+        <key>scope</key>
+        <string>sublimelinter.mark.error</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>SublimeLinter Gutter Mark</string>
+        <key>scope</key>
+        <string>sublimelinter.gutter-mark</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>SublimeLinter Warning</string>
+        <key>scope</key>
+        <string>sublimelinter.mark.warning</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HexViewer Upper Byte Nibble</string>
+        <key>scope</key>
+        <string>raw.nibble.upper</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HexViewer Lower Byte Nibble</string>
+        <key>scope</key>
+        <string>raw.nibble.lower</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HexViewer Highlight</string>
+        <key>scope</key>
+        <string>hexviewer.highlight</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+          <key>background</key>
+          <string>#b57614</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HexViewer Edited Highlight</string>
+        <key>scope</key>
+        <string>hexviewer.highlight.edited</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9f5d7</string>
+          <key>background</key>
+          <string>#af3a03</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Raw New Line: Carriage Return</string>
+        <key>scope</key>
+        <string>glyph.carriage-return</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#3c383626</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Raw New Line: New Line Glyph</string>
+        <key>scope</key>
+        <string>glyph.new-line</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#3c383626</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Header</string>
+        <key>scope</key>
+        <string>keyword.control.header.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#79740e</string>
+          <key>background</key>
+          <string>#fefdf6</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Notes</string>
+        <key>scope</key>
+        <string>notes.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#665c54</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Punctuation</string>
+        <key>scope</key>
+        <string>text.todo punctuation.definition.bold, text.todo punctuation.definition.italic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a89984</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Task Pending</string>
+        <key>scope</key>
+        <string>meta.item.todo.pending</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1d2021</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Task Pending Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.bullet.pending.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Task Completed Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.bullet.completed.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#427b58</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Task Cancelled Punctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.bullet.cancelled.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag Critical</string>
+        <key>scope</key>
+        <string>string.other.tag.todo.critical</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9d0006</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag High</string>
+        <key>scope</key>
+        <string>string.other.tag.todo.high</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#af3a03</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag Low</string>
+        <key>scope</key>
+        <string>string.other.tag.todo.low</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag Today</string>
+        <key>scope</key>
+        <string>string.other.tag.todo.today</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b57614</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Tag</string>
+        <key>scope</key>
+        <string>meta.tag.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8f3f71</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: URL</string>
+        <key>scope</key>
+        <string>punctuation.definition.url, todo.url</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#076678</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PlainTasks: Separator</string>
+        <key>scope</key>
+        <string>meta.punctuation.archive.todo, meta.punctuation.separator.todo</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>italic</string>
+          <key>foreground</key>
+          <string>#928374</string>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>


### PR DESCRIPTION
Added two gruvbox themes: dark (hard contrast) and light (hard contrast). These are imported sublime themes from: https://github.com/Briles/gruvbox

To create the themes I followed the instructions from the wiki.