### PR TITLE
Remove unnecessary absolute position

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -244,7 +244,6 @@ styles.join("\n")
 
 .ace_text-layer > .ace_line, .ace_text-layer > .ace_line_group {
     contain: style size layout;
-    position: absolute;
     top: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
*Description of changes:*

I have been using Ace Editor as a part of a Chrome Extension. When injecting the editor (src-min-noconflict) via a content script, the styles of any existing on-page ace editor would become unreadable (see screenshots below).

In testing, removing the `position: absolute` rule from the `.ace_text-layer > .ace_line, .ace_text-layer > .ace_line_group` rule resolved the issue (the element inheriting the `static` position instead).

This is an edge case, but the change does not seem to have any negative impact on standard use cases

![Style Issues](https://imgur.com/a/nZfr09j)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
