### PR TITLE
Fix err object causing exception with postMessage

### DIFF
--- a/lib/ace/worker/worker_client.js
+++ b/lib/ace/worker/worker_client.js
@@ -159,6 +159,8 @@ var WorkerClient = function(topLevelNamespaces, mod, classname, workerUrl, impor
         try {
             // firefox refuses to clone objects which have function properties
             // TODO: cleanup event
+            if (data.data && data.data.err)
+                data.data.err = {message: data.data.err.message, stack: data.data.err.stack, code: data.data.err.code};
             this.$worker.postMessage({event: event, data: {data: data.data}});
         }
         catch(ex) {


### PR DESCRIPTION
@nightwing I noticed we're passing `err` via postMessage in Cloud9 in some places, causing an exception. I'd love to have a more general fix, but this should address some known cases already.