### PR TITLE
Add new Python 3.7 built-in functions

### DIFF
--- a/lib/ace/mode/python_highlight_rules.js
+++ b/lib/ace/mode/python_highlight_rules.js
@@ -58,7 +58,7 @@ var PythonHighlightRules = function() {
         "cmp|globals|max|reversed|zip|compile|hasattr|memoryview|round|" +
         "__import__|complex|hash|min|apply|delattr|help|next|setattr|set|" +
         "buffer|dict|hex|object|slice|coerce|dir|id|oct|sorted|intern|" +
-        "ascii|breakpoint|bytes"
+        "ascii|breakpoint|bytes|breakpoint"
     );
 
     //var futureReserved = "";


### PR DESCRIPTION
`breakpoint()` is the new built-in function for debugging as of Python 3.7

Breakpoint reference: https://docs.python.org/3/library/functions.html#breakpoint

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
