### PR TITLE
Fix popup bug

### DIFF
--- a/lib/ace/autocomplete/popup.js
+++ b/lib/ace/autocomplete/popup.js
@@ -299,7 +299,7 @@ var AcePopup = function(parentNode) {
         var max = this.session.getLength() - 1;
 
         switch(where) {
-            case "up": row = row < 0 ? max : row - 1; break;
+            case "up": row = row <= 0 ? max : row - 1; break;
             case "down": row = row >= max ? -1 : row + 1; break;
             case "start": row = 0; break;
             case "end": row = max; break;


### PR DESCRIPTION
*Issue:*
Completer popup doesn't select the last row when you're pressing UP button on the first row.

*Description of changes:*
This PR fixes this issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
