### PR TITLE
Add Swift's open, internal and fileprivate access level keywords

### DIFF
--- a/lib/ace/mode/swift_highlight_rules.js
+++ b/lib/ace/mode/swift_highlight_rules.js
@@ -50,7 +50,7 @@ var SwiftHighlightRules = function() {
             + "|convenience|dynamic|final|infix|lazy|mutating|nonmutating|optional|override|postfix"
             + "|prefix|required|static|guard|defer",
         "storage.type": "bool|double|Double"
-            + "|extension|float|Float|int|Int|private|public|string|String",
+            + "|extension|float|Float|int|Int|open|internal|fileprivate|private|public|string|String",
         "constant.language":
             "false|Infinity|NaN|nil|no|null|null|off|on|super|this|true|undefined|yes",
         "support.function":


### PR DESCRIPTION
*Description of changes:*

Swift 4.2 has open, internal, fileprivate, private and public access level [(AccessControl)] (https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html). The latest of the ace does not have open, internal and fileprivate. I added them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
