### PR TITLE
Support code lens in multiple sessions

### DIFF
--- a/lib/ace/ext/code_lens.js
+++ b/lib/ace/ext/code_lens.js
@@ -148,12 +148,7 @@ exports.setLenses = function(session, lenses) {
 };
 
 function attachToEditor(editor) {
-    var session = editor.session;
-    if (!session.widgetManager) {
-        session.widgetManager = new LineWidgets(session);
-        session.widgetManager.attach(editor);
-    }
-    session.codeLensProviders = [];
+    editor.codeLensProviders = [];
     editor.renderer.on("afterRender", renderWidgets);
     editor.$codeLensClickHandler = function(e) {
         var command = e.target.lensCommand;
@@ -164,9 +159,15 @@ function attachToEditor(editor) {
     editor.$updateLenses = function() {
         var session = editor.session;
         if (!session) return;
-        var providersToWaitNum = session.codeLensProviders.length;
+
+        if (!session.widgetManager) {
+            session.widgetManager = new LineWidgets(session);
+            session.widgetManager.attach(editor);
+        }
+
+        var providersToWaitNum = editor.codeLensProviders.length;
         var lenses = [];
-        session.codeLensProviders.forEach(function(provider) {
+        editor.codeLensProviders.forEach(function(provider) {
             provider.provideCodeLenses(session, function(currentLenses) {
                 currentLenses.forEach(function(lens) {
                     lenses.push(lens);
@@ -208,7 +209,7 @@ function detachFromEditor(editor) {
 
 exports.registerCodeLensProvider = function(editor, codeLensProvider) {
     editor.setOption("enableCodeLens", true);
-    editor.session.codeLensProviders.push(codeLensProvider);
+    editor.codeLensProviders.push(codeLensProvider);
     editor.$updateLensesOnInput();
 };
 

--- a/lib/ace/ext/code_lens_test.js
+++ b/lib/ace/ext/code_lens_test.js
@@ -221,6 +221,28 @@ module.exports = {
         editor.renderer.$loop._flush();
         var lens = editor.container.querySelector(".ace_codeLens");
         assert.equal(lens.textContent, "1\xa0|\xa02");
+    },
+
+    "test code lens behavior with multiple sessions": function() {
+        editor.session.setValue("a\nb");
+        codeLens.registerCodeLensProvider(editor, {
+            provideCodeLenses: function(session, callback) {
+                callback([{
+                    start: { row: 1 },
+                    command: { title: session.doc.$lines[0] }
+                }]);
+            }
+        });
+        editor.$updateLenses();
+        editor.renderer.$loop._flush();
+        var lens = editor.container.querySelector(".ace_codeLens");
+        assert.equal(lens.textContent, "a");
+
+        editor.setSession(ace.createEditSession("c\nd"));
+        editor.$updateLenses();
+        editor.renderer.$loop._flush();
+        var lens = editor.container.querySelector(".ace_codeLens");
+        assert.equal(lens.textContent, "c");
     }
 };
 


### PR DESCRIPTION
When switching between editor sessions, code lens providers should continue functioning. This PR is to support this behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
