### PR TITLE
lucene: fix catastrophic backtracking

### DIFF
--- a/lib/ace/mode/lucene_highlight_rules.js
+++ b/lib/ace/mode/lucene_highlight_rules.js
@@ -37,7 +37,7 @@ var LuceneHighlightRules = function() {
                 regex: "[\\)\\}\\]]"
             }, {
                 token: "keyword",
-                regex: "(?:[^\\s:]+|\\\\ )*[^\\\\]:"
+                regex: "(?:\\\\.|[^\\s:\\\\])+:"
             }, {
                 token: "string",           // " string
                 regex: '"(?:\\\\"|[^"])*"'


### PR DESCRIPTION
There's a case of [catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html) which results in ace hanging in certain cases when using the lucene mode.

This'll happen in most regex engines. Essentially because we have a quantified-quantifier (like `(\w+)*`).

Anyhow i've changed the keyword pattern to instead match:

* Anything that isn't a space, backslash or colon; followed by a colon
* Unless the character has been escaped