### PR TITLE
Fix test when run from a timezone with minute offset part from UTC != 0

### DIFF
--- a/lib/ace/snippets_test.js
+++ b/lib/ace/snippets_test.js
@@ -221,6 +221,7 @@ module.exports = {
         var D = Date;
         var d = new Date(0);
         d.setHours(4);
+        d.setMinutes(0);
         Date = function() { return d; }; // eslint-disable-line
         try {
             editor.insertSnippet([


### PR DESCRIPTION
I just ran the tests for the first time and this one failed. Turns out this test will only fail when run from a timezone with non-integer hour offset from UTC (I'm in UTC+5.5).