### PR TITLE
Fixes Emacs' killRingSave Behavior

### DIFF
--- a/lib/ace/keyboard/emacs.js
+++ b/lib/ace/keyboard/emacs.js
@@ -598,6 +598,7 @@ exports.handler.addCommands({
                 editor.$handlesEmacsOnCopy = false;
                 if (editor.inMultiSelectMode) editor.forEachSelection({exec: deselect});
                 else deselect();
+                editor.setEmacsMark(null);
                 editor.session.$emacsMarkRing = marks.concat(deselectedMarks.reverse());
             }, 0);
         },


### PR DESCRIPTION
The mark should be cleared when saving to the kill ring. This is consistent with
the actual behvaior of Emacs. The change is similar to #2821.

Tested in the kitchen sink.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
