### PR TITLE
fix markdown folding for headings containing #

### DIFF
--- a/lib/ace/mode/folding/fold_mode_test.js
+++ b/lib/ace/mode/folding/fold_mode_test.js
@@ -1,0 +1,76 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+if (typeof process !== "undefined")
+    require("amd-loader");
+
+define(function(require, exports, module) {
+"use strict";
+
+var MarkdownMode = require("../markdown").Mode;
+var EditSession = require("../../edit_session").EditSession;
+var assert = require("../../test/assertions");
+
+module.exports = {
+
+    "test: markdown folding": function() {
+        var session = new EditSession([
+            "# heading 1",
+            "## heading 2",
+            "something",
+            "### heading 3",
+            "#### heading4",
+            "other",
+            "",
+            "article 1",
+            "======",
+            "A Paragraph.",
+            "level 2",
+            "--------",
+            "A Paragraph."
+        ]);
+        var expected = "[0/11][5/5],[1/12][5/5],,[3/13][5/5],[4/13][5/5],,,,[8/6][12/12],,,[11/8][12/12],";
+
+        var mode = new MarkdownMode();
+        session.setFoldStyle("markbeginend");
+        session.setMode(mode);
+
+        var ranges = session.doc.getAllLines().map(function(_, i) {
+            return session.getFoldWidgetRange(i); 
+        });
+
+        assert.equal(ranges.toString().replace(/Range:|[\s]|->/g, ""), expected);
+    }
+};
+
+});
+
+if (typeof module !== "undefined" && module === require.main)
+    require("asyncjs").test.testcase(module.exports).exec();

--- a/lib/ace/mode/folding/markdown.js
+++ b/lib/ace/mode/folding/markdown.js
@@ -93,7 +93,7 @@ oop.inherits(FoldMode, BaseFoldMode);
             var ch = token.value[0];
             if (ch == "=") return 6;
             if (ch == "-") return 5;
-            return 7 - token.value.search(/[^#]/);
+            return 7 - token.value.search(/[^#]|$/);
         }
 
         if (isHeading(row)) {

--- a/lib/ace/test/all_browser.js
+++ b/lib/ace/test/all_browser.js
@@ -45,6 +45,7 @@ var testNames = [
     "ace/mode/python_test",
     "ace/mode/text_test",
     "ace/mode/xml_test",
+    "ace/mode/folding/fold_mode_test",
     "ace/mode/folding/cstyle_test",
     "ace/mode/folding/html_test",
     "ace/mode/folding/pythonic_test",


### PR DESCRIPTION
fixes #2973

the regression was caused by the tokenizer emitting leading `###` as a separate token, 

