### PR TITLE
Added Typescript interface definition for TokenIterator and Folding module.

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -73,6 +73,20 @@ export namespace Ace {
     restoreRange(range: Range): void;
   }
 
+  interface Folding {
+    getFoldAt(row:number, column:number, side:number):Fold;
+    getFoldsInRange(range:Range):Array<Fold>;
+    getFoldsInRangeList(ranges:Array<Range>):Array<Fold>;
+    getAllFolds():Array<Fold>;
+    addFold(placeholder:string, range:Range):Fold;
+    addFolds(folds:Array<Fold>);
+    removeFold(fold:Fold);
+    removeFolds(folds:Array<Fold>);
+    expandFold(fold:Fold);
+    expandFolds(folds:Array<Fold>);
+    foldAll(startRow:number, endRow:number, depth:number);
+  }
+
   export interface Range {
     start: Point;
     end: Point;
@@ -269,6 +283,16 @@ export namespace Ace {
     getLineTokens(line: string, startState: string | string[]): Token[];
   }
 
+  interface TokenIterator{
+    getCurrentToken():Token;
+    getCurrentTokenColumn():number;
+    getCurrentTokenRow():number;
+    getCurrentTokenPosition():Point;
+    getCurrentTokenRange():Range;
+    stepBackward():Token;
+    stepForward():Token;
+  }
+  
   export interface SyntaxMode {
     getTokenizer(): Tokenizer;
     toggleCommentLines(state: any,
@@ -337,7 +361,7 @@ export namespace Ace {
     isAtBookmark(): boolean;
   }
 
-  export interface EditSession extends EventEmitter, OptionsProvider {
+  export interface EditSession extends EventEmitter, OptionsProvider, Folding {
     selection: Selection;
 
     on(name: 'changeFold',


### PR DESCRIPTION
Added missing type deceleration for TokenIterator and Folding. To help developer using ace editor in TypeScript file.

Example Usage:

```
import {Ace, edit, Range, require as ace_require} from 'ace-builds';
import "ace-builds/webpack-resolver";
let {TokenIterator} = ace_require('ace/token_iterator');

let currentSession:Ace.EditSession = editor.getSession();
let stream:Ace.TokenIterator = new TokenIterator(currentSession, 0, 0);
```

Modified EditSession interface to extend Folding Interface to avoid errors in accessing methods like `addFold` on editor session in TypeScript.

Example Usage:

```
let currentSession:Ace.EditSession = editor.getSession();
let range:Ace.Range = new Range(10, 5, 10, 10);
currentSession.addFold('...', range);
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
