### PR TITLE
Fix in-editor cursor bug due to strange ligatures

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -53,6 +53,7 @@ styles.join("\n")
     box-sizing: border-box;
     min-width: 100%;
     contain: style size layout;
+    font-variant-ligatures: no-common-ligatures;
 }
 
 .ace_dragging .ace_scroller:before{


### PR DESCRIPTION
Adding a CSS rule to `.ace_content` solves the issue.

Fixes #3032.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
