### PR TITLE
Fix comparing strings in sorting of matches in autocomplete module.

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -489,7 +489,7 @@ var FilteredList = function(array, filterText) {
         matches = this.filterCompletions(matches, this.filterText);
         matches = matches.sort(function(a, b) {
             return b.exactMatch - a.exactMatch || b.$score - a.$score 
-                || (a.caption || a.value) < (b.caption || b.value);
+                || (a.caption || a.value).localeCompare(b.caption || b.value);
         });
 
         // make unique


### PR DESCRIPTION
The old code did a `<` comparison of 2 strings which results in
inconsistent sorting order in different browsers.

Demonstration:

The code:

    ["a", "c", "d", "A"].sort((a, b) => a < b)

returns:

    ["a", "c", "d", "A"]

in Chrome 75 while in Firefox 68, it returns:

    ["d", "c", "a", "A"]

NB. I didn't find any tests related to this and I'm not familiar with the codebase enough to write a new test but it's a tiny change and I've verified it works in my project.