### PR TITLE
escape special characters in the code

### DIFF
--- a/lib/ace/ext/static_highlight.js
+++ b/lib/ace/ext/static_highlight.js
@@ -36,15 +36,7 @@ var TextLayer = require("../layer/text").Text;
 var baseStyles = require("../requirejs/text!./static.css");
 var config = require("../config");
 var dom = require("../lib/dom");
-
-function escapeHtml(unsafe) {
-    return unsafe
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&apos;');
-}
+var escapeHTML = require("../lib/lang").escapeHTML;
 
 function Element(type) {
     this.type = type;
@@ -73,10 +65,7 @@ Element.prototype.toString = function() {
     }
 
     if (this.textContent) {
-        if (this.type === 'span')
-            stringBuilder.push(escapeHtml(this.textContent));
-        else
-            stringBuilder.push(this.textContent);
+        stringBuilder.push(this.textContent);
     }
 
     if (this.type != "fragment") {
@@ -89,7 +78,7 @@ Element.prototype.toString = function() {
 
 var simpleDom = {
     createTextNode: function(textContent, element) {
-        return textContent;
+        return escapeHTML(textContent);
     },
     createElement: function(type) {
         return new Element(type);

--- a/lib/ace/ext/static_highlight.js
+++ b/lib/ace/ext/static_highlight.js
@@ -37,6 +37,15 @@ var baseStyles = require("../requirejs/text!./static.css");
 var config = require("../config");
 var dom = require("../lib/dom");
 
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+
 function Element(type) {
     this.type = type;
     this.style = {};
@@ -62,10 +71,14 @@ Element.prototype.toString = function() {
             stringBuilder.push(" style='", styleStr.join(""), "'");
         stringBuilder.push(">");
     }
-    
-    if (this.textContent)
-        stringBuilder.push(this.textContent);
-    
+
+    if (this.textContent) {
+        if (this.type === 'span')
+            stringBuilder.push(escapeHtml(this.textContent));
+        else
+            stringBuilder.push(this.textContent);
+    }
+
     if (this.type != "fragment") {
         stringBuilder.push("</", this.type, ">");
     }

--- a/lib/ace/ext/static_highlight_test.js
+++ b/lib/ace/ext/static_highlight_test.js
@@ -44,7 +44,7 @@ module.exports = {
             + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_comment ace_doc'>*</span></div>"
             + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_comment ace_doc'>*/</span></div>"
             + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_storage ace_type'>function</span> <span class='ace_entity ace_name ace_function'>hello</span> <span class='ace_paren ace_lparen'>(</span><span class='ace_variable ace_parameter'>a</span><span class='ace_punctuation ace_operator'>, </span><span class='ace_variable ace_parameter'>b</span><span class='ace_punctuation ace_operator'>, </span><span class='ace_variable ace_parameter'>c</span><span class='ace_paren ace_rparen'>)</span> <span class='ace_paren ace_lparen'>{</span></div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span>    <span class='ace_storage ace_type'>console</span><span class='ace_punctuation ace_operator'>.</span><span class='ace_support ace_function ace_firebug'>log</span><span class='ace_paren ace_lparen'>(</span><span class='ace_identifier'>a</span> <span class='ace_keyword ace_operator'>*</span> <span class='ace_identifier'>b</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_identifier'>c</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_string'>'sup$'</span><span class='ace_paren ace_rparen'>)</span><span class='ace_punctuation ace_operator'>;</span></div>"
+            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span>    <span class='ace_storage ace_type'>console</span><span class='ace_punctuation ace_operator'>.</span><span class='ace_support ace_function ace_firebug'>log</span><span class='ace_paren ace_lparen'>(</span><span class='ace_identifier'>a</span> <span class='ace_keyword ace_operator'>*</span> <span class='ace_identifier'>b</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_identifier'>c</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_string'>&#39;sup$&#39;</span><span class='ace_paren ace_rparen'>)</span><span class='ace_punctuation ace_operator'>;</span></div>"
             + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_indent-guide'>    </span><span class='ace_indent-guide'>    </span>   <span class='ace_comment'>//</span></div>"
             + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_indent-guide'>    </span><span class='ace_indent-guide'>    </span>    <span class='ace_comment'>//</span></div>"
             + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_paren ace_rparen'>}</span></div>"
@@ -96,8 +96,23 @@ module.exports = {
         var mode = new TextMode();
 
         var result = highlighter.render(snippet, mode, theme);
-        assert.ok(result.html.indexOf(snippet) != -1);
+        assert.ok(result.html.indexOf("</span>$&#39;$1$2$$$&#38;</div>") != -1);
 
+        next();
+    },
+    
+    "test html special chars": function(next) {
+        var theme = require("../theme/tomorrow");
+        var snippet = "&<>'\"";
+        var mode = new TextMode();
+
+        var result = highlighter.render(snippet, mode, theme);
+        assert.ok(result.html.indexOf("</span>&#38;&#60;>&#39;&#34;</div>") != -1);
+        
+        var mode = new JavaScriptMode();
+        var result = highlighter.render("/*" + snippet, mode, theme);
+        assert.ok(result.html.indexOf("<span class='ace_comment'>/*&#38;&#60;>&#39;&#34;</span>") != -1);
+        
         next();
     },
     


### PR DESCRIPTION
fix bug: some codes contain html special characters (such as `<`, `>`) may not display well