### PR TITLE
Fix highlighting of multiline yaml string in lists

### DIFF
--- a/lib/ace/mode/_test/text_yaml.txt
+++ b/lib/ace/mode/_test/text_yaml.txt
@@ -1,0 +1,71 @@
+# This sample document was taken from wikipedia:
+# http://en.wikipedia.org/wiki/YAML#Sample_document
+---
+receipt:     Oz-Ware Purchase Invoice
+date:        2007-08-06
+customer:
+    given:   Dorothy
+    family:  Gale
+
+items:
+    - part_no:   'A4786'
+      descrip:   Water Bucket (Filled)
+      price:     1.47
+      quantity:  4
+
+    - part_no:   'E1628'
+      descrip:   High Heeled "Ruby" Slippers
+      size:      8
+      price:     100.27
+      quantity:  1
+
+bill-to:  &id001
+    street: |
+            123 Tornado Alley
+            Suite 16
+    city:   East Centerville
+    state:  KS
+
+ship-to:  *id001
+
+specialDelivery:  >
+    Follow the Yellow Brick
+    Road to the Emerald City.
+    Pay no attention to the
+    man behind the curtain.
+
+?        |
+ block key #1
+ kkk
+: - |
+   one 
+  - |
+   tw #o 
+  - ? |- 
+
+     as #d
+
+     q
+    b
+  - 
+     x: xx
+     r: xx
+     z: sss
+     zdd: dddd
+     "block key 2" : 
+       - two # block value
+       - ? | 
+          as #d
+         : |
+          asdadas #d
+          asd
+         a: 2
+       - ? | 
+          asdas #d
+         :  |
+          xx
+         s: |4+ #comment
+               7
+
+             a 
+           a

--- a/lib/ace/mode/_test/tokens_yaml.json
+++ b/lib/ace/mode/_test/tokens_yaml.json
@@ -106,17 +106,17 @@
   ["text","  "],
   ["constant.language","&id001"]
 ],[
-   ["mlString",4],
+   ["mlStringPre",4],
   ["meta.tag","    street"],
   ["keyword",":"],
   ["text"," "],
   ["string","|"]
 ],[
-   ["mlString",4],
+   ["mlString",11],
   ["indent","            "],
   ["string","123 Tornado Alley"]
 ],[
-   ["mlString",4],
+   ["mlString",11],
   ["indent","            "],
   ["string","Suite 16"]
 ],[
@@ -141,27 +141,181 @@
 ],[
    "start"
 ],[
-   ["mlString",0],
+   ["mlStringPre",0],
   ["meta.tag","specialDelivery"],
   ["keyword",":"],
   ["text","  "],
   ["string",">"]
 ],[
-   ["mlString",0],
+   ["mlString",3],
   ["indent","    "],
   ["string","Follow the Yellow Brick"]
 ],[
-   ["mlString",0],
+   ["mlString",3],
   ["indent","    "],
   ["string","Road to the Emerald City."]
 ],[
-   ["mlString",0],
+   ["mlString",3],
   ["indent","    "],
   ["string","Pay no attention to the"]
 ],[
-   ["mlString",0],
+   ["mlString",3],
   ["indent","    "],
   ["string","man behind the curtain."]
 ],[
-   ["mlString",0]
+   ["mlString",3]
+],[
+   ["mlStringPre",0],
+  ["list.markup","? "],
+  ["text","       "],
+  ["string","|"]
+],[
+   ["mlString",0],
+  ["indent"," "],
+  ["string","block key #1"]
+],[
+   ["mlString",0],
+  ["indent"," "],
+  ["string","kkk"]
+],[
+   ["mlStringPre",2],
+  ["text",": - "],
+  ["string","|"]
+],[
+   ["mlString",2],
+  ["indent","   "],
+  ["string","one "]
+],[
+   ["mlStringPre",2],
+  ["indent","  "],
+  ["text","- "],
+  ["string","|"]
+],[
+   ["mlString",2],
+  ["indent","   "],
+  ["string","tw #o "]
+],[
+   ["mlStringPre",4],
+  ["indent","  "],
+  ["text","- ? "],
+  ["string","|- "]
+],[
+   ["mlStringPre",4]
+],[
+   ["mlString",4],
+  ["indent","     "],
+  ["string","as #d"]
+],[
+   ["mlString",4]
+],[
+   ["mlString",4],
+  ["indent","     "],
+  ["string","q"]
+],[
+   "start",
+  ["indent","    "],
+  ["text","b"]
+],[
+   "start",
+  ["list.markup","  - "]
+],[
+   "start",
+  ["meta.tag","     x"],
+  ["keyword",":"],
+  ["text"," xx"]
+],[
+   "start",
+  ["meta.tag","     r"],
+  ["keyword",":"],
+  ["text"," xx"]
+],[
+   "start",
+  ["meta.tag","     z"],
+  ["keyword",":"],
+  ["text"," sss"]
+],[
+   "start",
+  ["meta.tag","     zdd"],
+  ["keyword",":"],
+  ["text"," dddd"]
+],[
+   "start",
+  ["text","     "],
+  ["string","\"block key 2\""],
+  ["text"," : "]
+],[
+   "start",
+  ["list.markup","       - "],
+  ["text","two "],
+  ["comment","# block value"]
+],[
+   ["mlStringPre",9],
+  ["list.markup","       - "],
+  ["text","? "],
+  ["string","| "]
+],[
+   ["mlString",9],
+  ["indent","          "],
+  ["string","as #d"]
+],[
+   ["mlStringPre",9],
+  ["indent","         "],
+  ["text",": "],
+  ["string","|"]
+],[
+   ["mlString",9],
+  ["indent","          "],
+  ["string","asdadas #d"]
+],[
+   ["mlString",9],
+  ["indent","          "],
+  ["string","asd"]
+],[
+   "start",
+  ["indent","         "],
+  ["meta.tag","a"],
+  ["keyword",":"],
+  ["text"," "],
+  ["constant.numeric","2"]
+],[
+   ["mlStringPre",9],
+  ["list.markup","       - "],
+  ["text","? "],
+  ["string","| "]
+],[
+   ["mlString",9],
+  ["indent","          "],
+  ["string","asdas #d"]
+],[
+   ["mlStringPre",9],
+  ["indent","         "],
+  ["text",":  "],
+  ["string","|"]
+],[
+   ["mlString",9],
+  ["indent","          "],
+  ["string","xx"]
+],[
+   ["mlString",12],
+  ["indent","         "],
+  ["meta.tag","s"],
+  ["keyword",":"],
+  ["text"," "],
+  ["string","|4+ #comment"]
+],[
+   ["mlString",12],
+  ["indent","               "],
+  ["string","7"]
+],[
+   ["mlString",12]
+],[
+   ["mlString",12],
+  ["indent","             "],
+  ["string","a "]
+],[
+   "start",
+  ["indent","           "],
+  ["text","a"]
+],[
+   "start"
 ]]

