### PR TITLE
Update .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,9 @@
         XMLHttpRequest: true,
         localStorage: true,
     },
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
     "rules": {
         curly: 0,
         eqeqeq: 0,


### PR DESCRIPTION
*Issue #, if available:*
Fix #4217 
*Description of changes:*
Added parserOptions to .eslintrc to support es2018. One specific case is to support lookbehinds for regex.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
