### PR TITLE
fix addMarker type

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -438,16 +438,16 @@ export namespace Ace {
     setBreakpoint(row: number, className: string): void;
     clearBreakpoint(row: number): void;
     addMarker(range: Range,
-              clazz: string,
-              type: MarkerRenderer | string,
-              inFront: boolean): number;
+              className: string,
+              type: "fullLine" | "screenLine" | "text" | MarkerRenderer,
+              inFront?: boolean): number;
     addDynamicMarker(marker: MarkerLike, inFront: boolean): MarkerLike;
     removeMarker(markerId: number): void;
     getMarkers(inFront?: boolean): MarkerLike[];
     highlight(re: RegExp): void;
     highlightLines(startRow: number,
                    endRow: number,
-                   clazz: string,
+                   className: string,
                    inFront?: boolean): Range;
     setAnnotations(annotations: Annotation[]): void;
     getAnnotations(): Annotation[];

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -439,7 +439,7 @@ export namespace Ace {
     clearBreakpoint(row: number): void;
     addMarker(range: Range,
               clazz: string,
-              type: MarkerRenderer,
+              type: MarkerRenderer | string,
               inFront: boolean): number;
     addDynamicMarker(marker: MarkerLike, inFront: boolean): MarkerLike;
     removeMarker(markerId: number): void;


### PR DESCRIPTION
*Description of changes:*. 
the implementation of addMarker function:
```
this.addMarker = function(range, clazz, type, inFront) {
        var id = this.$markerId++;

        var marker = {
            range : range,
            type : type || "line",
            renderer: typeof type == "function" ? type : null,
            clazz : clazz,
            inFront: !!inFront,
            id: id
        };
    //....
}
```
it actually accepts string as `type` argument. but in ace.d.ts. It only accepts function as `type` argument.
