### PR TITLE
set explicit line height to avoid normal resolving to different value…

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -230,6 +230,8 @@ var VirtualRenderer = function(container, theme) {
         this.layerConfig.lineHeight =
         this.lineHeight = this.$textLayer.getLineHeight();
         this.$updatePrintMargin();
+        // set explicit line height to avoid normal resolving to different values based on text
+        dom.setStyle(this.scroller.style, "line-height", this.lineHeight + "px");
     };
 
     /**


### PR DESCRIPTION
fixes the issue reported in https://github.com/integer32llc/rust-playground/issues/509

An alternative would be to change the css, but normal resolves to different values with default fonts on different platforms (from 1.2 to 1.4) so with that it is not possible to keep the look the same as now everywhere.