### PR TITLE
Tab key navigation (Experiment)

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -2818,6 +2818,15 @@ config.defineOptions(Editor.prototype, "editor", {
                 relativeNumberRenderer.detach(this);
         }
     },
+    ariaLabel: {
+        get: function() {
+            this.textInput.getElement().getAttribute("aria-label");
+        },
+        set: function(value) {
+            this.textInput.getElement().setAttribute("aria-label", value);
+        }
+    },
+    
 
     hScrollBarAlwaysVisible: "renderer",
     vScrollBarAlwaysVisible: "renderer",

--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -683,6 +683,12 @@ Editor.$uid = 0;
         this.renderer.showCursor();
         this.renderer.visualizeFocus();
         this._emit("focus", e);
+        
+        if (!this.$mouseHandler.isMousePressed) {
+            if (!this.node) {
+                this.node = dom.buildDom(["span"]);
+            }
+        }
     };
 
     /**
@@ -1095,7 +1101,38 @@ Editor.$uid = 0;
     };
 
     this.onCommandKey = function(e, hashId, keyCode) {
-        this.keyBinding.onCommandKey(e, hashId, keyCode);
+        if (this.node && keyCode != -1) {
+            clearTimeout(this.timer);
+            this.node && this.node.remove();
+            this.node = null;
+            
+            if (keyCode == 9) {
+                return;
+            }
+        }
+        
+        var isHandled = this.keyBinding.onCommandKey(e, hashId, keyCode);
+        if (!isHandled && keyCode == 27 && !hashId && e) {
+            var t = this.$lastEscT;
+            this.$lastEscT = e.timeStamp;
+            if (this.$lastEscT - t < 1000) {
+                this.node = dom.buildDom([
+                    "div",
+                    {
+                        style: "background: pink; color:black; position:absolute; top:0; right:20px; padding: 2px 10px;z-index: 10000"
+                    },
+                    "Press Tab to navigate away from the editor"
+                ], this.container);
+            }
+            clearTimeout(this.timer);
+            this.timer = setTimeout(function() {
+                this.node && this.node.remove();
+                this.node = null;
+            }.bind(this), 5000);
+        }
+        else {
+            this.$lastEscT = null
+        }
     };
 
     /**

--- a/lib/ace/keyboard/keybinding.js
+++ b/lib/ace/keyboard/keybinding.js
@@ -139,7 +139,7 @@ var KeyBinding = function(editor) {
 
     this.onCommandKey = function(e, hashId, keyCode) {
         var keyString = keyUtil.keyCodeToString(keyCode);
-        this.$callKeyboardHandlers(hashId, keyString, keyCode, e);
+        return this.$callKeyboardHandlers(hashId, keyString, keyCode, e);
     };
 
     this.onTextInput = function(text) {


### PR DESCRIPTION
An attempt to fix https://github.com/ajaxorg/ace/issues/3149

the code is not ready to be merged, but the behavior can be tested at
https://rawgit.com/ajaxorg/ace/tab-key-navigation/demo/autoresize.html

When keyboard focus first goes into the editor, and mouse is not pressed, or when esc key is pressed twice, editor allows the next Tab key to be handled by the browser.

I am not sure if this should be a behavior that is on by default and can be disabled, or an extension that needs to be enabled explicitly.