### PR TITLE
Fix incorrect Xcode casing

### DIFF
--- a/lib/ace/ext/themelist.js
+++ b/lib/ace/ext/themelist.js
@@ -54,7 +54,7 @@ var themeData = [
     ["Solarized Light"],
     ["TextMate"       ],
     ["Tomorrow"       ],
-    ["XCode"          ],
+    ["Xcode"          ],
     ["Kuroir"],
     ["KatzenMilch"],
     ["SQL Server"           ,"sqlserver"               , "light"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The correct casing is "Xcode", not "XCode".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
