### PR TITLE
re-order caption/value selection

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -479,7 +479,7 @@ var FilteredList = function(array, filterText) {
         var upper = needle.toUpperCase();
         var lower = needle.toLowerCase();
         loop: for (var i = 0, item; item = items[i]; i++) {
-            var caption = item.value || item.caption || item.snippet;
+            var caption = item.snippet || item.caption || item.value;
             if (!caption) continue;
             var lastIndex = -1;
             var matchMask = 0;

--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -479,7 +479,7 @@ var FilteredList = function(array, filterText) {
         var upper = needle.toUpperCase();
         var lower = needle.toLowerCase();
         loop: for (var i = 0, item; item = items[i]; i++) {
-            var caption = item.snippet || item.caption || item.value;
+            var caption = item.caption || item.value || item.snippet;
             if (!caption) continue;
             var lastIndex = -1;
             var matchMask = 0;


### PR DESCRIPTION
We were using `value` over `caption` for matching user input.

However, this meant that users were searching the value they weren't being shown (caption is displayed instead of value). So if the value contains more or less characters than the caption, the indices for where we highlight matching characters were offset incorrectly.

I think this is because, further up in `setFilter` we have caption/value, whereas here we had value/caption.

Example:
* Input: `b`
* Entry: `{ caption: "foobar", value: "xfoobar" }`
* Result: "foob**a**r"

cc @nightwing 