### PR TITLE
Don't use "eval", it breaks strict mode

### DIFF
--- a/lib/ace/mode/php/php.js
+++ b/lib/ace/mode/php/php.js
@@ -1026,7 +1026,7 @@ PHP.Lexer = function(src, ini) {
  */
 
 
-PHP.Parser = function ( preprocessedTokens, eval ) {
+PHP.Parser = function ( preprocessedTokens, evaluate ) {
 
     var yybase = this.yybase,
     yydefault = this.yydefault,
@@ -1187,7 +1187,7 @@ PHP.Parser = function ( preprocessedTokens, eval ) {
                 attributeStack[ this.stackPos ] = this.startAttributes;
             } else {
                 /* error */
-                if (eval !== true) {
+                if (evaluate !== true) {
 
                     var expected = [];
 


### PR DESCRIPTION
*Issue #, if available:* #4068

*Description of changes:* This PR changes `eval` to `evaluate` in the PHP parser. `eval` was causing webpack 4.0 strict mode to error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.