### PR TITLE
fix .split not a function warning

### DIFF
--- a/lib/ace/config.js
+++ b/lib/ace/config.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -79,9 +79,9 @@ exports.moduleUrl = function(name, component) {
     if (options.$moduleUrls[name])
         return options.$moduleUrls[name];
 
-    var parts = name.split("/");
+    var parts = name.id.split("/");
     component = component || parts[parts.length - 2] || "";
-    
+
     // todo make this configurable or get rid of '-'
     var sep = component == "snippets" ? "/" : "-";
     var base = parts[parts.length - 1];
@@ -143,14 +143,14 @@ exports.loadModule = function(moduleName, onLoad) {
 
     if (!exports.get("packaged"))
         return afterLoad();
-    
+
     net.loadScript(exports.moduleUrl(moduleName, moduleType), afterLoad);
     reportErrorIfPathIsNotConfigured();
 };
 
 var reportErrorIfPathIsNotConfigured = function() {
     if (
-        !options.basePath && !options.workerPath 
+        !options.basePath && !options.workerPath
         && !options.modePath && !options.themePath
         && !Object.keys(options.$moduleUrls).length
     ) {
@@ -167,7 +167,7 @@ var reportErrorIfPathIsNotConfigured = function() {
 function init(packaged) {
     if (!global || !global.document)
         return;
-    
+
     options.packaged = packaged || require.packaged || module.packaged || (global.define && define.packaged);
 
     var scriptOptions = {};
@@ -176,7 +176,7 @@ function init(packaged) {
     // Use currentScript.ownerDocument in case this file was loaded from imported document. (HTML Imports)
     var currentScript = (document.currentScript || document._currentScript ); // native or polyfill
     var currentDocument = currentScript && currentScript.ownerDocument || document;
-    
+
     var scripts = currentDocument.getElementsByTagName("script");
     for (var i=0; i<scripts.length; i++) {
         var script = scripts[i];


### PR DESCRIPTION
*Issue #, if available:*
Currently after downloading the newly released of react-ace v8.0.0, there is an error in the console that renders this:
![image](https://user-images.githubusercontent.com/8454621/66725853-076b6900-ee68-11e9-9316-4f0f7804b5f5.png)

It seems to be caused by `ace.js` in the ace module. I looked into the object and it seems that `name` has been modified to an object instead of a string, therefore it is causing the `.split is not a function` warning
![image](https://user-images.githubusercontent.com/8454621/66725867-2964eb80-ee68-11e9-885b-259e42555a7e.png)

*Description of changes:*
I've added a .id after name, the new code should be `var parts = name.id.split("/");`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
