### PR TITLE
Disable autocorrect on Vim command box

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -4674,7 +4674,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
     }
     function makePrompt(prefix, desc) {
       var raw = '<span style="font-family: monospace; white-space: pre">' +
-          (prefix || "") + '<input type="text"></span>';
+          (prefix || "") + '<input type="text" autocorrect="off" autocapitalize="none" autocomplete="off"></span>';
       if (desc)
         raw += ' <span style="color: #888">' + desc + '</span>';
       return raw;


### PR DESCRIPTION
Disables autocorrect and autocapitalize on the Vim command input box. Mobile devices will automatically capitalize the first letter and "correct" words.

*Description of changes:*
Added attributes to the inserted `input` tag to disable autocorrect and autocapitalize.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
