### PR TITLE
accessibility fixes to Kitchen Sink demo page

### DIFF
--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -255,13 +255,22 @@ commands.addCommand({
 
 
 /*********** manage layout ***************************/
-var sidePanelContainer = document.getElementById("sidePanel");
-sidePanelContainer.onclick = function(e) {
+function handleToggleActivate(target) {
     if (dom.hasCssClass(sidePanelContainer, "closed"))
         onResize(null, false);
-    else if (dom.hasCssClass(e.target, "toggleButton"))
+    else if (dom.hasCssClass(target, "toggleButton"))
         onResize(null, true);
-}
+};
+var sidePanelContainer = document.getElementById("sidePanel");
+sidePanelContainer.onclick = function(e) {
+    handleToggleActivate(e.target);
+};
+var optionToggle = document.getElementById("optionToggle");
+optionToggle.onkeydown = function(e) {
+    if (e.code === "Space" || e.code === "Enter") {
+        handleToggleActivate(e.target);
+    }
+};
 var consoleHeight = 20;
 function onResize(e, closeSidePanel) {
     var left = 280;
@@ -269,8 +278,11 @@ function onResize(e, closeSidePanel) {
     var height = document.documentElement.clientHeight;
     if (closeSidePanel == null)
         closeSidePanel = width < 2 * left;
-    if (closeSidePanel)
+    if (closeSidePanel) {
         left = 20;
+        document.getElementById("optionToggle").setAttribute("aria-label", "Show Options");
+    } else
+        document.getElementById("optionToggle").setAttribute("aria-label", "Hide Options");
     width -= left;
     container.style.width = width + "px";
     container.style.height = height - consoleHeight + "px";

--- a/demo/kitchen-sink/dev_util.js
+++ b/demo/kitchen-sink/dev_util.js
@@ -293,13 +293,13 @@ function toString(x) {
 }
 
 exports.getUI = function(container) {
-    return ["div", {},
+    return ["div", {role: "group", "aria-label": "Test"},
         " Test ", 
-        ["button", {onclick: exports.openLogView}, "O"],
+        ["button", {"aria-label": "Open Log View", onclick: exports.openLogView}, "O"],
         ["button", {onclick: exports.record}, "Record"],
         ["button", {onclick: exports.stop}, "Stop"],
         ["button", {onclick: exports.play}, "Play"],
-        ["button", {onclick: exports.closeLogView}, "X"],
+        ["button", {"aria-label": "Close Log View", onclick: exports.closeLogView}, "X"],
     ];
 };
 

--- a/demo/kitchen-sink/styles.css
+++ b/demo/kitchen-sink/styles.css
@@ -60,7 +60,16 @@ body {
     background-color: #eee;
     pointer-events: none;
     transition: 0.5s;
-} 
+}
+
+#sidePanel *:focus {
+    outline: 3px solid orange;
+}
+
+#sidePanel a {
+    display: inline-block;
+}
+
 #sidePanel:not(.closed) .toggleButton >div:nth-child(1) {transform: translate(0px, 5px) rotate(-45deg)}
 #sidePanel:not(.closed) .toggleButton >div:nth-child(2) {opacity: 0}
 #sidePanel:not(.closed) .toggleButton >div:nth-child(3) {transform: translate(0px, -5px) rotate(45deg)}

--- a/kitchen-sink.html
+++ b/kitchen-sink.html
@@ -21,18 +21,18 @@
 </head>
 <body>
 <div id="sidePanel" style="position:absolute;height:100%;">
-  <div class="toggleButton">
+  <div class="toggleButton" id="optionToggle" role="button" aria-label="Hide Options" tabindex="0">
     <div></div><div></div><div></div>
   </div>
-  <a href="https://c9.io" title="Cloud9 IDE | Your code anywhere, anytime">
-    <img id="c9-logo" src="demo/kitchen-sink/logo.png" style="width: 172px;margin: -9px 30px -12px 51px;">
+  <a href="https://c9.io">
+    <img id="c9-logo" alt="Cloud9 IDE | Your code anywhere, anytime" src="demo/kitchen-sink/logo.png" style="width: 172px;margin: -9px 30px -12px 51px;">
   </a>
   <div style="position: absolute; overflow: hidden; top:100px; bottom:0">
   <div id="optionsPanel" style="width: 120%; height:100%; overflow-y: scroll">
 
   
   <a href="https://ace.c9.io">
-    <img id="ace-logo" src="doc/site/images/ace-logo.png" style="width: 134px;margin: 46px 0px 4px 66px;">
+    <img id="ace-logo" alt="Ace Website" src="doc/site/images/ace-logo.png" style="width: 134px;margin: 46px 0px 4px 66px;">
   </a>
 <!--DEVEL-->
   <div style="text-align: left; padding: 0.5em 1em;">

--- a/lib/ace/ext/options.js
+++ b/lib/ace/ext/options.js
@@ -258,7 +258,7 @@ var OptionPanel = function(editor, element) {
                 return ["button", { 
                     value: item.value, 
                     ace_selected_button: value == item.value, 
-                    ['aria-pressed']: value == item.value, 
+                    'aria-pressed': value == item.value, 
                     onclick: function() {
                         self.setOption(option, item.value);
                         var nodes = this.parentNode.querySelectorAll("[ace_selected_button]");

--- a/lib/ace/ext/options.js
+++ b/lib/ace/ext/options.js
@@ -85,6 +85,7 @@ var optionGroups = {
         "Soft Tabs": [{
             path: "useSoftTabs"
         }, {
+            ariaLabel: "Tab Size",
             path: "tabSize",
             type: "number",
             values: [2, 3, 4, 8, 16]
@@ -120,11 +121,12 @@ var optionGroups = {
         "Show Indent Guides": {
             path: "displayIndentGuides"
         },
-        "Persistent Scrollbar": [{
+        "Persistent HScrollbar": {
             path: "hScrollBarAlwaysVisible"
-        }, {
+        },
+        "Persistent VScrollbar": {
             path: "vScrollBarAlwaysVisible"
-        }],
+        },
         "Animate scrolling": {
             path: "animatedScroll"
         },
@@ -143,6 +145,7 @@ var optionGroups = {
         "Show Print Margin": [{
             path: "showPrintMargin"
         }, {
+            ariaLabel: "Print Margin",
             type: "number",
             path: "printMarginColumn"
         }],
@@ -205,10 +208,10 @@ var OptionPanel = function(editor, element) {
     
     this.render = function() {
         this.container.innerHTML = "";
-        buildDom(["table", {id: "controls"}, 
+        buildDom(["table", {role: "presentation", id: "controls"}, 
             this.renderOptionGroup(optionGroups.Main),
             ["tr", null, ["td", {colspan: 2},
-                ["table", {id: "more-controls"}, 
+                ["table", {role: "presentation", id: "more-controls"}, 
                     this.renderOptionGroup(optionGroups.More)
                 ]
             ]],
@@ -251,17 +254,20 @@ var OptionPanel = function(editor, element) {
         }
         
         if (option.type == "buttonBar") {
-            control = ["div", option.items.map(function(item) {
+            control = ["div", {role: "group", "aria-labelledby": option.path + "-label"}, option.items.map(function(item) {
                 return ["button", { 
                     value: item.value, 
                     ace_selected_button: value == item.value, 
+                    ['aria-pressed']: value == item.value, 
                     onclick: function() {
                         self.setOption(option, item.value);
                         var nodes = this.parentNode.querySelectorAll("[ace_selected_button]");
                         for (var i = 0; i < nodes.length; i++) {
                             nodes[i].removeAttribute("ace_selected_button");
+                            nodes[i].setAttribute("aria-pressed", false);
                         }
                         this.setAttribute("ace_selected_button", true);
+                        this.setAttribute("aria-pressed", true);
                     } 
                 }, item.desc || item.caption || item.name];
             })];
@@ -269,6 +275,11 @@ var OptionPanel = function(editor, element) {
             control = ["input", {type: "number", value: value || option.defaultValue, style:"width:3em", oninput: function() {
                 self.setOption(option, parseInt(this.value));
             }}];
+            if (option.ariaLabel) {
+                control[1]["aria-label"] = option.ariaLabel;
+            } else {
+                control[1].id = key;
+            }
             if (option.defaults) {
                 control = [control, option.defaults.map(function(item) {
                     return ["button", {onclick: function() {
@@ -312,11 +323,13 @@ var OptionPanel = function(editor, element) {
     this.renderOption = function(key, option) {
         if (option.path && !option.onchange && !this.editor.$options[option.path])
             return;
-        this.options[option.path] = option;
-        var safeKey = "-" + option.path;
+        var path = Array.isArray(option) ? option[0].path : option.path;
+        this.options[path] = option;
+        var safeKey = "-" + path;
+        var safeId = path + "-label";
         var control = this.renderOptionControl(safeKey, option);
         return ["tr", {class: "ace_optionsMenuEntry"}, ["td",
-            ["label", {for: safeKey}, key]
+            ["label", {for: safeKey, id: safeId}, key]
         ], ["td", control]];
     };
     


### PR DESCRIPTION
*Description of changes:*

I will be working with a developer who is blind to help evaluate Ace accessibility improvements I'll be making so having the kitchen sink be usable by him is potentially helpful.

Also doing this for the practice and to avoid working on the more difficult problems of screen reader support in Ace itself just a little bit longer. :-)

- Fix the toggle control in upper-left to work like a button (keyboard and screen reader in addition to mouse), and give it a label for screen readers
- Mark layout tables as being for presentation so they aren't surfaced as containing tabular data by screen readers
- Wrap the Test controls in a named group so screen reader identifies them as part of that group
- Give the "O" and "X" test buttons more descriptive names for screen reader
- Supply alt-text for the two image-based links in the options panel
- Fix how ids and labels are associated for options containing multiple controls such as "Soft Tabs" and "Show Print Margin" and give the second control a screen reader label (this was generally broken resulting in duplicate and mis-assigned element IDs of "-Undefined")
- Separate the option for persistent horizontal and vertical scrollbars into two rows
- Improve the button-bar control to put them in named groups and to indicate which button is pressed via aria-pressed
- Change styling of keyboard focus indicators (defaults are very hard to see on a blue background)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Note: Submitting as RStudio employee, corporate CLA on file.