### PR TITLE
Use updated CSS properties for SASS/SCSS highlighting

### DIFF
--- a/lib/ace/mode/scss_highlight_rules.js
+++ b/lib/ace/mode/scss_highlight_rules.js
@@ -34,78 +34,11 @@ define(function(require, exports, module) {
 var oop = require("../lib/oop");
 var lang = require("../lib/lang");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+var CssHighlightRules = require("./css_highlight_rules");
 
 var ScssHighlightRules = function() {
     
-    var properties = lang.arrayToMap( (function () {
-
-        var browserPrefix = ("-webkit-|-moz-|-o-|-ms-|-svg-|-pie-|-khtml-").split("|");
-        
-        var prefixProperties = ("appearance|background-clip|background-inline-policy|background-origin|" + 
-             "background-size|binding|border-bottom-colors|border-left-colors|" + 
-             "border-right-colors|border-top-colors|border-end|border-end-color|" + 
-             "border-end-style|border-end-width|border-image|border-start|" + 
-             "border-start-color|border-start-style|border-start-width|box-align|" + 
-             "box-direction|box-flex|box-flexgroup|box-ordinal-group|box-orient|" + 
-             "box-pack|box-sizing|column-count|column-gap|column-width|column-rule|" + 
-             "column-rule-width|column-rule-style|column-rule-color|float-edge|" + 
-             "font-feature-settings|font-language-override|force-broken-image-icon|" + 
-             "image-region|margin-end|margin-start|opacity|outline|outline-color|" + 
-             "outline-offset|outline-radius|outline-radius-bottomleft|" + 
-             "outline-radius-bottomright|outline-radius-topleft|outline-radius-topright|" + 
-             "outline-style|outline-width|padding-end|padding-start|stack-sizing|" + 
-             "tab-size|text-blink|text-decoration-color|text-decoration-line|" + 
-             "text-decoration-style|transform|transform-origin|transition|" + 
-             "transition-delay|transition-duration|transition-property|" + 
-             "transition-timing-function|user-focus|user-input|user-modify|user-select|" +
-             "window-shadow|border-radius").split("|");
-        
-        var properties = ("azimuth|background-attachment|background-color|background-image|" +
-            "background-position|background-repeat|background|border-bottom-color|" +
-            "border-bottom-style|border-bottom-width|border-bottom|border-collapse|" +
-            "border-color|border-left-color|border-left-style|border-left-width|" +
-            "border-left|border-right-color|border-right-style|border-right-width|" +
-            "border-right|border-spacing|border-style|border-top-color|" +
-            "border-top-style|border-top-width|border-top|border-width|border|bottom|" +
-            "box-shadow|box-sizing|caption-side|clear|clip|color|content|counter-increment|" +
-            "counter-reset|cue-after|cue-before|cue|cursor|direction|display|" +
-            "elevation|empty-cells|float|font-family|font-size-adjust|font-size|" +
-            "font-stretch|font-style|font-variant|font-weight|font|height|left|" +
-            "letter-spacing|line-height|list-style-image|list-style-position|" +
-            "list-style-type|list-style|margin-bottom|margin-left|margin-right|" +
-            "margin-top|marker-offset|margin|marks|max-height|max-width|min-height|" +
-            "min-width|opacity|orphans|outline-color|" +
-            "outline-style|outline-width|outline|overflow|overflow-x|overflow-y|padding-bottom|" +
-            "padding-left|padding-right|padding-top|padding|page-break-after|" +
-            "page-break-before|page-break-inside|page|pause-after|pause-before|" +
-            "pause|pitch-range|pitch|play-during|position|quotes|richness|right|" +
-            "size|speak-header|speak-numeral|speak-punctuation|speech-rate|speak|" +
-            "stress|table-layout|text-align|text-decoration|text-indent|" +
-            "text-shadow|text-transform|top|unicode-bidi|vertical-align|" +
-            "visibility|voice-family|volume|white-space|widows|width|word-spacing|" +
-            "z-index").split("|");
-          
-        //The return array     
-        var ret = [];
-        
-        //All prefixProperties will get the browserPrefix in
-        //the begning by join the prefixProperties array with the value of browserPrefix
-        for (var i=0, ln=browserPrefix.length; i<ln; i++) {
-            Array.prototype.push.apply(
-                ret,
-                (( browserPrefix[i] + prefixProperties.join("|" + browserPrefix[i]) ).split("|"))
-            );
-        }
-        
-        //Add also prefixProperties and properties without any browser prefix
-        Array.prototype.push.apply(ret, prefixProperties);
-        Array.prototype.push.apply(ret, properties);
-        
-        return ret;
-        
-    })() );
-    
-
+    var properties = lang.arrayToMap(CssHighlightRules.supportType.split("|"));
 
     var functions = lang.arrayToMap(
         ("hsl|hsla|rgb|rgba|url|attr|counter|counters|abs|adjust_color|adjust_hue|" +
@@ -115,56 +48,9 @@ var ScssHighlightRules = function() {
          "scale_color|transparentize|type_of|unit|unitless|unquote").split("|")
     );
 
-    var constants = lang.arrayToMap(
-        ("absolute|all-scroll|always|armenian|auto|baseline|below|bidi-override|" +
-        "block|bold|bolder|border-box|both|bottom|break-all|break-word|capitalize|center|" +
-        "char|circle|cjk-ideographic|col-resize|collapse|content-box|crosshair|dashed|" +
-        "decimal-leading-zero|decimal|default|disabled|disc|" +
-        "distribute-all-lines|distribute-letter|distribute-space|" +
-        "distribute|dotted|double|e-resize|ellipsis|fixed|georgian|groove|" +
-        "hand|hebrew|help|hidden|hiragana-iroha|hiragana|horizontal|" +
-        "ideograph-alpha|ideograph-numeric|ideograph-parenthesis|" +
-        "ideograph-space|inactive|inherit|inline-block|inline|inset|inside|" +
-        "inter-ideograph|inter-word|italic|justify|katakana-iroha|katakana|" +
-        "keep-all|left|lighter|line-edge|line-through|line|list-item|loose|" +
-        "lower-alpha|lower-greek|lower-latin|lower-roman|lowercase|lr-tb|ltr|" +
-        "medium|middle|move|n-resize|ne-resize|newspaper|no-drop|no-repeat|" +
-        "nw-resize|none|normal|not-allowed|nowrap|oblique|outset|outside|" +
-        "overline|pointer|progress|relative|repeat-x|repeat-y|repeat|right|" +
-        "ridge|row-resize|rtl|s-resize|scroll|se-resize|separate|small-caps|" +
-        "solid|square|static|strict|super|sw-resize|table-footer-group|" +
-        "table-header-group|tb-rl|text-bottom|text-top|text|thick|thin|top|" +
-        "transparent|underline|upper-alpha|upper-latin|upper-roman|uppercase|" +
-        "vertical-ideographic|vertical-text|visible|w-resize|wait|whitespace|" +
-        "zero").split("|")
-    );
+    var constants = lang.arrayToMap(CssHighlightRules.supportConstant.split("|"));
 
-    var colors = lang.arrayToMap(
-        ("aliceblue|antiquewhite|aqua|aquamarine|azure|beige|bisque|black|" +
-        "blanchedalmond|blue|blueviolet|brown|burlywood|cadetblue|" +
-        "chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|" +
-        "darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|" +
-        "darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|" +
-        "darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|" +
-        "darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|" +
-        "dodgerblue|firebrick|floralwhite|forestgreen|fuchsia|gainsboro|" +
-        "ghostwhite|gold|goldenrod|gray|green|greenyellow|grey|honeydew|" +
-        "hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|" +
-        "lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|" +
-        "lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|" +
-        "lightsalmon|lightseagreen|lightskyblue|lightslategray|" +
-        "lightslategrey|lightsteelblue|lightyellow|lime|limegreen|linen|" +
-        "magenta|maroon|mediumaquamarine|mediumblue|mediumorchid|" +
-        "mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|" +
-        "mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|" +
-        "moccasin|navajowhite|navy|oldlace|olive|olivedrab|orange|orangered|" +
-        "orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|" +
-        "papayawhip|peachpuff|peru|pink|plum|powderblue|purple|rebeccapurple|" +
-        "red|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|" +
-        "seashell|sienna|silver|skyblue|slateblue|slategray|slategrey|snow|" +
-        "springgreen|steelblue|tan|teal|thistle|tomato|turquoise|violet|" +
-        "wheat|white|whitesmoke|yellow|yellowgreen").split("|")
-    );
+    var colors = lang.arrayToMap(CssHighlightRules.supportConstantColor.split("|"));
     
     var keywords = lang.arrayToMap(
         ("@mixin|@extend|@include|@import|@media|@debug|@warn|@if|@for|@each|@while|@else|@font-face|@-webkit-keyframes|if|and|!default|module|def|end|declare").split("|")
@@ -216,7 +102,7 @@ var ScssHighlightRules = function() {
                 next : "qstring"
             }, {
                 token : "constant.numeric",
-                regex : numRe + "(?:em|ex|px|cm|mm|in|pt|pc|deg|rad|grad|ms|s|hz|khz|%)"
+                regex : numRe + "(?:ch|cm|deg|em|ex|fr|gd|grad|Hz|in|kHz|mm|ms|pc|pt|px|rad|rem|s|turn|vh|vmax|vmin|vm|vw|%)"
             }, {
                 token : "constant.numeric", // hex6 color
                 regex : "#[a-f0-9]{6}"


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* SASS and SCSS files has quite a few properties and numerical units not being highlighted compared to the standard CSS highlighter, so this PR fixes that by importing the updated values from the CSS highlighting rules (the LESS highlighting has been done the same way).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
