### PR TITLE
Added new CDN - PageCDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,8 @@ console.log(addResult);
                                 one of <code>src*</code> subdirectories somewhere into your project, or use RequireJS to load the
                                 contents of <a href="https://github.com/ajaxorg/ace/tree/master/lib/ace">lib/ace</a> folder as <code>ace</code>:
                             </p>
-                            <p>The packaged version can also be loaded from CDN's such as <a href="http://www.jsdelivr.com/#!ace">jsDelivr</a> or <a href="http://cdnjs.com/libraries/ace/">cdnjs</a>.
+			    <h2>Loading Ace from a CDN</h2>                            
+                            <p>The packaged version can also be loaded from CDN's such as <a href="https://pagecdn.com/lib/ace">PageCDN</a>, <a href="http://www.jsdelivr.com/#!ace">jsDelivr</a> or <a href="http://cdnjs.com/libraries/ace/">cdnjs</a>.
                             </p>
                         </div>
                         <div class="tab-pane fade" id="howto">


### PR DESCRIPTION
PageCDN uses brotli-11 compression that reduces ace.js size by more than 11 KBs compared to other CDNs. In addition, immutable caching is enabled by default to optimize ace.js delivery a little more aggressively. This will make PageCDN a valuable addition to the documentation.

Thanks.