### PR TITLE
Allow snippets to be registered with provided docHTML for completions.

### DIFF
--- a/lib/ace/ext/language_tools.js
+++ b/lib/ace/ext/language_tools.js
@@ -73,6 +73,7 @@ var snippetCompleter = {
                     caption: caption,
                     snippet: s.content,
                     meta: s.tabTrigger && !s.name ? s.tabTrigger + "\u21E5 " : "snippet",
+                    docHTML: s.docHTML,
                     type: "snippet"
                 });
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allows snippets to be registered with a provided docHTML rather than forcing it to be generated from the snippet itself.

e.g.

aceEditorSnippetManager.register(
  [{ name: 'color', tabTrigger: 'color', content: "color('${1:name}')", docHTML: '<b>docHTML</b>' }],
  "javascript");

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
