### PR TITLE
Replace createShadowRoot by attachShadow

### DIFF
--- a/demo/shadow-dom.html
+++ b/demo/shadow-dom.html
@@ -47,7 +47,7 @@ class AcePlayground extends HTMLElement {
     constructor() {
         super();
         
-        var shadow = this.createShadowRoot({mode: "open"});
+        var shadow = this.attachShadow({mode: "open"});
         
         var dom = require("ace/lib/dom");
         dom.buildDom(["div", {id: "host"},


### PR DESCRIPTION
Element.createShadowRoot() is deprecated.
https://developer.mozilla.org/en-US/docs/Web/API/Element/createShadowRoot

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
