### PR TITLE
popup null check

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -421,10 +421,12 @@ var Autocomplete = function() {
 
     this.destroy = function() {
         this.detach();
-        this.popup && this.popup.destroy();
-        var el = this.popup.container;
-        if (el && el.parentNode)
-            el.parentNode.removeChild(el);
+        if (this.popup) {
+            this.popup.destroy();
+            var el = this.popup.container;
+            if (el && el.parentNode)
+                el.parentNode.removeChild(el);
+        }
         if (this.editor && this.editor.completer == this)
             this.editor.completer == null;
         this.popup = null;


### PR DESCRIPTION
there is no null check on `popup.container` which causes exceptions in some cases (especially in tests, ive found).

so i wrapped the whole thing instead of just one line

cc @nightwing 