### PR TITLE
initial CodeLense support

### DIFF
--- a/demo/code_lense.html
+++ b/demo/code_lense.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ACE Autocompletion demo</title>
+  <style type="text/css" media="screen">
+    body {
+        overflow: hidden;
+    }
+    
+    #editor { 
+        margin: 0;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+    }
+  </style>
+</head>
+<body>
+
+<pre id="editor"></pre>
+
+<script src="kitchen-sink/require.js"></script>
+<script>
+// setup paths
+require.config({paths: { "ace" : "../lib/ace"}});
+// load ace and extensions
+require(["ace/ace", "ace/ext/code_lense"], function(ace, codeLense) {
+    var editor = ace.edit("editor");
+    editor.session.setMode("ace/mode/html");
+
+    var commandId = "describeCodeLense"
+    editor.commands.addCommand({
+        name: commandId,
+        exec: function(editor, args) {
+            // services available in `ctx`
+            alert('CodeLense command called with arguments ' + args);
+        }
+    });
+
+    codeLense.setCodeLenseProvider(editor, {
+        provideCodeLenses: function(session) {
+            var p = []
+            var l = session.getLength()
+
+            for (var row = 0; row < l; row += 2 + Math.floor(row / 10)) {
+                var endColumn = session.getLine(row).length
+                p.push({
+                    range: {
+                        startLineNumber: row,
+                        startColumn: 1,
+                        endLineNumber: 2 + row,
+                        endColumn: 1
+                    },
+                    command: {
+                        id: commandId,
+                        title: "Line " + (row + 1),
+                        arguments: ["line", row]
+                    }
+                }, {
+                    range: {
+                        startLineNumber: row,
+                        startColumn: row,
+                        endLineNumber: 12 + row,
+                        endColumn: row + 10
+                    },
+                    command: {
+                        id: commandId,
+                        title: "column " + endColumn,
+                        arguments: ["column", endColumn]
+                    }
+                });
+            }
+            return p;
+        }
+    })
+});
+</script>
+
+<script src="./show_own_source.js"></script>
+</body>
+</html>

