### PR TITLE
Avoid problems with multiple cursors and lines

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -966,7 +966,7 @@ Editor.$uid = 0;
             var lines = text.split(/\r\n|\r|\n/);
             var ranges = this.selection.rangeList.ranges;
     
-            if (lines.length > ranges.length || lines.length < 2 || !lines[1])
+            if (lines.length != ranges.length)
                 return this.commands.exec("insertstring", this, text);
     
             for (var i = ranges.length; i--;) {

--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -966,7 +966,8 @@ Editor.$uid = 0;
             var lines = text.split(/\r\n|\r|\n/);
             var ranges = this.selection.rangeList.ranges;
     
-            if (lines.length != ranges.length)
+            var isFullLine = lines.length == 2 && (!lines[0] || !lines[1]);
+            if (lines.length != ranges.length || isFullLine)
                 return this.commands.exec("insertstring", this, text);
     
             for (var i = ranges.length; i--;) {
@@ -1037,7 +1038,7 @@ Editor.$uid = 0;
         var lineState = session.getState(cursor.row);
         var line = session.getLine(cursor.row);
         var shouldOutdent = mode.checkOutdent(lineState, line, text);
-        var end = session.insert(cursor, text);
+        session.insert(cursor, text);
 
         if (transform && transform.selection) {
             if (transform.selection.length == 2) { // Transform relative to the current column

--- a/lib/ace/multi_select_test.js
+++ b/lib/ace/multi_select_test.js
@@ -192,6 +192,35 @@ module.exports = {
         assert.ok(!editor.inMultiSelectMode);
     },
 
+    "test: multiselect paste": function() {
+        editor = new Editor(new MockRenderer());
+
+        editor.setValue("l1\nl2\nl3", -1);
+        editor.selectMoreLines(1);
+        editor.$handlePaste("x\n");
+        assert.equal("x\nl1\nx\nl2\nl3", editor.getValue());
+        editor.execCommand("gotolineend");
+        editor.$handlePaste("\ny");
+        assert.equal("x\nl1\ny\nx\nl2\ny\nl3", editor.getValue());
+        
+        editor.selectMoreLines(-1);
+        editor.$handlePaste("4\n5\n6");
+        assert.equal("x\nl1\ny4\nx\nl52\ny6\nl3", editor.getValue());
+
+        editor.$handlePaste("7\n\n8");
+        assert.equal("x\nl1\ny47\nx\nl52\ny68\nl3", editor.getValue());
+        editor.execCommand("selectleft");
+        editor.execCommand("selectleft");
+        editor.$handlePaste("t\nz");
+        
+        assert.equal("x\nl1\nyt\nz\nx\nt\nz2\nyt\nz\nl3", editor.getValue());
+        editor.setValue("l1\nl2\nl3", -1);
+        editor.selectMoreLines(1);
+        editor.selectMoreLines(1);
+        editor.$handlePaste("a\nb\nc\nd");
+        assert.equal("a\nb\nc\ndl1\na\nb\nc\ndl2\na\nb\nc\ndl3", editor.getValue());
+    },
+    
     "test: onPaste in command with multiselect": function() {
         var doc = new EditSession(["l1", "l2"]);
         editor = new Editor(new MockRenderer(), doc);


### PR DESCRIPTION
*Issue #, if available:*
When you have multiple cursors and less copied lines than cursors, it will throw an unhandled exception. And when you have multiple copied lines where the second line is empty, it will not paste one line per cursor.

*Description of changes:*
It will paste one line per cursor only if the same amount of lines are pasted, avoiding errors or unwanted behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
