### PR TITLE
Improve VHDL highlighting

### DIFF
--- a/demo/kitchen-sink/docs/vhdl.vhd
+++ b/demo/kitchen-sink/docs/vhdl.vhd
@@ -1,5 +1,5 @@
-library IEEE
-user IEEE.std_logic_1164.all;
+library IEEE;
+use IEEE.std_logic_1164.all;
 use IEEE.numeric_std.all;
 
 entity COUNT16 is
@@ -14,7 +14,7 @@ entity COUNT16 is
 end entity;
 
 architecture count_rtl of COUNT16 is
-    signal count :std_logic_vector (15 downto 0);
+    signal count : unsigned (15 downto 0);
     
 begin
     process (clk, rst) begin
@@ -28,7 +28,7 @@ begin
         end if;
         
     end process;
-    cOut <= count;
+    cOut <= std_logic_vector(count);
 
 end architecture;
-    
+

--- a/lib/ace/mode/_test/tokens_vhdl.json
+++ b/lib/ace/mode/_test/tokens_vhdl.json
@@ -124,7 +124,7 @@
 ],[
    "start",
   ["text","    "],
-  ["storage.type","signal"],
+  ["keyword","signal"],
   ["text"," "],
   ["identifier","count"],
   ["text"," "],

--- a/lib/ace/mode/vhdl_highlight_rules.js
+++ b/lib/ace/mode/vhdl_highlight_rules.js
@@ -41,15 +41,14 @@ var VHDLHighlightRules = function() {
                    "begin|block|buffer|bus|case|component|configuration|"+
                    "disconnect|downto|else|elsif|end|entity|file|for|function|"+
                    "generate|generic|guarded|if|impure|in|inertial|inout|is|"+
-                   "label|linkage|literal|loop|mapnew|next|of|on|open|"+
-                   "others|out|port|process|pure|range|record|reject|"+
-                   "report|return|select|shared|subtype|then|to|transport|"+
+                   "label|linkage|literal|loop|mapnew|next|of|on|open|others|"+
+                   "out|port|process|pure|range|record|reject|report|return|"+
+                   "select|severity|shared|signal|subtype|then|to|transport|"+
                    "type|unaffected|united|until|wait|when|while|with";
     
     var storageType = "bit|bit_vector|boolean|character|integer|line|natural|"+
-                      "positive|real|register|severity|signal|signed|"+
-                      "std_logic|std_logic_vector|string||text|time|unsigned|"+
-                      "variable";
+                      "positive|real|register|signed|std_logic|"+
+                      "std_logic_vector|string||text|time|unsigned|variable";
     
     var storageModifiers = "array|constant";
     


### PR DESCRIPTION
This PR includes a couple of small improvements to VHDL syntax highlighting.

First, two keywords "signal" and "severity" should be keywords, not data types.

Second, I cleaned up the kitchen sink example so that it's actually valid VHDL.
