### PR TITLE
Fix OOM error when closing CDATA not found

### DIFF
--- a/lib/ace/mode/xml/sax.js
+++ b/lib/ace/mode/xml/sax.js
@@ -477,10 +477,15 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 	default:
 		if(source.substr(start+3,6) == 'CDATA['){
 			var end = source.indexOf(']]>',start+9);
-			domBuilder.startCDATA();
-			domBuilder.characters(source,start+9,end-start-9);
-			domBuilder.endCDATA() 
-			return end+3;
+			if (end > start) {
+				domBuilder.startCDATA();
+				domBuilder.characters(source,start+9,end-start-9);
+				domBuilder.endCDATA() 
+				return end+3;
+			} else {
+				errorHandler.error("Unclosed CDATA");
+				return -1;
+			}
 		}
 		//<!DOCTYPE
 		//startDTD(java.lang.String name, java.lang.String publicId, java.lang.String systemId) 


### PR DESCRIPTION
*Issue #, if available:* 4102

*Description of changes:* Added a check for closing CDATA tag and add error if none found


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
