### PR TITLE
add missing types

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -852,10 +852,14 @@ export namespace Ace {
     completers: Completer[];
   }
 
-  type CompleterCallback = (_, completions: Completion[]) => void;
+  type CompleterCallback = (_: any, completions: Completion[]) => void;
 
   interface Completer {
-    getCompletions(editor: Editor, session: EditSession, position: Point, prefix, callback: CompleterCallback): void;
+    getCompletions(editor: Editor,
+      session: EditSession,
+      position: Point,
+      prefix: string,
+      callback: CompleterCallback): void;
   }
 }
 


### PR DESCRIPTION
In #3984 we introduced two implicit any types which cause strict typescript builds to fail.

i set `prefix` as `string` but wasn't sure what the first arg of a completer callback is (the error?) so i set it to `any` explicitly.

cc @nightwing 