--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -74,7 +74,7 @@ var YamlHighlightRules = function() {
                 token : "string", // multi line string start
                 regex : /[|>][-+\d\s]*$/,
                 onMatch: function(val, state, stack, line) {
-                    var indent = /^\s*/.exec(line)[0];
+                    var indent = /^\s*(?:[-?]\s)?/.exec(line)[0];
                     if (stack.length < 1) {
                         stack.push(this.next);
                     } else {

--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -74,7 +74,7 @@ var YamlHighlightRules = function() {
                 token : "string", // multi line string start
                 regex : /[|>][-+\d\s]*$/,
                 onMatch: function(val, state, stack, line) {
-                    var indent = /^\s*(?:[-?]\s)?/.exec(line)[0];
+                    var indent = /^\s*(?:[-?]\s)?\s*/.exec(line)[0];
                     if (stack.length < 1) {
                         stack.push(this.next);
                     } else {

--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -72,20 +72,25 @@ var YamlHighlightRules = function() {
                 regex : '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
             }, {
                 token : "string", // multi line string start
-                regex : /[|>][-+\d\s]*$/,
+                regex : /[|>][-+\d]*(?:$|\s+(?:$|#))/,
                 onMatch: function(val, state, stack, line) {
-                    var indent = /^\s*(?:[-?]\s)?\s*/.exec(line)[0];
-                    if (stack.length < 1) {
-                        stack.push(this.next);
+                    line = line.replace(/ #.*/, "");
+                    var indent = /^ *((:\s*)?-(\s*[^|>])?)?/.exec(line)[0]
+                        .replace(/\S\s*$/, "").length;
+                    var indentationIndicator = parseInt(/\d+[\s+-]*$/.exec(line));
+                    
+                    if (indentationIndicator) {
+                        indent += indentationIndicator - 1;
+                        this.next = "mlString";
                     } else {
-                        stack[0] = "mlString";
+                        this.next = "mlStringPre";
                     }
-
-                    if (stack.length < 2) {
-                        stack.push(indent.length);
-                    }
-                    else {
-                        stack[1] = indent.length;
+                    if (!stack.length) {
+                        stack.push(this.next);
+                        stack.push(indent);
+                    } else {
+                        stack[0] = this.next;
+                        stack[1] = indent;
                     }
                     return this.token;
                 },
@@ -113,13 +118,39 @@ var YamlHighlightRules = function() {
                 regex : /[^\s,:\[\]\{\}]+/
             }
         ],
+        "mlStringPre" : [
+            {
+                token : "indent",
+                regex : /^ *$/
+            }, {
+                token : "indent",
+                regex : /^ */,
+                onMatch: function(val, state, stack) {
+                    var curIndent = stack[1];
+
+                    if (curIndent >= val.length) {
+                        this.next = "start";
+                        stack.shift();
+                        stack.shift();
+                    }
+                    else {
+                        stack[1] = val.length - 1;
+                        this.next = stack[0] = "mlString";
+                    }
+                    return this.token;
+                },
+                next : "mlString"
+            }, {
+                defaultToken : "string"
+            }
+        ],
         "mlString" : [
             {
                 token : "indent",
-                regex : /^\s*$/
+                regex : /^ *$/
             }, {
                 token : "indent",
-                regex : /^\s*/,
+                regex : /^ */,
                 onMatch: function(val, state, stack) {
                     var curIndent = stack[1];
 


### PR DESCRIPTION
*Description of changes:*
Commit 1168fdd728f193c4b7e4290695d166ca55ae3280 breaks highlighting of multiline yaml string in lists, for example this will be incorrectly highlighted:
```yaml
- specialDelivery2:  >
    Follow the Yellow Brick
    Road to the Emerald City.
    Pay no attention to the
    man behind the curtain.

  blabla: This is not a string but is highlighted as one
```