### PR TITLE
Add new breakpoint function from Python 3.7

### DIFF
--- a/lib/ace/mode/python_highlight_rules.js
+++ b/lib/ace/mode/python_highlight_rules.js
@@ -57,7 +57,8 @@ var PythonHighlightRules = function() {
         "chr|frozenset|long|reload|vars|classmethod|getattr|map|repr|xrange|" +
         "cmp|globals|max|reversed|zip|compile|hasattr|memoryview|round|" +
         "__import__|complex|hash|min|set|apply|delattr|help|next|setattr|" +
-        "buffer|dict|hex|object|slice|coerce|dir|id|oct|sorted|intern"
+        "buffer|dict|hex|object|slice|coerce|dir|id|oct|sorted|intern|" +
+        "breakpoint"
     );
 
     //var futureReserved = "";


### PR DESCRIPTION
Python 3.7 includes a new function called `breakpoint`.

https://docs.python.org/3/library/functions.html#breakpoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