--- a/demo/code_lense.html
+++ b/demo/code_lense.html
@@ -45,33 +45,37 @@ require(["ace/ace", "ace/ext/code_lense"], function(ace, codeLense) {
             var p = []
             var l = session.getLength()
 
-            for (var row = 0; row < l; row += 2 + Math.floor(row / 10)) {
-                var endColumn = session.getLine(row).length
-                p.push({
-                    range: {
-                        startLineNumber: row,
-                        startColumn: 1,
-                        endLineNumber: 2 + row,
-                        endColumn: 1
-                    },
-                    command: {
-                        id: commandId,
-                        title: "Line " + (row + 1),
-                        arguments: ["line", row]
-                    }
-                }, {
-                    range: {
-                        startLineNumber: row,
-                        startColumn: row,
-                        endLineNumber: 12 + row,
-                        endColumn: row + 10
-                    },
-                    command: {
-                        id: commandId,
-                        title: "column " + endColumn,
-                        arguments: ["column", endColumn]
-                    }
-                });
+            for (var row = 0; row < l; row ++) {
+                var line = session.getLine(row);
+                var endColumn = line.length;
+                
+                if (/[{>]\s*$/.test(line)) {
+                    p.push({
+                        range: {
+                            startLineNumber: row,
+                            startColumn: 1,
+                            endLineNumber: 2 + row,
+                            endColumn: 1
+                        },
+                        command: {
+                            id: commandId,
+                            title: "Line " + (row + 1),
+                            arguments: ["line", row]
+                        }
+                    }, {
+                        range: {
+                            startLineNumber: row,
+                            startColumn: row,
+                            endLineNumber: 12 + row,
+                            endColumn: row + 10
+                        },
+                        command: {
+                            id: commandId,
+                            title: "column " + endColumn,
+                            arguments: ["column", endColumn]
+                        }
+                    });
+                }
             }
             return p;
         }

--- a/demo/code_lense.html
+++ b/demo/code_lense.html
@@ -31,7 +31,7 @@ require(["ace/ace", "ace/ext/code_lense"], function(ace, codeLense) {
     var editor = ace.edit("editor");
     editor.session.setMode("ace/mode/html");
 
-    var commandId = "describeCodeLense"
+    var commandId = "describeCodeLense";
     editor.commands.addCommand({
         name: commandId,
         exec: function(editor, args) {
@@ -39,47 +39,83 @@ require(["ace/ace", "ace/ext/code_lense"], function(ace, codeLense) {
             alert('CodeLense command called with arguments ' + args);
         }
     });
+    editor.commands.addCommand({
+        name: "clearCodeLenses",
+        exec: function(editor, args) {
+            editor.setOption("enableCodeLense", false);
+            codeLense.clear(editor.session);
+        }
+    });
+    editor.setOption("enableCodeLense", true);
 
     codeLense.setCodeLenseProvider(editor, {
         provideCodeLenses: function(session) {
-            var p = []
+            var p = [{
+                start: {row: 0},
+                command: {
+                    id: "clearCodeLenses",
+                    title: "Clear all code lenses",
+                    arguments: []
+                }
+            }];
             var l = session.getLength()
 
-            for (var row = 0; row < l; row ++) {
+            for (var row = 2; row < l; row ++) {
                 var line = session.getLine(row);
                 var endColumn = line.length;
                 
-                if (/[{>]\s*$/.test(line)) {
-                    p.push({
-                        range: {
-                            startLineNumber: row,
-                            startColumn: 1,
-                            endLineNumber: 2 + row,
-                            endColumn: 1
-                        },
-                        command: {
-                            id: commandId,
-                            title: "Line " + (row + 1),
-                            arguments: ["line", row]
-                        }
-                    }, {
-                        range: {
-                            startLineNumber: row,
-                            startColumn: row,
-                            endLineNumber: 12 + row,
-                            endColumn: row + 10
-                        },
-                        command: {
-                            id: commandId,
-                            title: "column " + endColumn,
-                            arguments: ["column", endColumn]
-                        }
-                    });
-                }
+                var m = /[{>]\s*$/.exec(line);
+                if (!m) continue;
+                
+                p.push({
+                    start: {
+                        row: row,
+                        column: m.index,
+                    },
+                    command: {
+                        id: commandId,
+                        title: "Line " + (row + 1),
+                        arguments: ["line", row]
+                    }
+                });
+                
+                if (m.index < 10) continue;
+                p.push({
+                    start: {
+                        row: row,
+                        column: m.index,
+                    },
+                    end: {
+                        row: row,
+                        column: m.index + 1,
+                    },
+                    command: {
+                        id: commandId,
+                        title: "column " + endColumn,
+                        arguments: ["column", endColumn]
+                    }
+                });
+                
+                if (m.index < 30) continue;
+                p.push({
+                    start: {
+                        row: row,
+                        column: m.index,
+                    },
+                    command: {
+                        id: commandId,
+                        title: "Third Link",
+                        arguments: ["3", row]
+                    }
+                });
+                
             }
             return p;
         }
-    })
+    });
+    
+    window.editor = editor;
+    window.codeLense = codeLense;
 });
 </script>
 

--- a/demo/show_own_source.js
+++ b/demo/show_own_source.js
@@ -9,8 +9,8 @@ if (typeof ace == "undefined" && typeof require == "undefined") {
 }
 
 function setValue() {
-    require("ace/lib/net").get(document.baseURI, function(t){
+    require("ace/lib/net").get(document.baseURI, function(text) {
         var el = document.getElementById("editor");
-        el.env.editor.setValue(t, 1);
+        el.env.editor.session.setValue(text);
     })
 }

--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -2014,15 +2014,14 @@ EditSession.$uid = 0;
      * @returns {Number}
      **/
     this.getRowLength = function(row) {
+        var h = 1;
         if (this.lineWidgets)
-            var h = this.lineWidgets[row] && this.lineWidgets[row].rowCount || 0;
-        else 
-            h = 0;
-        if (!this.$useWrapMode || !this.$wrapData[row]) {
-            return 1 + h;
-        } else {
-            return this.$wrapData[row].length + 1 + h;
-        }
+            h += this.lineWidgets[row] && this.lineWidgets[row].rowCount || 0;
+        
+        if (!this.$useWrapMode || !this.$wrapData[row])
+            return h;
+        else
+            return this.$wrapData[row].length + h;
     };
     this.getRowLineCount = function(row) {
         if (!this.$useWrapMode || !this.$wrapData[row]) {
@@ -2299,6 +2298,9 @@ EditSession.$uid = 0;
                 wrapIndent = screenRowOffset > 0 ? wrapRow.indent : 0;
             }
         }
+        
+        if (this.lineWidgets && this.lineWidgets[row] && this.lineWidgets[row].rowsAbove)
+            screenRow += this.lineWidgets[row].rowsAbove;
 
         return {
             row: screenRow,

--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -2663,9 +2663,11 @@ Editor.$uid = 0;
     this.destroy = function() {
         this.renderer.destroy();
         this._signal("destroy", this);
-        if (this.session) {
+        if (this.session)
             this.session.destroy();
-        }
+        if (this._$emitInputEvent)
+            this._$emitInputEvent.cancel();
+        this.session = null;
     };
 
     /**

--- a/lib/ace/ext/code_lense.js
+++ b/lib/ace/ext/code_lense.js
@@ -31,6 +31,7 @@
 define(function(require, exports, module) {
 "use strict";
 var LineWidgets = require("../line_widgets").LineWidgets;
+var lang = require("../lib/lang");
 var dom = require("../lib/dom");
 
 function clearLenseElements(renderer) {
@@ -92,7 +93,7 @@ function renderWidgets(changes, renderer) {
             el.textContent = lenses[j].title;
             el.lenseCommand = lenses[j];
         }
-        while (lenseContainer.childNodes.length > j + 1) 
+        while (lenseContainer.childNodes.length > 2 * j - 1) 
             lenseContainer.lastChild.remove();
 
         var top = renderer.$cursorLayer.getPixelPosition({
@@ -124,25 +125,28 @@ function clearCodeLenseWidgets(session) {
 
 exports.setLenses = function(session, lenses) {
     var firstRow = Number.MAX_VALUE;
-    function add(lense) {
-        var row = lense.range.startLineNumber;
+
+    clearCodeLenseWidgets(session);
+    lenses && lenses.forEach(function(lense) {
+        var row = lense.start.row;
+        var column = lense.start.column;
         var widget = session.lineWidgets && session.lineWidgets[row];
         if (!widget || !widget.lenses) {
             widget = session.widgetManager.$registerLineWidget({
                 rowCount: 1,
                 rowsAbove: 1,
                 row: row,
+                column: column,
                 lenses: []
             });
         }
         widget.lenses.push(lense.command);
         if (row < firstRow)
             firstRow = row;
-    }
-
-    clearCodeLenseWidgets(session);
-    lenses.map(add);
+    });
     session._emit("changeFold", {data: {start: {row: firstRow}}});
+    
+    
 };
 
 function attachToEditor(editor) {
@@ -152,23 +156,66 @@ function attachToEditor(editor) {
         session.widgetManager.attach(editor);
     }
     editor.renderer.on("afterRender", renderWidgets);
-    editor.container.addEventListener("click", function(e) {
+    editor.$codeLenseClickHandler = function(e) {
         var command = e.target.lenseCommand;
         if (command)
             editor.execCommand(command.id, command.arguments);
-    });
+    };
+    editor.container.addEventListener("click", editor.$codeLenseClickHandler);
+    editor.$updateLenses = function() {
+        var session = editor.session;
+        if (!session) return;
+        var codeLensProvider = session.codeLensProvider || session.$mode.codeLensProvider;
+        var lenses = codeLensProvider && codeLensProvider.provideCodeLenses(session);
+        
+        var cursor = session.selection.cursor;
+        var oldRow = session.documentToScreenRow(cursor);
+        exports.setLenses(session, lenses);
+        
+        var lastDelta = session.$undoManager && session.$undoManager.$lastDelta;
+        if (lastDelta && lastDelta.action == "remove" && lastDelta.lines.length > 1)
+            return;
+        var row = session.documentToScreenRow(cursor);
+        var lineHeight = editor.renderer.layerConfig.lineHeight;
+        var top = session.getScrollTop() + (row - oldRow) * lineHeight;
+        session.setScrollTop(top);
+    };
+    var updateLenses = lang.delayedCall(editor.$updateLenses);
+    editor.$updateLensesOnInput = function() {
+        updateLenses.delay(250);
+    };
+    editor.on("input", editor.$updateLensesOnInput);
+}
+
+function detachFromEditor(editor) {
+    editor.off("input", editor.$updateLensesOnInput);
+    editor.renderer.off("afterRender", renderWidgets);
+    if (editor.$codeLenseClickHandler)
+        editor.container.removeEventListener("click", editor.$codeLenseClickHandler);
 }
 
 exports.setCodeLenseProvider = function(editor, codeLensProvider) {
-    attachToEditor(editor);
-    var session = editor.session;
-    function updateLenses() {
-        var lenses = codeLensProvider.provideCodeLenses(session);
-        exports.setLenses(session, lenses);
-    }
-    editor.on("input", updateLenses);
-    updateLenses();
+    editor.setOption("enableCodeLense", true);
+    editor.session.codeLensProvider = codeLensProvider;
+    editor.$updateLensesOnInput();
 };
+
+exports.clear = function(session) {
+    exports.setLenses(session, null);
+};
+
+var Editor = require("../editor").Editor;
+require("../config").defineOptions(Editor.prototype, "editor", {
+    enableCodeLense: {
+        set: function(val) {
+            if (val) {
+                attachToEditor(this);
+            } else {
+                detachFromEditor(this);
+            }
+        }
+    }
+});
 
 dom.importCssString("\
 .ace_codeLense {\

--- a/lib/ace/ext/code_lense.js
+++ b/lib/ace/ext/code_lense.js
@@ -1,0 +1,197 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2012, Ajax.org B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+define(function(require, exports, module) {
+"use strict";
+var LineWidgets = require("../line_widgets").LineWidgets;
+var dom = require("../lib/dom");
+
+function clearLenseElements(renderer) {
+    var textLayer = renderer.$textLayer;
+    var lenseElements = textLayer.$lenses;
+    if (lenseElements)
+        lenseElements.forEach(function(el) {el.remove(); });
+    textLayer.$lenses = null;
+}
+
+function renderWidgets(changes, renderer) {
+    var changed = changes & renderer.CHANGE_LINES 
+        || changes & renderer.CHANGE_FULL 
+        || changes & renderer.CHANGE_SCROLL
+        || changes & renderer.CHANGE_TEXT;
+    if (!changed) 
+        return;
+    
+    var session = renderer.session;
+    var lineWidgets = renderer.session.lineWidgets;
+    var textLayer = renderer.$textLayer;
+    var lenseElements = textLayer.$lenses;
+    if (!lineWidgets) {
+        if (lenseElements)
+            clearLenseElements(renderer);
+        return;
+    }
+
+    var textCells = renderer.$textLayer.$lines.cells;
+    var config = renderer.layerConfig;
+    var padding = renderer.$padding;
+
+    if (!lenseElements)
+        lenseElements = textLayer.$lenses = [];
+
+
+    var index = 0;
+    for (var i = 0; i < textCells.length; i++) {
+        var row = textCells[i].row;
+        var widget = lineWidgets[row];
+        var lenses = widget && widget.lenses;
+
+        if (!lenses || !lenses.length) continue;
+
+        var lenseContainer = lenseElements[index];
+        if (!lenseContainer) {
+            lenseContainer = lenseElements[index]
+                = dom.buildDom(["div", {class: "ace_codeLense"}], renderer.container);
+        }
+        lenseContainer.style.height = config.lineHeight + "px";
+        index++;
+
+        for (var j = 0; j < lenses.length; j++) {
+            var el = lenseContainer.childNodes[2 * j];
+            if (!el) {
+                if (j != 0) lenseContainer.appendChild(dom.createTextNode("\xa0|\xa0"));
+                el = dom.buildDom(["a"], lenseContainer);
+            }
+            el.textContent = lenses[j].title;
+            el.lenseCommand = lenses[j];
+        }
+        while (lenseContainer.childNodes.length > j + 1) 
+            lenseContainer.lastChild.remove();
+
+        var top = renderer.$cursorLayer.getPixelPosition({
+            row: row,
+            column: 0
+        }, true).top - config.lineHeight * widget.rowsAbove - config.offset;
+        lenseContainer.style.top = top + "px";
+        
+        var left = renderer.gutterWidth;
+        var indent = session.getLine(row).search(/\S|$/);
+        if (indent == -1)
+            indent = 0;
+        left += indent * config.characterWidth;
+        left -= renderer.scrollLeft;
+        lenseContainer.style.paddingLeft = padding + left + "px";
+    }
+    while (index < lenseElements.length)
+        lenseElements.pop().remove();
+}
+
+function clearCodeLenseWidgets(session) {
+    if (!session.lineWidgets) return;
+    var widgetManager = session.widgetManager;
+    session.lineWidgets.forEach(function(widget) {
+        if (widget && widget.lenses)
+            widgetManager.removeLineWidget(widget);
+    });
+}
+
+exports.setLenses = function(session, lenses) {
+    var firstRow = Number.MAX_VALUE;
+    function add(lense) {
+        var row = lense.range.startLineNumber;
+        var widget = session.lineWidgets && session.lineWidgets[row];
+        if (!widget || !widget.lenses) {
+            widget = session.widgetManager.$registerLineWidget({
+                rowCount: 1,
+                rowsAbove: 1,
+                row: row,
+                lenses: []
+            });
+        }
+        widget.lenses.push(lense.command);
+        if (row < firstRow)
+            firstRow = row;
+    }
+
+    clearCodeLenseWidgets(session);
+    lenses.map(add);
+    session._emit("changeFold", {data: {start: {row: firstRow}}});
+};
+
+function attachToEditor(editor) {
+    var session = editor.session;
+    if (!session.widgetManager) {
+        session.widgetManager = new LineWidgets(session);
+        session.widgetManager.attach(editor);
+    }
+    editor.renderer.on("afterRender", renderWidgets);
+    editor.container.addEventListener("click", function(e) {
+        var command = e.target.lenseCommand;
+        if (command)
+            editor.execCommand(command.id, command.arguments);
+    });
+}
+
+exports.setCodeLenseProvider = function(editor, codeLensProvider) {
+    attachToEditor(editor);
+    var session = editor.session;
+    function updateLenses() {
+        var lenses = codeLensProvider.provideCodeLenses(session);
+        exports.setLenses(session, lenses);
+    }
+    editor.on("input", updateLenses);
+    updateLenses();
+};
+
+dom.importCssString("\
+.ace_codeLense {\
+    position: absolute;\
+    color: #aaa;\
+    font-size: 88%;\
+    background: inherit;\
+    width: 100%;\
+    display: flex;\
+    align-items: flex-end;\
+    pointer-events: none;\
+}\
+.ace_codeLense > a {\
+    cursor: pointer;\
+    pointer-events: auto;\
+}\
+.ace_codeLense > a:hover {\
+    color: #0000ff;\
+    text-decoration: underline;\
+}\
+.ace_dark > .ace_codeLense > a:hover {\
+    color: #4e94ce;\
+}\
+", "");
+
+});

--- a/lib/ace/ext/code_lense_test.js
+++ b/lib/ace/ext/code_lense_test.js
@@ -82,8 +82,8 @@ module.exports = {
         codeLense.setCodeLenseProvider(editor, {
             provideCodeLenses: function(session) {
                 return [{
-                    range: {
-                        startLineNumber: 1
+                    start: {
+                        row: 1
                     },
                     command: {
                         id: commandId,
@@ -91,8 +91,8 @@ module.exports = {
                         arguments: "line"
                     }
                 }, {
-                    range: {
-                        startLineNumber: 1
+                    start: {
+                        row: 1
                     },
                     command: {
                         id: commandId,
@@ -100,8 +100,8 @@ module.exports = {
                         arguments: "column"
                     }
                 }, {
-                    range: {
-                        startLineNumber: editor.session.getLength() - 1
+                    start: {
+                        row: session.getLength() - 1
                     },
                     command: {
                         id: commandId,
@@ -111,6 +111,7 @@ module.exports = {
                 }];
             }
         });
+        editor.$updateLenses();
         editor.renderer.$loop._flush();
         var lense = editor.container.querySelector(".ace_codeLense");
         assert.equal(lense.textContent, "1\xa0|\xa02");

--- a/lib/ace/ext/code_lense_test.js
+++ b/lib/ace/ext/code_lense_test.js
@@ -1,0 +1,144 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Distributed under the BSD license:
+ *
+ * Copyright (c) 2010, Ajax.org B.V.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Ajax.org B.V. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL AJAX.ORG B.V. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+if (typeof process !== "undefined") {
+    require("amd-loader");
+    require("../test/mockdom");
+}
+
+define(function(require, exports, module) {
+"use strict";
+
+var ace = require("../ace");
+var codeLense = require("./code_lense");
+var assert = require("../test/assertions");
+require("./error_marker");
+
+function click(node) {
+    node.dispatchEvent(new window.CustomEvent("click", {bubbles: true}));
+}
+
+var editor = null;
+module.exports = {
+    setUp: function() {
+        if (editor)
+            editor.destroy();
+        var el = document.createElement("div");
+
+        el.style.left = "20px";
+        el.style.top = "30px";
+        el.style.width = "300px";
+        el.style.height = "100px";
+        document.body.appendChild(el);
+        editor = ace.edit(el);
+        editor.on("destroy", function() {
+            document.body.removeChild(el);
+        });
+    },
+    tearDown: function() {
+        editor && editor.destroy();
+        editor = null;
+    },
+    
+    "test code lense": function() {
+        editor.session.setValue("a\nb|c\nd" + "\n".repeat(100) + "\txxx");
+        
+        var commandId = "codeLenseAction";
+        var called = null;
+        editor.commands.addCommand({
+            name: commandId,
+            exec: function(editor, args) {
+                called = args;
+            }
+        });
+
+        codeLense.setCodeLenseProvider(editor, {
+            provideCodeLenses: function(session) {
+                return [{
+                    range: {
+                        startLineNumber: 1
+                    },
+                    command: {
+                        id: commandId,
+                        title: "1",
+                        arguments: "line"
+                    }
+                }, {
+                    range: {
+                        startLineNumber: 1
+                    },
+                    command: {
+                        id: commandId,
+                        title: "2",
+                        arguments: "column"
+                    }
+                }, {
+                    range: {
+                        startLineNumber: editor.session.getLength() - 1
+                    },
+                    command: {
+                        id: commandId,
+                        title: "last",
+                        arguments: "last"
+                    }
+                }];
+            }
+        });
+        editor.renderer.$loop._flush();
+        var lense = editor.container.querySelector(".ace_codeLense");
+        assert.equal(lense.textContent, "1\xa0|\xa02");
+        assert.equal(lense.childNodes.length, 3);
+        click(lense.childNodes[0]);
+        assert.equal(called, "line");
+        click(lense.childNodes[2]);
+        assert.equal(called, "column");
+        
+        editor.gotoLine(10);
+        editor.renderer.$loop._flush();
+        lense = editor.container.querySelector(".ace_codeLense");
+        assert.ok(!lense);
+
+        editor.gotoLine(200);
+        editor.renderer.$loop._flush();
+        lense = editor.container.querySelector(".ace_codeLense");
+        assert.equal(lense.textContent, "last");
+        
+        editor.setSession(ace.createEditSession("\n".repeat(100)));
+        editor.renderer.$loop._flush();
+        lense = editor.container.querySelector(".ace_codeLense");
+        assert.ok(!lense);
+    }
+};
+
+});
+
+if (typeof module !== "undefined" && module === require.main) {
+    require("asyncjs").test.testcase(module.exports).exec();
+}

--- a/lib/ace/layer/lines.js
+++ b/lib/ace/layer/lines.js
@@ -64,7 +64,7 @@ var Lines = function(element, canvasHeight) {
     };
     
     this.computeLineHeight = function(row, config, session) {
-        return config.lineHeight * session.getRowLength(row);
+        return config.lineHeight * session.getRowLineCount(row);
     };
     
     this.getLength = function() {
@@ -91,10 +91,10 @@ var Lines = function(element, canvasHeight) {
                 fragment.appendChild(cell[i].element);
             }
             this.element.appendChild(fragment);
-         } else {
+        } else {
             this.cells.push(cell);
             this.element.appendChild(cell.element);
-         }
+        }
     };
     
     this.unshift = function(cell) {
@@ -108,10 +108,10 @@ var Lines = function(element, canvasHeight) {
                 this.element.insertBefore(fragment, this.element.firstChild);
             else
                 this.element.appendChild(fragment);
-         } else {
+        } else {
             this.cells.unshift(cell);
             this.element.insertAdjacentElement("afterbegin", cell.element);
-         }
+        }
     };
     
     this.last = function() {

--- a/lib/ace/line_widgets.js
+++ b/lib/ace/line_widgets.js
@@ -202,6 +202,8 @@ function LineWidgets(session) {
         this.$registerLineWidget(w);
         w.session = this.session;
         
+        if (!this.editor) return w;
+        
         var renderer = this.editor.renderer;
         if (w.html && !w.el) {
             w.el = dom.createElement("div");
@@ -213,13 +215,13 @@ function LineWidgets(session) {
             w.el.style.zIndex = 5;
             renderer.container.appendChild(w.el);
             w._inDocument = true;
-        }
-        
-        if (!w.coverGutter) {
-            w.el.style.zIndex = 3;
-        }
-        if (w.pixelHeight == null) {
-            w.pixelHeight = w.el.offsetHeight;
+            
+            if (!w.coverGutter) {
+                w.el.style.zIndex = 3;
+            }
+            if (w.pixelHeight == null) {
+                w.pixelHeight = w.el.offsetHeight;
+            }
         }
         if (w.rowCount == null) {
             w.rowCount = w.pixelHeight / renderer.layerConfig.lineHeight;

--- a/lib/ace/line_widgets.js
+++ b/lib/ace/line_widgets.js
@@ -181,7 +181,7 @@ function LineWidgets(session) {
             this.session.lineWidgets = null;
     };
 
-    this.addLineWidget = function(w) {
+    this.$registerLineWidget = function(w) {
         if (!this.session.lineWidgets)
             this.session.lineWidgets = new Array(this.session.getLength());
         
@@ -195,7 +195,11 @@ function LineWidgets(session) {
         }
             
         this.session.lineWidgets[w.row] = w;
-        
+        return w;
+    };
+    
+    this.addLineWidget = function(w) {
+        this.$registerLineWidget(w);
         w.session = this.session;
         
         var renderer = this.editor.renderer;

--- a/lib/ace/line_widgets.js
+++ b/lib/ace/line_widgets.js
@@ -31,10 +31,7 @@
 define(function(require, exports, module) {
 "use strict";
 
-var oop = require("./lib/oop");
 var dom = require("./lib/dom");
-var Range = require("./range").Range;
-
 
 function LineWidgets(session) {
     this.session = session;
@@ -149,14 +146,21 @@ function LineWidgets(session) {
 
         if (len === 0) {
             // return
-        } else if (delta.action == 'remove') {
+        } else if (delta.action == "remove") {
             var removed = lineWidgets.splice(startRow + 1, len);
+            if (!lineWidgets[startRow] && removed[removed.length - 1]) {
+                lineWidgets[startRow] = removed.pop();
+            }
             removed.forEach(function(w) {
                 w && this.removeLineWidget(w);
             }, this);
             this.$updateRows();
         } else {
             var args = new Array(len);
+            if (lineWidgets[startRow] && lineWidgets[startRow].column != null) {
+                if (delta.start.column > lineWidgets[startRow].column)
+                    startRow++;
+            }
             args.unshift(startRow, 0);
             lineWidgets.splice.apply(lineWidgets, args);
             this.$updateRows();

--- a/lib/ace/selection.js
+++ b/lib/ace/selection.js
@@ -764,14 +764,19 @@ var Selection = function(session) {
             else
                 this.$desiredColumn = screenPos.column;
         }
-
+        
+        if (rows != 0 && this.session.lineWidgets && this.session.lineWidgets[this.lead.row]) {
+            var widget = this.session.lineWidgets[this.lead.row];
+            if (rows < 0)
+                rows -= widget.rowsAbove || 0;
+            else if (rows > 0)
+                rows += widget.rowCount - (widget.rowsAbove || 0);
+        }
+        
         var docPos = this.session.screenToDocumentPosition(screenPos.row + rows, screenPos.column, offsetX);
         
         if (rows !== 0 && chars === 0 && docPos.row === this.lead.row && docPos.column === this.lead.column) {
-            if (this.session.lineWidgets && this.session.lineWidgets[docPos.row]) {
-                if (docPos.row > 0 || rows > 0)
-                    docPos.row++;
-            }
+            
         }
 
         // move the cursor and update the desired column

--- a/lib/ace/selection_test.js
+++ b/lib/ace/selection_test.js
@@ -35,6 +35,7 @@ if (typeof process !== "undefined") {
 define(function(require, exports, module) {
 "use strict";
 
+var LineWidgets = require("./line_widgets").LineWidgets;
 var EditSession = require("./edit_session").EditSession;
 var assert = require("./test/assertions");
 var Range = require("./range").Range;
@@ -529,6 +530,43 @@ module.exports = {
         selection.setRange(new Range(1, 1, 1, 5)); 
         
         assert.equal(session.getTextRange(), "fold");
+    },
+    
+    "test navigate around line widgets": function() {
+        var session = new EditSession(["a", "b", "", "c", "d"]);
+        session.widgetManager = new LineWidgets(session);
+
+        var selection = session.getSelection();
+
+        session.widgetManager.addLineWidget({
+            row: 0,
+            rowCount: 5,
+            rowsAbove: 2,
+        });
+        session.widgetManager.addLineWidget({
+            row: 1,
+            rowCount: 3,
+            rowsAbove: 1,
+        });
+        session.widgetManager.addLineWidget({
+            row: 3,
+            rowCount: 4
+        });
+        assert.position(session.documentToScreenPosition(3, 1), 11, 1);
+        
+        session.selection.moveCursorLineEnd();
+        session.selection.moveCursorUp();
+        assert.position(selection.cursor, 0, 0);
+        session.selection.moveCursorDown();
+        assert.position(selection.cursor, 1, 1);
+        session.selection.moveCursorDown();
+        assert.position(selection.cursor, 2, 0);
+        session.selection.moveCursorDown();
+        assert.position(selection.cursor, 3, 1);
+        session.selection.moveCursorUp();
+        assert.position(selection.cursor, 2, 0);
+        session.selection.moveCursorUp();
+        assert.position(selection.cursor, 1, 1);
     },
 
     "test selectLine": function() {

--- a/lib/ace/selection_test.js
+++ b/lib/ace/selection_test.js
@@ -541,12 +541,12 @@ module.exports = {
         session.widgetManager.addLineWidget({
             row: 0,
             rowCount: 5,
-            rowsAbove: 2,
+            rowsAbove: 2
         });
         session.widgetManager.addLineWidget({
             row: 1,
             rowCount: 3,
-            rowsAbove: 1,
+            rowsAbove: 1
         });
         session.widgetManager.addLineWidget({
             row: 3,

--- a/lib/ace/test/all_browser.js
+++ b/lib/ace/test/all_browser.js
@@ -26,6 +26,7 @@ var testNames = [
     "ace/ext/static_highlight_test",
     "ace/ext/whitespace_test",
     "ace/ext/error_marker_test",
+    "ace/ext/code_lense_test",
     "ace/incremental_search_test",
     "ace/keyboard/emacs_test",
     "ace/keyboard/textinput_test",

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -837,7 +837,7 @@ var VirtualRenderer = function(container, theme) {
         }
         // this.$logChanges(changes);
         
-        this._signal("beforeRender");
+        this._signal("beforeRender", changes);
         
         if (this.session && this.session.$bidiHandler)
             this.session.$bidiHandler.updateCharacterWidths(this.$fontMetrics);
@@ -897,7 +897,7 @@ var VirtualRenderer = function(container, theme) {
             this.$markerFront.update(config);
             this.$cursorLayer.update(config);
             this.$moveTextAreaToCursor();
-            this._signal("afterRender");
+            this._signal("afterRender", changes);
             return;
         }
 
@@ -919,7 +919,7 @@ var VirtualRenderer = function(container, theme) {
             this.$markerFront.update(config);
             this.$cursorLayer.update(config);
             this.$moveTextAreaToCursor();
-            this._signal("afterRender");
+            this._signal("afterRender", changes);
             return;
         }
 
@@ -955,7 +955,7 @@ var VirtualRenderer = function(container, theme) {
             this.$markerBack.update(config);
         }
 
-        this._signal("afterRender");
+        this._signal("afterRender", changes);
     };
 
     


### PR DESCRIPTION
can be tested at https://raw.githack.com/ajaxorg/ace/code-lense/demo/code_lense.html
to change theme use `cmd-,`

- adds support for displaying widgets above the line
- passes `changes` number to `before/afterRender` event handlers
- fixes bug with moveSelection across lineWidgets

TODO:
- show multiple lineWidgets added to the same line
- move cursor to previous line when clicking on upper half of lineWidget
- decide what should be the api exposed by the extension in ace, `registerCodeLenseProvider` for mode that handles promises/callbacks, or simply setLenses(session, lenses)