### PR TITLE
Mobile scroll fix

### DIFF
--- a/lib/ace/mouse/touch_handler.js
+++ b/lib/ace/mouse/touch_handler.js
@@ -251,7 +251,6 @@ exports.addTouchListeners = function(el, editor) {
             showContextMenu();
         } else if (mode == "scroll") {
             animate();
-            e.preventDefault();
             hideContextMenu();
         } else {
             showContextMenu();


### PR DESCRIPTION
Issue #4168

Removing **preventDefault** method on **touchend** event, **mode = "scroll"**. This will prevent virtual keyboard from opening when scrolling on the editor and has focus at the same time.

```javascript
event.addListener(el, "touchend", function (e) {
  .
  .
   else if (mode == "scroll") {
        animate();
        // event.preventDefault();  -> removed 
        hideContextMenu();
    }
  .
  .
});
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.