### PR TITLE
Add toJSON method

### DIFF
--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -2365,7 +2365,30 @@ EditSession.$uid = 0;
 
         return screenRows;
     };
-    
+ 
+    /**
+     * @private
+     *
+     */
+    this.toJSON = function() {
+        return {
+            annotations: this.$annotations,
+            breakpoints: this.$breakpoints,
+            folds: this.getAllFolds().map(function(fold) {
+                return fold.range;
+            }),
+            history: {
+                undo: this.getUndoManager().$undoStack,
+                redo: this.getUndoManager().$redoStack
+            },
+            mode: this.$mode.$id,
+            scrollLeft: this.$scrollLeft,
+            scrollTop: this.$scrollTop,
+            selection: this.selection.toJSON(),
+            value: this.doc.getValue(),
+        }
+    };
+ 
     /**
      * @private
      *


### PR DESCRIPTION
Adds a [`toJSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior) method to facilitate serialization of the the `EditSession` object into JSON through the [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.

Related to issue #1452

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
