### PR TITLE
Added check for 'undefined' on for-in

### DIFF
--- a/lib/ace/lib/keys.js
+++ b/lib/ace/lib/keys.js
@@ -112,14 +112,18 @@ var Keys = (function() {
     // A reverse map of FUNCTION_KEYS
     var name, i;
     for (i in ret.FUNCTION_KEYS) {
-        name = ret.FUNCTION_KEYS[i].toLowerCase();
-        ret[name] = parseInt(i, 10);
+        if (ret.FUNCTION_KEYS[i]) {
+            name = ret.FUNCTION_KEYS[i].toLowerCase();
+            ret[name] = parseInt(i, 10);
+        }
     }
 
     // A reverse map of PRINTABLE_KEYS
     for (i in ret.PRINTABLE_KEYS) {
-        name = ret.PRINTABLE_KEYS[i].toLowerCase();
-        ret[name] = parseInt(i, 10);
+        if (ret.PRINTABLE_KEYS[i]) {
+            name = ret.PRINTABLE_KEYS[i].toLowerCase();
+            ret[name] = parseInt(i, 10);
+        }
     }
 
     // Add the MODIFIER_KEYS, FUNCTION_KEYS and PRINTABLE_KEYS to the KEY


### PR DESCRIPTION
Added check for 'undefined' on for-in to prevent Internet Explorer 11 (and older) from crashing.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
