### PR TITLE
Prevent corrupted document state because of out-of-sync undo stack

### DIFF
--- a/lib/ace/undomanager.js
+++ b/lib/ace/undomanager.js
@@ -141,7 +141,26 @@ var UndoManager = function() {
         if (to == null) to = this.$rev + 1;
         
     };
-    
+
+    this.validateDeltaBoundaries = function(deltaSet, docLength, invertAction) {
+        if (!deltaSet || !deltaSet.length) {
+            return false;
+        }
+        return deltaSet.every(function(delta) {
+            var action = delta.action;
+            if (invertAction && delta.action === "insert") action = "remove";
+            if (invertAction && delta.action === "remove") action = "insert";
+            switch(action) {
+                case "insert":
+                    return delta.start.row <= docLength;
+                case "remove":
+                    return delta.start.row < docLength && delta.end.row < docLength;
+                default:
+                    return true;
+            }
+        });
+    };
+
     /**
      * [Perform an undo operation on the document, reverting the last change.]{: #UndoManager.undo}
      * @param {Boolean} dontSelect {:dontSelect}
@@ -165,7 +184,7 @@ var UndoManager = function() {
         
         var deltaSet = stack.pop();
         var undoSelectionRange = null;
-        if (deltaSet && deltaSet.length) {
+        if (this.validateDeltaBoundaries(deltaSet, session.getLength(), true)) {
             undoSelectionRange = session.undoChanges(deltaSet, dontSelect);
             this.$redoStack.push(deltaSet);
             this.$syncRev();
@@ -199,7 +218,7 @@ var UndoManager = function() {
         var deltaSet = this.$redoStack.pop();
         var redoSelectionRange = null;
         
-        if (deltaSet) {
+        if (this.validateDeltaBoundaries(deltaSet, session.getLength(), false)) {
             redoSelectionRange = session.redoChanges(deltaSet, dontSelect);
             this.$undoStack.push(deltaSet);
             this.$syncRev();

--- a/lib/ace/undomanager.js
+++ b/lib/ace/undomanager.js
@@ -143,7 +143,7 @@ var UndoManager = function() {
     };
 
     this.validateDeltaBoundaries = function(deltaSet, docLength, invertAction) {
-        if (!deltaSet || !deltaSet.length) {
+        if (!deltaSet) {
             return false;
         }
         return deltaSet.every(function(delta) {

--- a/lib/ace/undomanager.js
+++ b/lib/ace/undomanager.js
@@ -188,9 +188,6 @@ var UndoManager = function() {
             undoSelectionRange = session.undoChanges(deltaSet, dontSelect);
             this.$redoStack.push(deltaSet);
             this.$syncRev();
-        } else if (deltaSet) {
-            // DeltaSet exists, but it's incorrect - reset the state
-            this.reset();
         }
         
         this.$fromUndo = false;
@@ -225,9 +222,6 @@ var UndoManager = function() {
             redoSelectionRange = session.redoChanges(deltaSet, dontSelect);
             this.$undoStack.push(deltaSet);
             this.$syncRev();
-        } else if (deltaSet) {
-            // DeltaSet exists, but it's incorrect - reset the state
-            this.reset();
         }
         this.$fromUndo = false;
         

--- a/lib/ace/undomanager.js
+++ b/lib/ace/undomanager.js
@@ -188,6 +188,9 @@ var UndoManager = function() {
             undoSelectionRange = session.undoChanges(deltaSet, dontSelect);
             this.$redoStack.push(deltaSet);
             this.$syncRev();
+        } else if (deltaSet) {
+            // DeltaSet exists, but it's incorrect - reset the state
+            this.reset();
         }
         
         this.$fromUndo = false;
@@ -222,6 +225,9 @@ var UndoManager = function() {
             redoSelectionRange = session.redoChanges(deltaSet, dontSelect);
             this.$undoStack.push(deltaSet);
             this.$syncRev();
+        } else if (deltaSet) {
+            // DeltaSet exists, but it's incorrect - reset the state
+            this.reset();
         }
         this.$fromUndo = false;
         

--- a/lib/ace/undomanager_test.js
+++ b/lib/ace/undomanager_test.js
@@ -325,7 +325,7 @@ module.exports = {
             action: "remove",
             start: {row: 3, column: 0},
             end: {row: 5, column: 0},
-            lines: ["hello", "world"],
+            lines: ["hello", "world"]
         });
         editor.undo();
         assert.equal(editor.getValue(), "012\n345\n678\nhello\nworld");
@@ -336,7 +336,7 @@ module.exports = {
             action: "remove",
             start: {row: 5, column: 0},
             end: {row: 7, column: 0},
-            lines: ["hello", "world"],
+            lines: ["hello", "world"]
         });
         editor.undo();
         assert.equal(editor.getValue(), "012\n345\n678");
@@ -346,7 +346,7 @@ module.exports = {
             action: "insert",
             start: {row: 3, column: 0},
             end: {row: 5, column: 0},
-            lines: ["hello", "world"],
+            lines: ["hello", "world"]
         });
         editor.undo();
         assert.equal(editor.getValue(), "012\n345\n678");
@@ -356,45 +356,9 @@ module.exports = {
             action: "remove",
             start: {row: 2, column: 0},
             end: {row: 4, column: 0},
-            lines: ["hello", "world"],
+            lines: ["hello", "world"]
         }]);
         editor.redo();
-        assert.equal(editor.getValue(), "012\n345\n678");
-    },
-    "test: reset the state in case of incorrect delta during undo uperation": function() {
-        session.setValue("012\n345\n678");
-        var delta = {
-            action: "insert",
-            start: {row: 6, column: 0},
-            end: {row: 8, column: 0},
-            lines: ["hello", "world"],
-        };
-        undoManager.add(Object.assign({}, delta), false);
-        undoManager.add(Object.assign({}, delta), false);
-        assert.equal(undoManager.$undoStack.length, 2);
-        editor.undo();
-        assert.equal(undoManager.$undoStack.length, 0);
-        assert.equal(undoManager.$rev, 0);
-        assert.equal(editor.getValue(), "012\n345\n678");
-    },
-    "test: reset the state in case of incorrect delta during redo uperation": function() {
-        session.setValue("012\n345\n678");
-        var delta = {
-            action: "insert",
-            start: {row: 6, column: 0},
-            end: {row: 8, column: 0},
-            lines: ["hello", "world"],
-        };
-        undoManager.add(Object.assign({}, delta), false);
-        undoManager.add(Object.assign({}, delta), false);
-        undoManager.$redoStack.push([delta]);
-        undoManager.$redoStack.push([delta]);
-        assert.equal(undoManager.$undoStack.length, 2);
-        assert.equal(undoManager.$redoStack.length, 2);
-        editor.redo();
-        assert.equal(undoManager.$undoStack.length, 0);
-        assert.equal(undoManager.$redoStack.length, 0);
-        assert.equal(undoManager.$rev, 0);
         assert.equal(editor.getValue(), "012\n345\n678");
     }
 };

--- a/lib/ace/undomanager_test.js
+++ b/lib/ace/undomanager_test.js
@@ -318,7 +318,7 @@ module.exports = {
             lines: ["hello", "world"]
         });
         editor.undo();
-        assert.equal(editor.getValue(), "012\nhello\nworld345\n678", "undo: correct 'insert' delta is not ignored");
+        assert.equal(editor.getValue(), "012\nhello\nworld345\n678");
 
         session.setValue("012\n345\n678");
         undoManager.add({
@@ -328,7 +328,7 @@ module.exports = {
             lines: ["hello", "world"],
         });
         editor.undo();
-        assert.equal(editor.getValue(), "012\n345\n678\nhello\nworld", "undo: correct 'insert' delta is not ingored");
+        assert.equal(editor.getValue(), "012\n345\n678\nhello\nworld");
 
 
         session.setValue("012\n345\n678");
@@ -339,7 +339,7 @@ module.exports = {
             lines: ["hello", "world"],
         });
         editor.undo();
-        assert.equal(editor.getValue(), "012\n345\n678", "undo: incorrect 'insert' delta is ignored");
+        assert.equal(editor.getValue(), "012\n345\n678");
 
         session.setValue("012\n345\n678");
         undoManager.add({
@@ -349,7 +349,7 @@ module.exports = {
             lines: ["hello", "world"],
         });
         editor.undo();
-        assert.equal(editor.getValue(), "012\n345\n678", "undo: incorrect 'remove' delta is ignored");
+        assert.equal(editor.getValue(), "012\n345\n678");
 
         session.setValue("012\n345\n678");
         undoManager.$redoStack.push([{
@@ -359,7 +359,43 @@ module.exports = {
             lines: ["hello", "world"],
         }]);
         editor.redo();
-        assert.equal(editor.getValue(), "012\n345\n678", "redo: incorrect 'remove' delta is ignored");
+        assert.equal(editor.getValue(), "012\n345\n678");
+    },
+    "test: reset the state in case of incorrect delta during undo uperation": function() {
+        session.setValue("012\n345\n678");
+        var delta = {
+            action: "insert",
+            start: {row: 6, column: 0},
+            end: {row: 8, column: 0},
+            lines: ["hello", "world"],
+        };
+        undoManager.add(Object.assign({}, delta), false);
+        undoManager.add(Object.assign({}, delta), false);
+        assert.equal(undoManager.$undoStack.length, 2);
+        editor.undo();
+        assert.equal(undoManager.$undoStack.length, 0);
+        assert.equal(undoManager.$rev, 0);
+        assert.equal(editor.getValue(), "012\n345\n678");
+    },
+    "test: reset the state in case of incorrect delta during redo uperation": function() {
+        session.setValue("012\n345\n678");
+        var delta = {
+            action: "insert",
+            start: {row: 6, column: 0},
+            end: {row: 8, column: 0},
+            lines: ["hello", "world"],
+        };
+        undoManager.add(Object.assign({}, delta), false);
+        undoManager.add(Object.assign({}, delta), false);
+        undoManager.$redoStack.push([delta]);
+        undoManager.$redoStack.push([delta]);
+        assert.equal(undoManager.$undoStack.length, 2);
+        assert.equal(undoManager.$redoStack.length, 2);
+        editor.redo();
+        assert.equal(undoManager.$undoStack.length, 0);
+        assert.equal(undoManager.$redoStack.length, 0);
+        assert.equal(undoManager.$rev, 0);
+        assert.equal(editor.getValue(), "012\n345\n678");
     }
 };
 

--- a/lib/ace/undomanager_test.js
+++ b/lib/ace/undomanager_test.js
@@ -308,6 +308,58 @@ module.exports = {
         assert.equal(session.$undoManager.$redoStack.length, 1);
         session.insert({row: 0, column: 0}, "y");
         assert.equal(session.$undoManager.$redoStack.length, 0);
+    },
+    "test: ignore deltas with incorrect boundaries": function () {
+        session.setValue("012\n345\n678");
+        undoManager.add({
+            action: "remove",
+            start: {row: 1, column: 0},
+            end: {row: 3, column: 0},
+            lines: ["hello", "world"]
+        });
+        editor.undo();
+        assert.equal(editor.getValue(), "012\nhello\nworld345\n678", "undo: correct 'insert' delta is not ignored");
+
+        session.setValue("012\n345\n678");
+        undoManager.add({
+            action: "remove",
+            start: {row: 3, column: 0},
+            end: {row: 5, column: 0},
+            lines: ["hello", "world"],
+        });
+        editor.undo();
+        assert.equal(editor.getValue(), "012\n345\n678\nhello\nworld", "undo: correct 'insert' delta is not ingored");
+
+
+        session.setValue("012\n345\n678");
+        undoManager.add({
+            action: "remove",
+            start: {row: 5, column: 0},
+            end: {row: 7, column: 0},
+            lines: ["hello", "world"],
+        });
+        editor.undo();
+        assert.equal(editor.getValue(), "012\n345\n678", "undo: incorrect 'insert' delta is ignored");
+
+        session.setValue("012\n345\n678");
+        undoManager.add({
+            action: "insert",
+            start: {row: 3, column: 0},
+            end: {row: 5, column: 0},
+            lines: ["hello", "world"],
+        });
+        editor.undo();
+        assert.equal(editor.getValue(), "012\n345\n678", "undo: incorrect 'remove' delta is ignored");
+
+        session.setValue("012\n345\n678");
+        undoManager.$redoStack.push([{
+            action: "remove",
+            start: {row: 2, column: 0},
+            end: {row: 4, column: 0},
+            lines: ["hello", "world"],
+        }]);
+        editor.redo();
+        assert.equal(editor.getValue(), "012\n345\n678", "redo: incorrect 'remove' delta is ignored");
     }
 };
 


### PR DESCRIPTION
In the case when undo stack is out-of-sync with document value, applying deltas from the stack can result in corrupted document state.

*Description of changes:*
- Check delta boundaries in undo-manager before applying them.
- If incorrect delta is detected, reset the undo-manager state, since we can't trust it anymore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
