### PR TITLE
fix chaos fold widget icon

### DIFF
--- a/lib/ace/theme/ambiance.css
+++ b/lib/ace/theme/ambiance.css
@@ -26,7 +26,7 @@
 .ace-ambiance .ace_fold-widget.ace_start,
 .ace-ambiance .ace_fold-widget.ace_end,
 .ace-ambiance .ace_fold-widget.ace_closed{
-  background: none;
+  background: none !important;
   border: none;
   box-shadow: none;
 }

--- a/lib/ace/theme/chaos.css
+++ b/lib/ace/theme/chaos.css
@@ -120,7 +120,7 @@
 .ace-chaos .ace_fold-widget.ace_start,
 .ace-chaos .ace_fold-widget.ace_end,
 .ace-chaos .ace_fold-widget.ace_closed{
-  background: none;
+  background: none !important;
   border: none;
   box-shadow: none;
 }


### PR DESCRIPTION
Issue #4190

Fixes background image that is repeated over and over again in the fold-widget collapsed and end icon.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
