### PR TITLE
fix static-highlight extension

### DIFF
--- a/demo/static-highlighter/server.js
+++ b/demo/static-highlighter/server.js
@@ -27,7 +27,9 @@ http.createServer(function(req, res) {
     res.writeHead(200, {"Content-Type": "text/html; charset=utf-8"});
     fs.readFile(path, "utf8", function(err, data) {
         if (err) data = err.message;
+        var t = Date.now();
         var highlighted = highlighter.render(data, new JavaScriptMode(), theme);
+        console.log("Rendered " + (data.length/1000) + "kb in " + (Date.now() - t) + "ms");
         res.end(
             '<html><body>\n' +
                 '<style type="text/css" media="screen">\n' +

--- a/lib/ace/ext/static_highlight.js
+++ b/lib/ace/ext/static_highlight.js
@@ -37,71 +37,52 @@ var baseStyles = require("../requirejs/text!./static.css");
 var config = require("../config");
 var dom = require("../lib/dom");
 
+function Element(type) {
+    this.type = type;
+    this.style = {};
+    this.textContent = "";
+}
+Element.prototype.cloneNode = function() {
+    return this;
+};
+Element.prototype.appendChild = function(child) {
+    this.textContent += child.toString();
+};
+Element.prototype.toString = function() {
+    var stringBuilder = [];
+    if (this.type != "fragment") {
+        stringBuilder.push("<", this.type);
+        if (this.className)
+            stringBuilder.push(" class='", this.className, "'");
+        var styleStr = [];
+        for (var key in this.style) {
+            styleStr.push(key, ":", this.style[key]);
+        }
+        if (styleStr.length)
+            stringBuilder.push(" style='", styleStr.join(""), "'");
+        stringBuilder.push(">");
+    }
+    
+    if (this.textContent)
+        stringBuilder.push(this.textContent);
+    
+    if (this.type != "fragment") {
+        stringBuilder.push("</", this.type, ">");
+    }
+    
+    return stringBuilder.join("");
+};
+
+
 var simpleDom = {
-    createTextNode: function(textContent) {
+    createTextNode: function(textContent, element) {
         return textContent;
     },
     createElement: function(type) {
-        var element = {
-            type: type,
-            style: {},
-            childNodes: [],
-            appendChild: function(child) {
-                element.childNodes.push(child);
-            },
-            toString: function() {
-                var internal = {
-                    type: 1,
-                    style: 1,
-                    className: 1,
-                    textContent: 1,
-                    childNodes: 1,
-                    appendChild: 1,
-                    toString: 1
-                };
-                var stringBuilder = [];
-                
-                if (element.type != "fragment") {
-                    stringBuilder.push("<", element.type);
-                    if (element.className)
-                        stringBuilder.push(" class='", element.className, "'");
-                    var styleStr = [];
-                    for (var key in element.style) {
-                        styleStr.push(key, ":", element.style[key]);
-                    }
-                    if (styleStr.length)
-                        stringBuilder.push(" style='", styleStr.join(""), "'");
-                    for (var key in element) {
-                        if (!internal[key]) {
-                            stringBuilder.push(" ", key, "='", element[key], "'");
-                        }
-                    }
-                    stringBuilder.push(">");
-                }
-                
-                if (element.textContent) {
-                    stringBuilder.push(element.textContent);
-                } else {
-                    for (var i=0; i<element.childNodes.length; i++) {
-                        var child = element.childNodes[i];
-                        if (typeof child == "string")
-                            stringBuilder.push(child);
-                        else
-                            stringBuilder.push(child.toString());
-                    }
-                }
-                
-                if (element.type != "fragment") {
-                    stringBuilder.push("</", element.type, ">");
-                }
-                
-                return stringBuilder.join("");
-            }
-        };
-        return element;
+        return new Element(type);
     },
     createFragment: function() {
-        return this.createElement("fragment");
+        return new Element("fragment");
     }
 };
 
@@ -224,6 +205,13 @@ highlight.renderSync = function(input, mode, theme, lineStart, disableGutter) {
 
     var textLayer = new SimpleTextLayer();
     textLayer.setSession(session);
+    Object.keys(textLayer.$tabStrings).forEach(function(k) {
+        if (typeof textLayer.$tabStrings[k] == "string") {
+            var el = simpleDom.createFragment();
+            el.textContent = textLayer.$tabStrings[k];
+            textLayer.$tabStrings[k] = el;
+        }
+    });
 
     session.setValue(input);
     var length =  session.getLength();
@@ -234,7 +222,6 @@ highlight.renderSync = function(input, mode, theme, lineStart, disableGutter) {
     var innerEl = simpleDom.createElement("div");
     innerEl.className = "ace_static_highlight" + (disableGutter ? "" : " ace_show_gutter");
     innerEl.style["counter-reset"] = "ace_line " + (lineStart - 1);
-    outerEl.appendChild(innerEl);
 
     for (var ix = 0; ix < length; ix++) {
         var lineEl = simpleDom.createElement("div");
@@ -243,7 +230,6 @@ highlight.renderSync = function(input, mode, theme, lineStart, disableGutter) {
         if (!disableGutter) {
             var gutterEl = simpleDom.createElement("span");
             gutterEl.className ="ace_gutter ace_gutter-cell";
-            gutterEl.unselectable ="on";
             gutterEl.textContent = ""; /*(ix + lineStart) + */
             lineEl.appendChild(gutterEl);
         }
@@ -253,6 +239,7 @@ highlight.renderSync = function(input, mode, theme, lineStart, disableGutter) {
 
     //console.log(JSON.stringify(outerEl, null, 2));
     //console.log(outerEl.toString());
+    outerEl.appendChild(innerEl);
     textLayer.destroy();
 
     return {

--- a/lib/ace/ext/static_highlight_test.js
+++ b/lib/ace/ext/static_highlight_test.js
@@ -29,18 +29,21 @@ module.exports = {
             "*/",
             "function hello (a, b, c) {",
             "    console.log(a * b + c + 'sup$');",
+            "           //",
+            "\t\t\t//",
             "}"
         ].join("\n");
         var mode = new JavaScriptMode();
-
         var result = highlighter.render(snippet, mode, theme);
         assert.equal(result.html, "<div class='ace-tomorrow'><div class='ace_static_highlight ace_show_gutter' style='counter-reset:ace_line 0'>" 
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell' unselectable='on'></span><span class='ace_comment ace_doc'>/** this is a function</span></div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell' unselectable='on'></span><span class='ace_comment ace_doc'>*</span></div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell' unselectable='on'></span><span class='ace_comment ace_doc'>*/</span></div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell' unselectable='on'></span><span class='ace_storage ace_type'>function</span> <span class='ace_entity ace_name ace_function'>hello</span> <span class='ace_paren ace_lparen'>(</span><span class='ace_variable ace_parameter'>a</span><span class='ace_punctuation ace_operator'>, </span><span class='ace_variable ace_parameter'>b</span><span class='ace_punctuation ace_operator'>, </span><span class='ace_variable ace_parameter'>c</span><span class='ace_paren ace_rparen'>)</span> <span class='ace_paren ace_lparen'>{</span></div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell' unselectable='on'></span>    <span class='ace_storage ace_type'>console</span><span class='ace_punctuation ace_operator'>.</span><span class='ace_support ace_function ace_firebug'>log</span><span class='ace_paren ace_lparen'>(</span><span class='ace_identifier'>a</span> <span class='ace_keyword ace_operator'>*</span> <span class='ace_identifier'>b</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_identifier'>c</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_string'>'sup$'</span><span class='ace_paren ace_rparen'>)</span><span class='ace_punctuation ace_operator'>;</span></div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell' unselectable='on'></span><span class='ace_paren ace_rparen'>}</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_comment ace_doc'>/** this is a function</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_comment ace_doc'>*</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_comment ace_doc'>*/</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_storage ace_type'>function</span> <span class='ace_entity ace_name ace_function'>hello</span> <span class='ace_paren ace_lparen'>(</span><span class='ace_variable ace_parameter'>a</span><span class='ace_punctuation ace_operator'>, </span><span class='ace_variable ace_parameter'>b</span><span class='ace_punctuation ace_operator'>, </span><span class='ace_variable ace_parameter'>c</span><span class='ace_paren ace_rparen'>)</span> <span class='ace_paren ace_lparen'>{</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span>    <span class='ace_storage ace_type'>console</span><span class='ace_punctuation ace_operator'>.</span><span class='ace_support ace_function ace_firebug'>log</span><span class='ace_paren ace_lparen'>(</span><span class='ace_identifier'>a</span> <span class='ace_keyword ace_operator'>*</span> <span class='ace_identifier'>b</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_identifier'>c</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_string'>'sup$'</span><span class='ace_paren ace_rparen'>)</span><span class='ace_punctuation ace_operator'>;</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_indent-guide'>    </span><span class='ace_indent-guide'>    </span>   <span class='ace_comment'>//</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_indent-guide'>    </span><span class='ace_indent-guide'>    </span>    <span class='ace_comment'>//</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_paren ace_rparen'>}</span></div>"
             + "</div></div>");
         assert.ok(!!result.css);
         next();


### PR DESCRIPTION

- fixes issue with cloneNode not defined when rendering indent guides
- mostly fixes performance regression introduced by removal of innerHTML, rendering build/src/ace.js several times in a row was taking [689ms, 627ms, 639ms, 563ms] with innerHTML [1424ms, 1391ms, 1354ms, 1318ms] with the version on mainline and [737ms, 619ms, 590ms, 558ms] with this branch.

removes unselectable= on since it doesn't have any effect on ie 11