### PR TITLE
use CSS filter to preserve original requested opacity (closes #3777)

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -315,15 +315,15 @@ styles.join("\n")
 }
     
 @keyframes blink-ace-animate {
-    from, to { opacity: 1; }
-    60% { opacity: 0; }
+    from, to { filter: opacity(1); }
+    60% { filter: opacity(0); }
 }
 
 @keyframes blink-ace-animate-smooth {
-    from, to { opacity: 1; }
-    45% { opacity: 1; }
-    60% { opacity: 0; }
-    85% { opacity: 0; }
+    from, to { filter: opacity(1); }
+    45% { filter: opacity(1); }
+    60% { filter: opacity(0); }
+    85% { filter: opacity(0); }
 }
 
 .ace_marker-layer .ace_step, .ace_marker-layer .ace_stack {


### PR DESCRIPTION
*Issue #, if available:*

#3777 

*Description of changes:*

Use `filter: opacity();` with cursor blink animation, to preserve a pre-existing opacity on block cursors (for e.g. Vim and Emacs modes)