### PR TITLE
exclude rtl direction mark from autocompletion word regex

### DIFF
--- a/lib/ace/autocomplete/util.js
+++ b/lib/ace/autocomplete/util.js
@@ -45,7 +45,7 @@ exports.parForEach = function(array, fn, callback) {
     }
 };
 
-var ID_REGEX = /[a-zA-Z_0-9\$\-\u00A2-\uFFFF]/;
+var ID_REGEX = /[a-zA-Z_0-9\$\-\u00A2-\u2000\u2070-\uFFFF]/;
 
 exports.retrievePrecedingIdentifier = function(text, pos, regex) {
     regex = regex || ID_REGEX;


### PR DESCRIPTION
fixes https://groups.google.com/d/msg/ace-discuss/2MC4yRqcC7g/E3nVmiLoDgAJ