### PR TITLE
hide replace toggle & replace dialog when the editor is in read only mode

### DIFF
--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -72,6 +72,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
     this.element = div.firstChild;
     
     this.setSession = this.setSession.bind(this);
+
     this.$init();
     this.setEditor(editor);
     dom.importCssString(searchboxCss, "ace_searchbox", editor.container);
@@ -87,10 +88,6 @@ var SearchBox = function(editor, range, showReplaceForm) {
     this.setSession = function(e) {
         this.searchRange = null;
         this.$syncOptions(true);
-    };
-
-    this.$getReplaceEnabled = function() {
-        return !this.editor.getReadOnly();
     };
 
     this.$initElements = function(sb) {
@@ -167,16 +164,14 @@ var SearchBox = function(editor, range, showReplaceForm) {
     this.$searchBarKb = new HashHandler();
     this.$searchBarKb.bindKeys({
         "Ctrl-f|Command-f": function(sb) {
-            if (this.$getReplaceEnabled()) {
-                var isReplace = sb.isReplace = !sb.isReplace;
-                sb.replaceBox.style.display = isReplace ? "" : "none";
-                sb.replaceOption.checked = false;
-            }
+            var isReplace = sb.isReplace = !sb.isReplace;
+            sb.replaceBox.style.display = isReplace ? "" : "none";
+            sb.replaceOption.checked = false;
             sb.$syncOptions();
             sb.searchInput.focus();
         },
         "Ctrl-H|Command-Option-F": function(sb) {
-            if (!this.$getReplaceEnabled())
+            if (sb.editor.getReadOnly())
                 return;
             sb.replaceOption.checked = true;
             sb.$syncOptions();
@@ -235,7 +230,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
     }, {
         name: "toggleReplace",
         exec: function(sb) {
-            sb.replaceOption.checked = sb.$getReplaceEnabled() && !sb.replaceOption.checked;
+            sb.replaceOption.checked = !sb.replaceOption.checked;
             sb.$syncOptions();
         }
     }, {
@@ -258,18 +253,15 @@ var SearchBox = function(editor, range, showReplaceForm) {
     };
 
     this.$syncOptions = function(preventScroll) {
+        dom.setCssClass(this.replaceOption, "checked", this.searchRange);
         dom.setCssClass(this.searchOption, "checked", this.searchOption.checked);
+        this.replaceOption.textContent = this.replaceOption.checked ? "-" : "+";
         dom.setCssClass(this.regExpOption, "checked", this.regExpOption.checked);
         dom.setCssClass(this.wholeWordOption, "checked", this.wholeWordOption.checked);
         dom.setCssClass(this.caseSensitiveOption, "checked", this.caseSensitiveOption.checked);
-        if (this.$getReplaceEnabled()) {
-            dom.setCssClass(this.replaceOption, "checked", this.searchRange);
-            this.replaceOption.textContent = this.replaceOption.checked ? "-" : "+";
-        } else {
-            this.replaceOption.checked = false;
-        }
-        this.replaceOption.style.display = this.replaceOption.checked ? "" : "none";
-        this.replaceBox.style.display = this.replaceOption.checked ? "" : "none";
+        var readOnly = this.editor.getReadOnly();
+        this.replaceOption.style.display = readOnly ? "none" : "";
+        this.replaceBox.style.display = this.replaceOption.checked && !readOnly ? "" : "none";
         this.find(false, false, preventScroll);
     };
 
@@ -345,17 +337,17 @@ var SearchBox = function(editor, range, showReplaceForm) {
         this.hide();
     };
     this.replace = function() {
-        if (this.$getReplaceEnabled())
+        if (!this.editor.getReadOnly())
             this.editor.replace(this.replaceInput.value);
     };    
     this.replaceAndFindNext = function() {
-        if (this.$getReplaceEnabled()) {
+        if (!this.editor.getReadOnly()) {
             this.editor.replace(this.replaceInput.value);
             this.findNext();
         }
     };
     this.replaceAll = function() {
-        if (this.$getReplaceEnabled())
+        if (!this.editor.getReadOnly())
             this.editor.replaceAll(this.replaceInput.value);
     };
 
@@ -369,11 +361,10 @@ var SearchBox = function(editor, range, showReplaceForm) {
         this.editor.focus();
     };
     this.show = function(value, isReplace) {
-        var showReplace = isReplace && this.$getReplaceEnabled();
         this.active = true;
         this.editor.on("changeSession", this.setSession);
         this.element.style.display = "";
-        this.replaceOption.checked = showReplace;
+        this.replaceOption.checked = isReplace;
         
         if (value)
             this.searchInput.value = value;

--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -72,7 +72,6 @@ var SearchBox = function(editor, range, showReplaceForm) {
     this.element = div.firstChild;
     
     this.setSession = this.setSession.bind(this);
-
     this.$init();
     this.setEditor(editor);
     dom.importCssString(searchboxCss, "ace_searchbox", editor.container);
@@ -88,6 +87,10 @@ var SearchBox = function(editor, range, showReplaceForm) {
     this.setSession = function(e) {
         this.searchRange = null;
         this.$syncOptions(true);
+    };
+
+    this.$getReplaceEnabled = function() {
+        return !this.editor.getReadOnly();
     };
 
     this.$initElements = function(sb) {
@@ -164,13 +167,17 @@ var SearchBox = function(editor, range, showReplaceForm) {
     this.$searchBarKb = new HashHandler();
     this.$searchBarKb.bindKeys({
         "Ctrl-f|Command-f": function(sb) {
-            var isReplace = sb.isReplace = !sb.isReplace;
-            sb.replaceBox.style.display = isReplace ? "" : "none";
-            sb.replaceOption.checked = false;
+            if (this.$getReplaceEnabled()) {
+                var isReplace = sb.isReplace = !sb.isReplace;
+                sb.replaceBox.style.display = isReplace ? "" : "none";
+                sb.replaceOption.checked = false;
+            }
             sb.$syncOptions();
             sb.searchInput.focus();
         },
         "Ctrl-H|Command-Option-F": function(sb) {
+            if (!this.$getReplaceEnabled())
+                return;
             sb.replaceOption.checked = true;
             sb.$syncOptions();
             sb.replaceInput.focus();
@@ -228,7 +235,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
     }, {
         name: "toggleReplace",
         exec: function(sb) {
-            sb.replaceOption.checked = !sb.replaceOption.checked;
+            sb.replaceOption.checked = sb.$getReplaceEnabled() && !sb.replaceOption.checked;
             sb.$syncOptions();
         }
     }, {
@@ -251,12 +258,17 @@ var SearchBox = function(editor, range, showReplaceForm) {
     };
 
     this.$syncOptions = function(preventScroll) {
-        dom.setCssClass(this.replaceOption, "checked", this.searchRange);
         dom.setCssClass(this.searchOption, "checked", this.searchOption.checked);
-        this.replaceOption.textContent = this.replaceOption.checked ? "-" : "+";
         dom.setCssClass(this.regExpOption, "checked", this.regExpOption.checked);
         dom.setCssClass(this.wholeWordOption, "checked", this.wholeWordOption.checked);
         dom.setCssClass(this.caseSensitiveOption, "checked", this.caseSensitiveOption.checked);
+        if (this.$getReplaceEnabled()) {
+            dom.setCssClass(this.replaceOption, "checked", this.searchRange);
+            this.replaceOption.textContent = this.replaceOption.checked ? "-" : "+";
+        } else {
+            this.replaceOption.checked = false;
+        }
+        this.replaceOption.style.display = this.replaceOption.checked ? "" : "none";
         this.replaceBox.style.display = this.replaceOption.checked ? "" : "none";
         this.find(false, false, preventScroll);
     };
@@ -333,17 +345,17 @@ var SearchBox = function(editor, range, showReplaceForm) {
         this.hide();
     };
     this.replace = function() {
-        if (!this.editor.getReadOnly())
+        if (this.$getReplaceEnabled())
             this.editor.replace(this.replaceInput.value);
     };    
     this.replaceAndFindNext = function() {
-        if (!this.editor.getReadOnly()) {
+        if (this.$getReplaceEnabled()) {
             this.editor.replace(this.replaceInput.value);
             this.findNext();
         }
     };
     this.replaceAll = function() {
-        if (!this.editor.getReadOnly())
+        if (this.$getReplaceEnabled())
             this.editor.replaceAll(this.replaceInput.value);
     };
 
@@ -357,10 +369,11 @@ var SearchBox = function(editor, range, showReplaceForm) {
         this.editor.focus();
     };
     this.show = function(value, isReplace) {
+        var showReplace = isReplace && this.$getReplaceEnabled();
         this.active = true;
         this.editor.on("changeSession", this.setSession);
         this.element.style.display = "";
-        this.replaceOption.checked = isReplace;
+        this.replaceOption.checked = showReplace;
         
         if (value)
             this.searchInput.value = value;


### PR DESCRIPTION

*Issue #, if available:*
#3773 

*Description of changes:*

Hide the replace toggle button and the replace dialog when the editor is in read only mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
