### PR TITLE
fix wrong state being passed to indenting functions

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -95,13 +95,13 @@ var Editor = function(renderer, session, options) {
     this.commands.on("exec", this.$historyTracker);
 
     this.$initOperationListeners();
-    
+
     this._$emitInputEvent = lang.delayedCall(function() {
         this._signal("input", {});
         if (this.session && this.session.bgTokenizer)
             this.session.bgTokenizer.scheduleStart();
     }.bind(this));
-    
+
     this.on("change", function(_, _self) {
         _self._$emitInputEvent.schedule(31);
     });
@@ -124,7 +124,7 @@ Editor.$uid = 0;
         this.commands.on("afterExec", this.endOperation.bind(this), true);
 
         this.$opResetTimer = lang.delayedCall(this.endOperation.bind(this, true));
-        
+
         // todo: add before change events?
         this.on("change", function() {
             if (!this.curOp) {
@@ -133,7 +133,7 @@ Editor.$uid = 0;
             }
             this.curOp.docChanged = true;
         }.bind(this), true);
-        
+
         this.on("changeSelection", function() {
             if (!this.curOp) {
                 this.startOperation();
@@ -203,7 +203,7 @@ Editor.$uid = 0;
             var sel = this.selection.toJSON();
             this.curOp.selectionAfter = sel;
             this.$lastSel = this.selection.toJSON();
-            
+
             // console.log(this.$lastSel+"  endOP")
             this.session.getUndoManager().addSelection(sel);
             this.prevOp = this.curOp;
@@ -295,7 +295,7 @@ Editor.$uid = 0;
     this.setSession = function(session) {
         if (this.session == session)
             return;
-        
+
         // make sure operationEnd events are not emitted to wrong session
         if (this.curOp) this.endOperation();
         this.curOp = {};
@@ -327,56 +327,56 @@ Editor.$uid = 0;
             this.$onDocumentChange = this.onDocumentChange.bind(this);
             session.on("change", this.$onDocumentChange);
             this.renderer.setSession(session);
-    
+
             this.$onChangeMode = this.onChangeMode.bind(this);
             session.on("changeMode", this.$onChangeMode);
-    
+
             this.$onTokenizerUpdate = this.onTokenizerUpdate.bind(this);
             session.on("tokenizerUpdate", this.$onTokenizerUpdate);
-    
+
             this.$onChangeTabSize = this.renderer.onChangeTabSize.bind(this.renderer);
             session.on("changeTabSize", this.$onChangeTabSize);
-    
+
             this.$onChangeWrapLimit = this.onChangeWrapLimit.bind(this);
             session.on("changeWrapLimit", this.$onChangeWrapLimit);
-    
+
             this.$onChangeWrapMode = this.onChangeWrapMode.bind(this);
             session.on("changeWrapMode", this.$onChangeWrapMode);
-    
+
             this.$onChangeFold = this.onChangeFold.bind(this);
             session.on("changeFold", this.$onChangeFold);
-    
+
             this.$onChangeFrontMarker = this.onChangeFrontMarker.bind(this);
             this.session.on("changeFrontMarker", this.$onChangeFrontMarker);
-    
+
             this.$onChangeBackMarker = this.onChangeBackMarker.bind(this);
             this.session.on("changeBackMarker", this.$onChangeBackMarker);
-    
+
             this.$onChangeBreakpoint = this.onChangeBreakpoint.bind(this);
             this.session.on("changeBreakpoint", this.$onChangeBreakpoint);
-    
+
             this.$onChangeAnnotation = this.onChangeAnnotation.bind(this);
             this.session.on("changeAnnotation", this.$onChangeAnnotation);
-    
+
             this.$onCursorChange = this.onCursorChange.bind(this);
             this.session.on("changeOverwrite", this.$onCursorChange);
-    
+
             this.$onScrollTopChange = this.onScrollTopChange.bind(this);
             this.session.on("changeScrollTop", this.$onScrollTopChange);
-    
+
             this.$onScrollLeftChange = this.onScrollLeftChange.bind(this);
             this.session.on("changeScrollLeft", this.$onScrollLeftChange);
-    
+
             this.selection = session.getSelection();
             this.selection.on("changeCursor", this.$onCursorChange);
-    
+
             this.$onSelectionChange = this.onSelectionChange.bind(this);
             this.selection.on("changeSelection", this.$onSelectionChange);
-    
+
             this.onChangeMode();
-    
+
             this.onCursorChange();
-    
+
             this.onScrollTopChange();
             this.onScrollLeftChange();
             this.onSelectionChange();
@@ -395,12 +395,12 @@ Editor.$uid = 0;
             session: session,
             oldSession: oldSession
         });
-        
+
         this.curOp = null;
-        
+
         oldSession && oldSession._signal("changeEditor", {oldEditor: this});
         session && session._signal("changeEditor", {editor: this});
-        
+
         if (session && session.bgTokenizer)
             session.bgTokenizer.scheduleStart();
     };
@@ -558,36 +558,36 @@ Editor.$uid = 0;
         this.$highlightTagPending = true;
         setTimeout(function() {
             self.$highlightTagPending = false;
-            
+
             var session = self.session;
             if (!session || !session.bgTokenizer) return;
-            
+
             var pos = self.getCursorPosition();
             var iterator = new TokenIterator(self.session, pos.row, pos.column);
             var token = iterator.getCurrentToken();
-            
+
             if (!token || !/\b(?:tag-open|tag-name)/.test(token.type)) {
                 session.removeMarker(session.$tagHighlight);
                 session.$tagHighlight = null;
                 return;
             }
-            
+
             if (token.type.indexOf("tag-open") != -1) {
                 token = iterator.stepForward();
                 if (!token)
                     return;
             }
-            
+
             var tag = token.value;
             var depth = 0;
             var prevToken = iterator.stepBackward();
-            
+
             if (prevToken.value == '<'){
                 //find closing tag
                 do {
                     prevToken = token;
                     token = iterator.stepForward();
-                    
+
                     if (token && token.value === tag && token.type.indexOf('tag-name') !== -1) {
                         if (prevToken.value === '<'){
                             depth++;
@@ -595,14 +595,14 @@ Editor.$uid = 0;
                             depth--;
                         }
                     }
-                    
+
                 } while (token && depth >= 0);
             } else {
                 //find opening tag
                 do {
                     token = prevToken;
                     prevToken = iterator.stepBackward();
-                    
+
                     if (token && token.value === tag && token.type.indexOf('tag-name') !== -1) {
                         if (prevToken.value === '<') {
                             depth++;
@@ -611,28 +611,28 @@ Editor.$uid = 0;
                         }
                     }
                 } while (prevToken && depth <= 0);
-                
+
                 //select tag again
                 iterator.stepForward();
             }
-            
+
             if (!token) {
                 session.removeMarker(session.$tagHighlight);
                 session.$tagHighlight = null;
                 return;
             }
-            
+
             var row = iterator.getCurrentTokenRow();
             var column = iterator.getCurrentTokenColumn();
             var range = new Range(row, column, row, column+token.value.length);
-            
+
             //remove range if different
             var sbm = session.$backMarkers[session.$tagHighlight];
             if (session.$tagHighlight && sbm != undefined && range.compareRange(sbm.range) !== 0) {
                 session.removeMarker(session.$tagHighlight);
                 session.$tagHighlight = null;
             }
-            
+
             if (!session.$tagHighlight)
                 session.$tagHighlight = session.addMarker(range, "ace_bracket", "text");
         }, 50);
@@ -644,7 +644,7 @@ Editor.$uid = 0;
      **/
     this.focus = function() {
         // focusing after timeout is not needed now, but some code using ace
-        // depends on being able to call focus when textarea is not visible, 
+        // depends on being able to call focus when textarea is not visible,
         // so to keep backwards compatibility we keep this until the next major release
         var _self = this;
         setTimeout(function() {
@@ -719,7 +719,7 @@ Editor.$uid = 0;
         this.renderer.updateLines(delta.start.row, lastRow, wrap);
 
         this._signal("change", delta);
-        
+
         // Update cursor because tab characters can influence the cursor position.
         this.$cursorChange();
         this.$updateHighlightActiveLine();
@@ -812,9 +812,9 @@ Editor.$uid = 0;
         var startColumn = selection.start.column;
         var endColumn = selection.end.column;
         var line = session.getLine(selection.start.row);
-        
+
         var needle = line.substring(startColumn, endColumn);
-        // maximum allowed size for regular expressions in 32000, 
+        // maximum allowed size for regular expressions in 32000,
         // but getting close to it has significant impact on the performance
         if (needle.length > 5000 || !/[\w\d]/.test(needle))
             return;
@@ -824,11 +824,11 @@ Editor.$uid = 0;
             caseSensitive: true,
             needle: needle
         });
-        
+
         var wordWithBoundary = line.substring(startColumn - 1, endColumn + 1);
         if (!re.test(wordWithBoundary))
             return;
-        
+
         return re;
     };
 
@@ -874,7 +874,7 @@ Editor.$uid = 0;
         this.renderer.updateFull();
     };
 
-    
+
     /**
      * Returns the string of text currently highlighted.
      * @returns {String}
@@ -882,7 +882,7 @@ Editor.$uid = 0;
     this.getSelectedText = function() {
         return this.session.getTextRange(this.getSelectionRange());
     };
-    
+
     /**
      * Emitted when text is copied.
      * @event copy
@@ -944,9 +944,9 @@ Editor.$uid = 0;
         var e = {text: text, event: event};
         this.commands.exec("paste", this, e);
     };
-    
+
     this.$handlePaste = function(e) {
-        if (typeof e == "string") 
+        if (typeof e == "string")
             e = {text: e};
         this._signal("paste", e);
         var text = e.text;
@@ -965,15 +965,15 @@ Editor.$uid = 0;
         } else {
             var lines = text.split(/\r\n|\r|\n/);
             var ranges = this.selection.rangeList.ranges;
-    
+
             if (lines.length > ranges.length || lines.length < 2 || !lines[1])
                 return this.commands.exec("insertstring", this, text);
-    
+
             for (var i = ranges.length; i--;) {
                 var range = ranges[i];
                 if (!range.isEmpty())
                     session.remove(range);
-    
+
                 session.insert(range.start, lines[i]);
             }
         }
@@ -1008,7 +1008,7 @@ Editor.$uid = 0;
 
             }
         }
-        
+
         if (text == "\t")
             text = this.session.getTabString();
 
@@ -1034,7 +1034,7 @@ Editor.$uid = 0;
         this.clearSelection();
 
         var start = cursor.column;
-        var lineState = session.getState(cursor.row);
+        var lineState = session.getState(cursor.row - 1);
         var line = session.getLine(cursor.row);
         var shouldOutdent = mode.checkOutdent(lineState, line, text);
         var end = session.insert(cursor, text);
@@ -1065,7 +1065,7 @@ Editor.$uid = 0;
     this.onTextInput = function(text, composition) {
         if (!composition)
             return this.keyBinding.onTextInput(text);
-        
+
         this.startOperation({command: { name: "insertstring" }});
         var applyComposition = this.applyComposition.bind(this, text, composition);
         if (this.selection.rangeCount)
@@ -1074,7 +1074,7 @@ Editor.$uid = 0;
             applyComposition();
         this.endOperation();
     };
-    
+
     this.applyComposition = function(text, composition) {
         if (composition.extendLeft || composition.extendRight) {
             var r = this.selection.getRange();
@@ -1541,7 +1541,7 @@ Editor.$uid = 0;
                 return;
             }
         }
-        
+
         var line = session.getLine(range.start.row);
         var position = range.start;
         var size = session.getTabSize();
@@ -1869,7 +1869,7 @@ Editor.$uid = 0;
             var ranges = selection.rangeList.ranges;
             selection.rangeList.detach(this.session);
             this.inVirtualSelectionMode = true;
-            
+
             var diff = 0;
             var totalDiff = 0;
             var l = ranges.length;
@@ -1898,7 +1898,7 @@ Editor.$uid = 0;
                 if (!copy) diff = 0;
                 totalDiff += diff;
             }
-            
+
             selection.fromOrientedRange(selection.ranges[0]);
             selection.rangeList.attach(this.session);
             this.inVirtualSelectionMode = false;
@@ -2181,7 +2181,7 @@ Editor.$uid = 0;
             "{": "{",
             "}": "{"
         };
-        
+
         do {
             if (token.value.match(/[{}()\[\]]/g)) {
                 for (; i < token.value.length && !found; i++) {
@@ -2218,14 +2218,14 @@ Editor.$uid = 0;
                 if (isNaN(depth[token.value])) {
                     depth[token.value] = 0;
                 }
-                
+
                 if (prevToken.value === '<') {
                     depth[token.value]++;
                 }
                 else if (prevToken.value === '</') {
                     depth[token.value]--;
                 }
-                
+
                 if (depth[token.value] === -1) {
                     matchType = 'tag';
                     found = true;
@@ -2259,7 +2259,7 @@ Editor.$uid = 0;
             }
         }
         else if (matchType === 'tag') {
-            if (token && token.type.indexOf('tag-name') !== -1) 
+            if (token && token.type.indexOf('tag-name') !== -1)
                 var tag = token.value;
             else
                 return;
@@ -2277,7 +2277,7 @@ Editor.$uid = 0;
                 do {
                     token = prevToken;
                     prevToken = iterator.stepBackward();
-                    
+
                     if (prevToken) {
                         if (prevToken.type.indexOf('tag-close') !== -1) {
                             range.setEnd(iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn() + 1);
@@ -2290,7 +2290,7 @@ Editor.$uid = 0;
                             else if (prevToken.value === '</') {
                                 depth[tag]--;
                             }
-                            
+
                             if (depth[tag] === 0)
                                 found = true;
                         }
@@ -2758,7 +2758,7 @@ config.defineOptions(Editor.prototype, "editor", {
     readOnly: {
         set: function(readOnly) {
             this.textInput.setReadOnly(readOnly);
-            this.$resetCursorStyle(); 
+            this.$resetCursorStyle();
         },
         initialValue: false
     },
@@ -2799,7 +2799,7 @@ config.defineOptions(Editor.prototype, "editor", {
         handlesSet: true,
         hidden: true
     },
-    
+
     showLineNumbers: {
         set: function(show) {
             this.renderer.$gutterLayer.setShowLineNumbers(show);


### PR DESCRIPTION
Currently, editor.js passes a linestate to the mode checkOutdent, getNextLineIndent, and autoOutdent functions. It also passes the line. The idea is that the function can then reconstruct the tokens of the line using starting state and the line. From other examples I have seen, this is how it is supposed to be used. The problem is, editor.js currently passes the state at the end of the line. This is not very useful, since you cannot get the tokens of a line using the line text and the end state. (at least not reliably)

*Issue #, if available:*

*Description of changes:
editor.js:1037 is changed from "var lineState = session.getState(cursor.row);" to "var lineState = session.getState(cursor.row - 1);"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.