### PR TITLE
Update list of PHP keywords

### DIFF
--- a/lib/ace/mode/php_highlight_rules.js
+++ b/lib/ace/mode/php_highlight_rules.js
@@ -850,18 +850,18 @@ ziparchive_unchangeindex|ziparchive_unchangename|zlib_get_coding_type'.split('|'
 
     // http://php.net/manual/en/reserved.keywords.php
     var keywords = lang.arrayToMap(
-'abstract|and|array|as|break|case|catch|class|clone|const|continue|declare|default|do|else|elseif|enddeclare|endfor|endforeach|endif|\
-endswitch|endwhile|extends|final|for|foreach|function|global|goto|if|implements|interface|instanceof|namespace|new|or|private|protected|\
-public|static|switch|throw|trait|try|use|var|while|xor'.split('|')
+'abstract|and|array|as|break|callable|case|catch|class|clone|const|continue|declare|default|do|else|elseif|enddeclare|endfor|endforeach|\
+endif|endswitch|endwhile|extends|final|finally|for|foreach|function|global|goto|if|implements|instanceof|insteadof|interface|namespace|new|or|private|protected|\
+public|static|switch|throw|trait|try|use|var|while|xor|yield'.split('|')
     );
 
     // http://php.net/manual/en/reserved.keywords.php
     var languageConstructs = lang.arrayToMap(
-        ('die|echo|empty|exit|eval|include|include_once|isset|list|require|require_once|return|print|unset').split('|')
+        ('__halt_compiler|die|echo|empty|exit|eval|include|include_once|isset|list|require|require_once|return|print|unset').split('|')
     );
 
     var builtinConstants = lang.arrayToMap(
-        ('true|TRUE|false|FALSE|null|NULL|__CLASS__|__DIR__|__FILE__|__LINE__|__METHOD__|__FUNCTION__|__NAMESPACE__').split('|')
+        ('true|TRUE|false|FALSE|null|NULL|__CLASS__|__DIR__|__FILE__|__LINE__|__METHOD__|__FUNCTION__|__NAMESPACE__|__TRAIT__').split('|')
     );
 
     var builtinVariables = lang.arrayToMap(


### PR DESCRIPTION
Generated using a variation of:

```
curl -s http://php.net/manual/en/reserved.keywords.php|grep -A999 doctable|grep -B999 /table \
 |grep -v 'td>'|grep -o '>[^<]*</a>'|grep -v '()'|cut -d\> -f2|cut -d\< -f1|tr '\n' '|'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
