### PR TITLE
Add Editor to ace exports

### DIFF
--- a/lib/ace/ace.js
+++ b/lib/ace/ace.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -120,7 +120,7 @@ exports.edit = function(el, options) {
  * Creates a new [[EditSession]], and returns the associated [[Document]].
  * @param {Document | String} text {:textParam}
  * @param {TextMode} mode {:modeParam}
- * 
+ *
  **/
 exports.createEditSession = function(text, mode) {
     var doc = new EditSession(text, mode);
@@ -128,6 +128,7 @@ exports.createEditSession = function(text, mode) {
     return doc;
 };
 exports.Range = Range;
+exports.Editor = Editor;
 exports.EditSession = EditSession;
 exports.UndoManager = UndoManager;
 exports.VirtualRenderer = Renderer;


### PR DESCRIPTION
The `Editor` export was missing on the `ace` namespace.

*Description of changes:*
Add `Editor` class to `exports`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
