### PR TITLE
Fix wrong "span"

### DIFF
--- a/lib/ace/layer/text.js
+++ b/lib/ace/layer/text.js
@@ -387,7 +387,7 @@ var Text = function(parentEl) {
                 valueFragment.appendChild(span);
             } else if (cjk) {
                 screenColumn += 1;
-                var span = dom.createElement("span");
+                var span = this.dom.createElement("span");
                 span.style.width = (self.config.characterWidth * 2) + "px";
                 span.className = "ace_cjk";
                 span.textContent = cjk;


### PR DESCRIPTION
*Issue #, if available:*
It will append element like "[object HTMLSpanElement]" into valueFragment.
*Description of changes:*
Just add "this." before dom.createElement :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
