### PR TITLE
Cleanup event listeners

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -382,9 +382,6 @@ function buildAce(options, callback) {
     });
     // snippets
     modeNames.forEach(function(name) {
-        if (snippetFiles.indexOf(name + ".js") == -1)
-            addSnippetFile(name);
-        
         buildSubmodule(options, {
             require: ["ace/snippets/" + name]
         }, "snippets/" + name, addCb());
@@ -603,18 +600,6 @@ function generateThemesModule(themes) {
         ';\n\n});'
     ].join('');
     fs.writeFileSync(__dirname + '/lib/ace/ext/themelist_utils/themes.js', themelist, 'utf8');
-}
-
-function addSnippetFile(modeName) {
-    var snippetFilePath = ACE_HOME + "/lib/ace/snippets/" + modeName;
-    if (!fs.existsSync(snippetFilePath + ".js")) {
-        copy.file(ACE_HOME + "/tool/templates/snippets.js", snippetFilePath + ".js", function(t) {
-            return t.replace(/%modeName%/g, modeName);
-        });
-    }
-    if (!fs.existsSync(snippetFilePath + ".snippets")) {
-        fs.writeFileSync(snippetFilePath + ".snippets", "");
-    }
 }
 
 function compress(text) {

--- a/lib/ace/ace_test.js
+++ b/lib/ace/ace_test.js
@@ -83,15 +83,53 @@ module.exports = {
     },
     "test: destroy": function(done) {
         var editor = ace.edit();
+        var mouseTarget = editor.renderer.getMouseEventTarget();
+        var textarea = editor.textInput.getElement();
+        
+        // editor.curOp is undefined after commands
+        sendText(textarea, "x");
+        assert.ok(!editor.curOp);
+        assert.equal(editor.getValue(), "x");
+        
+        // editor.curOp is defined if api is used without endOperation
         editor.insert("1");
         assert.ok(editor.curOp);
+        
+        // clicking on editor calls focus
+        var focusCalled = 0;
+        editor.focus = function() { focusCalled++; };
+        click(mouseTarget);
+        assert.equal(focusCalled, 1);
+        
         editor.destroy();
+
+        // clicking on destroyed editor doesn't call focus
+        click(mouseTarget);
+        assert.equal(focusCalled, 1);
+
         setTimeout(function() {
             assert.notOk(!!editor.curOp);
+            
+            // input commands on destroed editor without session do not throw errors
+            editor.setSession(null);
+            sendText(textarea, "2");
+            
             done();
         });
     }
 };
+
+/*global CustomEvent*/
+function click(node) {
+    node.dispatchEvent(new CustomEvent("mousedown"));
+}
+
+function sendText(textarea, text) {
+    textarea.value = textarea.value.slice(0, textarea.selectionStart) + text
+        +  textarea.value.slice(textarea.selectionEnd);
+    textarea.dispatchEvent(new CustomEvent("input"));
+}
+
 });
 
 if (typeof module !== "undefined" && module === require.main) {

--- a/lib/ace/anchor.js
+++ b/lib/ace/anchor.js
@@ -187,7 +187,7 @@ var Anchor = exports.Anchor = function(doc, row, column) {
      *
      **/
     this.detach = function() {
-        this.document.removeEventListener("change", this.$onChange);
+        this.document.off("change", this.$onChange);
     };
     this.attach = function(doc) {
         this.document = doc || this.document;

--- a/lib/ace/commands/command_manager.js
+++ b/lib/ace/commands/command_manager.js
@@ -65,7 +65,7 @@ oop.inherits(CommandManager, MultiHashHandler);
         editor && editor._emit("changeStatus");
         if (this.recording) {
             this.macro.pop();
-            this.removeEventListener("exec", this.$addCommandToMacro);
+            this.off("exec", this.$addCommandToMacro);
 
             if (!this.macro.length)
                 this.macro = this.oldMacro;

--- a/lib/ace/commands/incremental_search_commands.js
+++ b/lib/ace/commands/incremental_search_commands.js
@@ -174,7 +174,7 @@ oop.inherits(IncrementalSearchKeyboardHandler, HashHandler);
     this.attach = function(editor) {
         var iSearch = this.$iSearch;
         HashHandler.call(this, exports.iSearchCommands, editor.commands.platform);
-        this.$commandExecHandler = editor.commands.addEventListener('exec', function(e) {
+        this.$commandExecHandler = editor.commands.on('exec', function(e) {
             if (!e.command.isIncrementalSearchCommand)
                 return iSearch.deactivate();
             e.stopPropagation();
@@ -189,7 +189,7 @@ oop.inherits(IncrementalSearchKeyboardHandler, HashHandler);
 
     this.detach = function(editor) {
         if (!this.$commandExecHandler) return;
-        editor.commands.removeEventListener('exec', this.$commandExecHandler);
+        editor.commands.off('exec', this.$commandExecHandler);
         delete this.$commandExecHandler;
     };
 
@@ -198,7 +198,7 @@ oop.inherits(IncrementalSearchKeyboardHandler, HashHandler);
         if (((hashId === 1/*ctrl*/ || hashId === 8/*command*/) && key === 'v')
          || (hashId === 1/*ctrl*/ && key === 'y')) return null;
         var cmd = handleKeyboard$super.call(this, data, hashId, key, keyCode);
-        if (cmd.command) { return cmd; }
+        if (cmd && cmd.command) { return cmd; }
         if (hashId == -1) {
             var extendCmd = this.commands.extendSearchTerm;
             if (extendCmd) { return {command: extendCmd, args: key}; }

--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -908,15 +908,15 @@ EditSession.$uid = 0;
 
         var tokenizer = mode.getTokenizer();
 
-        if(tokenizer.addEventListener !== undefined) {
+        if(tokenizer.on !== undefined) {
             var onReloadTokenizer = this.onReloadTokenizer.bind(this);
-            tokenizer.addEventListener("update", onReloadTokenizer);
+            tokenizer.on("update", onReloadTokenizer);
         }
 
         if (!this.bgTokenizer) {
             this.bgTokenizer = new BackgroundTokenizer(tokenizer);
             var _self = this;
-            this.bgTokenizer.addEventListener("update", function(e) {
+            this.bgTokenizer.on("update", function(e) {
                 _self._signal("tokenizerUpdate", e);
             });
         } else {

--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -2402,6 +2402,8 @@ EditSession.$uid = 0;
             this.bgTokenizer = null;
         }
         this.$stopWorker();
+        this.removeAllListeners();
+        this.selection.detach();
     };
 
     this.isFullWidth = isFullWidth;

--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -71,6 +71,7 @@ var clipboard = require("./clipboard");
  * @constructor
  **/
 var Editor = function(renderer, session, options) {
+    this.$toDestroy = [];
     var container = renderer.getContainerElement();
     this.container = container;
     this.renderer = renderer;
@@ -2731,13 +2732,20 @@ Editor.$uid = 0;
      * Cleans up the entire editor.
      **/
     this.destroy = function() {
+        if (this.$toDestroy) {
+            this.$toDestroy.forEach(function(el) {
+                el.destroy();
+            });
+            this.$toDestroy = null;
+        }
         this.renderer.destroy();
+        this.textInput.destroy();
         this._signal("destroy", this);
         if (this.session)
             this.session.destroy();
         if (this._$emitInputEvent)
             this._$emitInputEvent.cancel();
-        this.session = null;
+        this.removeAllListeners();
     };
 
     /**

--- a/lib/ace/ext/code_lens.js
+++ b/lib/ace/ext/code_lens.js
@@ -31,6 +31,7 @@
 define(function(require, exports, module) {
 "use strict";
 var LineWidgets = require("../line_widgets").LineWidgets;
+var event = require("../lib/event");
 var lang = require("../lib/lang");
 var dom = require("../lib/dom");
 
@@ -155,7 +156,7 @@ function attachToEditor(editor) {
         if (command)
             editor.execCommand(command.id, command.arguments);
     };
-    editor.container.addEventListener("click", editor.$codeLensClickHandler);
+    event.addListener(editor.container, "click", editor.$codeLensClickHandler, editor);
     editor.$updateLenses = function() {
         var session = editor.session;
         if (!session) return;

--- a/lib/ace/incremental_search.js
+++ b/lib/ace/incremental_search.js
@@ -103,7 +103,7 @@ function objectToRegExp(obj) {
         // we need to completely intercept paste, just registering an event handler does not work
         this.$originalEditorOnPaste = editor.onPaste; 
         editor.onPaste = this.onPaste.bind(this);
-        this.$mousedownHandler = editor.addEventListener('mousedown', this.onMouseDown.bind(this));
+        this.$mousedownHandler = editor.on('mousedown', this.onMouseDown.bind(this));
         this.selectionFix(editor);
         this.statusMessage(true);
     };

--- a/lib/ace/incremental_search.js
+++ b/lib/ace/incremental_search.js
@@ -94,28 +94,29 @@ function objectToRegExp(obj) {
 
 (function() {
 
-    this.activate = function(ed, backwards) {
-        this.$editor = ed;
-        this.$startPos = this.$currentPos = ed.getCursorPosition();
+    this.activate = function(editor, backwards) {
+        this.$editor = editor;
+        this.$startPos = this.$currentPos = editor.getCursorPosition();
         this.$options.needle = '';
         this.$options.backwards = backwards;
-        ed.keyBinding.addKeyboardHandler(this.$keyboardHandler);
+        editor.keyBinding.addKeyboardHandler(this.$keyboardHandler);
         // we need to completely intercept paste, just registering an event handler does not work
-        this.$originalEditorOnPaste = ed.onPaste; ed.onPaste = this.onPaste.bind(this);
-        this.$mousedownHandler = ed.addEventListener('mousedown', this.onMouseDown.bind(this));
-        this.selectionFix(ed);
+        this.$originalEditorOnPaste = editor.onPaste; 
+        editor.onPaste = this.onPaste.bind(this);
+        this.$mousedownHandler = editor.addEventListener('mousedown', this.onMouseDown.bind(this));
+        this.selectionFix(editor);
         this.statusMessage(true);
     };
 
     this.deactivate = function(reset) {
         this.cancelSearch(reset);
-        var ed = this.$editor;
-        ed.keyBinding.removeKeyboardHandler(this.$keyboardHandler);
+        var editor = this.$editor;
+        editor.keyBinding.removeKeyboardHandler(this.$keyboardHandler);
         if (this.$mousedownHandler) {
-            ed.removeEventListener('mousedown', this.$mousedownHandler);
+            editor.off('mousedown', this.$mousedownHandler);
             delete this.$mousedownHandler;
         }
-        ed.onPaste = this.$originalEditorOnPaste;
+        editor.onPaste = this.$originalEditorOnPaste;
         this.message('');
     };
 

--- a/lib/ace/keyboard/emacs.js
+++ b/lib/ace/keyboard/emacs.js
@@ -135,20 +135,20 @@ exports.handler.attach = function(editor) {
     editor.commands.addCommands(commands);
     exports.handler.platform = editor.commands.platform;
     editor.$emacsModeHandler = this;
-    editor.addEventListener('copy', this.onCopy);
-    editor.addEventListener('paste', this.onPaste);
+    editor.on('copy', this.onCopy);
+    editor.on('paste', this.onPaste);
 };
 
 exports.handler.detach = function(editor) {
     editor.renderer.$blockCursor = false;
     editor.session.$selectLongWords = $formerLongWords;
     editor.session.$useEmacsStyleLineStart = $formerLineStart;
-    editor.removeEventListener("click", $resetMarkMode);
-    editor.removeEventListener("changeSession", $kbSessionChange);
+    editor.off("click", $resetMarkMode);
+    editor.off("changeSession", $kbSessionChange);
     editor.unsetStyle("emacs-mode");
     editor.commands.removeCommands(commands);
-    editor.removeEventListener('copy', this.onCopy);
-    editor.removeEventListener('paste', this.onPaste);
+    editor.off('copy', this.onCopy);
+    editor.off('paste', this.onPaste);
     editor.$emacsModeHandler = null;
 };
 

--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -84,7 +84,7 @@ var TextInput = function(parentNode, host) {
         if (ignoreFocusEvents) return;
         host.onBlur(e);
         isFocused = false;
-    });
+    }, host);
     event.addListener(text, "focus", function(e) {
         if (ignoreFocusEvents) return;
         isFocused = true;
@@ -100,7 +100,7 @@ var TextInput = function(parentNode, host) {
             setTimeout(resetSelection);
         else
             resetSelection();
-    });
+    }, host);
     this.$focusScroll = false;
     this.focus = function() {
         if (tempStyle || HAS_FOCUS_ARGS || this.$focusScroll == "browser")
@@ -427,14 +427,14 @@ var TextInput = function(parentNode, host) {
         }
     };
 
-    event.addCommandKeyListener(text, host.onCommandKey.bind(host));
+    event.addCommandKeyListener(text, host.onCommandKey.bind(host), host);
 
-    event.addListener(text, "select", onSelect);
-    event.addListener(text, "input", onInput);
+    event.addListener(text, "select", onSelect, host);
+    event.addListener(text, "input", onInput, host);
 
-    event.addListener(text, "cut", onCut);
-    event.addListener(text, "copy", onCopy);
-    event.addListener(text, "paste", onPaste);
+    event.addListener(text, "cut", onCut, host);
+    event.addListener(text, "copy", onCopy, host);
+    event.addListener(text, "paste", onPaste, host);
 
 
     // Opera has no clipboard events
@@ -454,7 +454,7 @@ var TextInput = function(parentNode, host) {
                     onCut(e);
                     break;
             }
-        });
+        }, host);
     }
 
 
@@ -547,11 +547,11 @@ var TextInput = function(parentNode, host) {
         syncComposition();
     }
 
-    event.addListener(text, "compositionstart", onCompositionStart);
-    event.addListener(text, "compositionupdate", onCompositionUpdate);
-    event.addListener(text, "keyup", onKeyup);
-    event.addListener(text, "keydown", syncComposition);
-    event.addListener(text, "compositionend", onCompositionEnd);
+    event.addListener(text, "compositionstart", onCompositionStart, host);
+    event.addListener(text, "compositionupdate", onCompositionUpdate, host);
+    event.addListener(text, "keyup", onKeyup, host);
+    event.addListener(text, "keydown", syncComposition, host);
+    event.addListener(text, "compositionend", onCompositionEnd, host);
 
     this.getElement = function() {
         return text;
@@ -626,13 +626,13 @@ var TextInput = function(parentNode, host) {
         host.textInput.onContextMenu(e);
         onContextMenuClose();
     };
-    event.addListener(text, "mouseup", onContextMenu);
+    event.addListener(text, "mouseup", onContextMenu, host);
     event.addListener(text, "mousedown", function(e) {
         e.preventDefault();
         onContextMenuClose();
-    });
-    event.addListener(host.renderer.scroller, "contextmenu", onContextMenu);
-    event.addListener(text, "contextmenu", onContextMenu);
+    }, host);
+    event.addListener(host.renderer.scroller, "contextmenu", onContextMenu, host);
+    event.addListener(text, "contextmenu", onContextMenu, host);
     
     if (isIOS)
         addIosSelectionHandler(parentNode, host, text);
@@ -723,6 +723,11 @@ var TextInput = function(parentNode, host) {
         });
     }
 
+    this.destroy = function() {
+        if (text.parentElement)
+            text.parentElement.removeChild(text);
+        host = text = parentNode = null;
+    };
 };
 
 exports.TextInput = TextInput;

--- a/lib/ace/layer/gutter.js
+++ b/lib/ace/layer/gutter.js
@@ -58,7 +58,7 @@ var Gutter = function(parentEl) {
 
     this.setSession = function(session) {
         if (this.session)
-            this.session.removeEventListener("change", this.$updateAnnotations);
+            this.session.off("change", this.$updateAnnotations);
         this.session = session;
         if (session)
             session.on("change", this.$updateAnnotations);

--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -65,10 +65,10 @@ EventListener.prototype.destroy = function() {
     this.elem = this.type = this.callback = undefined;
 };
 
-var addListener = exports.addListener = function(elem, type, callback, destroyable) {
+var addListener = exports.addListener = function(elem, type, callback, destroyer) {
     elem.addEventListener(type, callback, getListenerOptions());
-    if (destroyable && destroyable.$toDestroy) 
-        destroyable.$toDestroy.push(new EventListener(elem, type, callback));
+    if (destroyer)
+        destroyer.$toDestroy.push(new EventListener(elem, type, callback));
 };
 
 var removeListener = exports.removeListener = function(elem, type, callback) {
@@ -124,7 +124,7 @@ exports.capture = function(el, eventHandler, releaseCaptureHandler) {
     return onMouseUp;
 };
 
-exports.addMouseWheelListener = function(el, callback, destroyable) {
+exports.addMouseWheelListener = function(el, callback, destroyer) {
     if ("onmousewheel" in el) {
         addListener(el, "mousewheel", function(e) {
             var factor = 8;
@@ -136,7 +136,7 @@ exports.addMouseWheelListener = function(el, callback, destroyable) {
                 e.wheelY = -e.wheelDelta / factor;
             }
             callback(e);
-        }, destroyable);
+        }, destroyer);
     } else if ("onwheel" in el) {
         addListener(el, "wheel",  function(e) {
             var factor = 0.35;
@@ -153,7 +153,7 @@ exports.addMouseWheelListener = function(el, callback, destroyable) {
             }
             
             callback(e);
-        }, destroyable);
+        }, destroyer);
     } else {
         addListener(el, "DOMMouseScroll", function(e) {
             if (e.axis && e.axis == e.HORIZONTAL_AXIS) {
@@ -164,11 +164,11 @@ exports.addMouseWheelListener = function(el, callback, destroyable) {
                 e.wheelY = (e.detail || 0) * 5;
             }
             callback(e);
-        }, destroyable);
+        }, destroyer);
     }
 };
 
-exports.addMultiMouseDownListener = function(elements, timeouts, eventHandler, callbackName, destroyable) {
+exports.addMultiMouseDownListener = function(elements, timeouts, eventHandler, callbackName, destroyer) {
     var clicks = 0;
     var startX, startY, timer; 
     var eventNames = {
@@ -213,7 +213,7 @@ exports.addMultiMouseDownListener = function(elements, timeouts, eventHandler, c
     if (!Array.isArray(elements))
         elements = [elements];
     elements.forEach(function(el) {
-        addListener(el, "mousedown", onMousedown, destroyable);
+        addListener(el, "mousedown", onMousedown, destroyer);
     });
 };
 
@@ -282,7 +282,7 @@ function normalizeCommandKeys(callback, e, keyCode) {
 }
 
 
-exports.addCommandKeyListener = function(el, callback, destroyable) {
+exports.addCommandKeyListener = function(el, callback, destroyer) {
     if (useragent.isOldGecko || (useragent.isOpera && !("KeyboardEvent" in window))) {
         // Old versions of Gecko aka. Firefox < 4.0 didn't repeat the keydown
         // event if the user pressed the key for a longer time. Instead, the
@@ -293,10 +293,10 @@ exports.addCommandKeyListener = function(el, callback, destroyable) {
         var lastKeyDownKeyCode = null;
         addListener(el, "keydown", function(e) {
             lastKeyDownKeyCode = e.keyCode;
-        }, destroyable);
+        }, destroyer);
         addListener(el, "keypress", function(e) {
             return normalizeCommandKeys(callback, e, lastKeyDownKeyCode);
-        }, destroyable);
+        }, destroyer);
     } else {
         var lastDefaultPrevented = null;
 
@@ -305,18 +305,18 @@ exports.addCommandKeyListener = function(el, callback, destroyable) {
             var result = normalizeCommandKeys(callback, e, e.keyCode);
             lastDefaultPrevented = e.defaultPrevented;
             return result;
-        }, destroyable);
+        }, destroyer);
 
         addListener(el, "keypress", function(e) {
             if (lastDefaultPrevented && (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey)) {
                 exports.stopEvent(e);
                 lastDefaultPrevented = null;
             }
-        }, destroyable);
+        }, destroyer);
 
         addListener(el, "keyup", function(e) {
             pressedKeys[e.keyCode] = null;
-        }, destroyable);
+        }, destroyer);
 
         if (!pressedKeys) {
             resetPressedKeys();

--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -55,12 +55,24 @@ function getListenerOptions() {
     return activeListenerOptions;
 }
 
-exports.addListener = function(elem, type, callback) {
-    return elem.addEventListener(type, callback, getListenerOptions());
+function EventListener(elem, type, callback) {
+    this.elem = elem;
+    this.type = type;
+    this.callback = callback;
+}
+EventListener.prototype.destroy = function() {
+    removeListener(this.elem, this.type, this.callback);
+    this.elem = this.type = this.callback = undefined;
 };
 
-exports.removeListener = function(elem, type, callback) {
-    return elem.removeEventListener(type, callback, getListenerOptions());
+var addListener = exports.addListener = function(elem, type, callback, destroyable) {
+    elem.addEventListener(type, callback, getListenerOptions());
+    if (destroyable && destroyable.$toDestroy) 
+        destroyable.$toDestroy.push(new EventListener(elem, type, callback));
+};
+
+var removeListener = exports.removeListener = function(elem, type, callback) {
+    elem.removeEventListener(type, callback, getListenerOptions());
 };
 
 /*
@@ -100,21 +112,21 @@ exports.capture = function(el, eventHandler, releaseCaptureHandler) {
         eventHandler && eventHandler(e);
         releaseCaptureHandler && releaseCaptureHandler(e);
 
-        exports.removeListener(document, "mousemove", eventHandler, true);
-        exports.removeListener(document, "mouseup", onMouseUp, true);
-        exports.removeListener(document, "dragstart", onMouseUp, true);
+        removeListener(document, "mousemove", eventHandler);
+        removeListener(document, "mouseup", onMouseUp);
+        removeListener(document, "dragstart", onMouseUp);
     }
 
-    exports.addListener(document, "mousemove", eventHandler, true);
-    exports.addListener(document, "mouseup", onMouseUp, true);
-    exports.addListener(document, "dragstart", onMouseUp, true);
+    addListener(document, "mousemove", eventHandler);
+    addListener(document, "mouseup", onMouseUp);
+    addListener(document, "dragstart", onMouseUp);
     
     return onMouseUp;
 };
 
-exports.addMouseWheelListener = function(el, callback) {
+exports.addMouseWheelListener = function(el, callback, destroyable) {
     if ("onmousewheel" in el) {
-        exports.addListener(el, "mousewheel", function(e) {
+        addListener(el, "mousewheel", function(e) {
             var factor = 8;
             if (e.wheelDeltaX !== undefined) {
                 e.wheelX = -e.wheelDeltaX / factor;
@@ -124,9 +136,9 @@ exports.addMouseWheelListener = function(el, callback) {
                 e.wheelY = -e.wheelDelta / factor;
             }
             callback(e);
-        });
+        }, destroyable);
     } else if ("onwheel" in el) {
-        exports.addListener(el, "wheel",  function(e) {
+        addListener(el, "wheel",  function(e) {
             var factor = 0.35;
             switch (e.deltaMode) {
                 case e.DOM_DELTA_PIXEL:
@@ -141,9 +153,9 @@ exports.addMouseWheelListener = function(el, callback) {
             }
             
             callback(e);
-        });
+        }, destroyable);
     } else {
-        exports.addListener(el, "DOMMouseScroll", function(e) {
+        addListener(el, "DOMMouseScroll", function(e) {
             if (e.axis && e.axis == e.HORIZONTAL_AXIS) {
                 e.wheelX = (e.detail || 0) * 5;
                 e.wheelY = 0;
@@ -152,11 +164,11 @@ exports.addMouseWheelListener = function(el, callback) {
                 e.wheelY = (e.detail || 0) * 5;
             }
             callback(e);
-        });
+        }, destroyable);
     }
 };
 
-exports.addMultiMouseDownListener = function(elements, timeouts, eventHandler, callbackName) {
+exports.addMultiMouseDownListener = function(elements, timeouts, eventHandler, callbackName, destroyable) {
     var clicks = 0;
     var startX, startY, timer; 
     var eventNames = {
@@ -201,7 +213,7 @@ exports.addMultiMouseDownListener = function(elements, timeouts, eventHandler, c
     if (!Array.isArray(elements))
         elements = [elements];
     elements.forEach(function(el) {
-        exports.addListener(el, "mousedown", onMousedown);
+        addListener(el, "mousedown", onMousedown, destroyable);
     });
 };
 
@@ -270,8 +282,7 @@ function normalizeCommandKeys(callback, e, keyCode) {
 }
 
 
-exports.addCommandKeyListener = function(el, callback) {
-    var addListener = exports.addListener;
+exports.addCommandKeyListener = function(el, callback, destroyable) {
     if (useragent.isOldGecko || (useragent.isOpera && !("KeyboardEvent" in window))) {
         // Old versions of Gecko aka. Firefox < 4.0 didn't repeat the keydown
         // event if the user pressed the key for a longer time. Instead, the
@@ -282,10 +293,10 @@ exports.addCommandKeyListener = function(el, callback) {
         var lastKeyDownKeyCode = null;
         addListener(el, "keydown", function(e) {
             lastKeyDownKeyCode = e.keyCode;
-        });
+        }, destroyable);
         addListener(el, "keypress", function(e) {
             return normalizeCommandKeys(callback, e, lastKeyDownKeyCode);
-        });
+        }, destroyable);
     } else {
         var lastDefaultPrevented = null;
 
@@ -294,18 +305,18 @@ exports.addCommandKeyListener = function(el, callback) {
             var result = normalizeCommandKeys(callback, e, e.keyCode);
             lastDefaultPrevented = e.defaultPrevented;
             return result;
-        });
+        }, destroyable);
 
         addListener(el, "keypress", function(e) {
             if (lastDefaultPrevented && (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey)) {
                 exports.stopEvent(e);
                 lastDefaultPrevented = null;
             }
-        });
+        }, destroyable);
 
         addListener(el, "keyup", function(e) {
             pressedKeys[e.keyCode] = null;
-        });
+        }, destroyable);
 
         if (!pressedKeys) {
             resetPressedKeys();
@@ -326,12 +337,12 @@ if (typeof window == "object" && window.postMessage && !useragent.isOldIE) {
         var listener = function(e) {
             if (e.data == messageName) {
                 exports.stopPropagation(e);
-                exports.removeListener(win, "message", listener);
+                removeListener(win, "message", listener);
                 callback();
             }
         };
         
-        exports.addListener(win, "message", listener);
+        addListener(win, "message", listener);
         win.postMessage(messageName, "*");
     };
 }

--- a/lib/ace/lib/event_emitter.js
+++ b/lib/ace/lib/event_emitter.js
@@ -152,7 +152,9 @@ EventEmitter.removeEventListener = function(eventName, callback) {
 };
 
 EventEmitter.removeAllListeners = function(eventName) {
-    if (this._eventRegistry) this._eventRegistry[eventName] = [];
+    if (!eventName) this._eventRegistry = this._defaultHandlers = undefined;
+    if (this._eventRegistry) this._eventRegistry[eventName] = undefined;
+    if (this._defaultHandlers) this._defaultHandlers[eventName] = undefined;
 };
 
 exports.EventEmitter = EventEmitter;

--- a/lib/ace/lib/event_emitter.js
+++ b/lib/ace/lib/event_emitter.js
@@ -78,8 +78,8 @@ EventEmitter._signal = function(eventName, e) {
 
 EventEmitter.once = function(eventName, callback) {
     var _self = this;
-    this.addEventListener(eventName, function newCallback() {
-        _self.removeEventListener(eventName, newCallback);
+    this.on(eventName, function newCallback() {
+        _self.off(eventName, newCallback);
         callback.apply(null, arguments);
     });
     if (!callback) {

--- a/lib/ace/mode/prisma.js
+++ b/lib/ace/mode/prisma.js
@@ -51,7 +51,7 @@ oop.inherits(Mode, TextMode);
     this.lineCommentStart = "//";
     // this.blockComment = {start: ""/*"", end: ""*/""};
     // Extra logic goes here.
-    this.$id = "ace/mode/prisma"
+    this.$id = "ace/mode/prisma";
 }).call(Mode.prototype);
 
 exports.Mode = Mode;

--- a/lib/ace/mode/prisma_highlight_rules.js
+++ b/lib/ace/mode/prisma_highlight_rules.js
@@ -341,7 +341,7 @@ var PrismaHighlightRules = function() {
                 defaultToken: "source.tag.embedded.source.prisma"
             }]
         }]
-    }
+    };
     
     this.normalizeRules();
 };
@@ -349,7 +349,7 @@ var PrismaHighlightRules = function() {
 PrismaHighlightRules.metaData = {
     name: "Prisma",
     scopeName: "source.prisma"
-}
+};
 
 
 oop.inherits(PrismaHighlightRules, TextHighlightRules);

--- a/lib/ace/mouse/default_gutter_handler.js
+++ b/lib/ace/mouse/default_gutter_handler.js
@@ -109,7 +109,7 @@ function GutterHandler(mouseHandler) {
             tooltip.hide();
             tooltipAnnotation = null;
             editor._signal("hideGutterTooltip", tooltip);
-            editor.removeEventListener("mousewheel", hideTooltip);
+            editor.off("mousewheel", hideTooltip);
         }
     }
 

--- a/lib/ace/mouse/default_gutter_handler.js
+++ b/lib/ace/mouse/default_gutter_handler.js
@@ -146,7 +146,7 @@ function GutterHandler(mouseHandler) {
             tooltipTimeout = null;
             hideTooltip();
         }, 50);
-    });
+    }, editor);
     
     editor.on("changeSession", hideTooltip);
 }

--- a/lib/ace/mouse/dragdrop_handler.js
+++ b/lib/ace/mouse/dragdrop_handler.js
@@ -54,7 +54,7 @@ function DragdropHandler(mouseHandler) {
      exports.forEach(function(x) {
          mouseHandler[x] = this[x];
     }, this);
-    editor.addEventListener("mousedown", this.onMouseDown.bind(mouseHandler));
+    editor.on("mousedown", this.onMouseDown.bind(mouseHandler));
 
 
     var mouseTarget = editor.container;

--- a/lib/ace/mouse/dragdrop_handler.js
+++ b/lib/ace/mouse/dragdrop_handler.js
@@ -188,12 +188,12 @@ function DragdropHandler(mouseHandler) {
         return event.preventDefault(e);
     };
 
-    event.addListener(mouseTarget, "dragstart", this.onDragStart.bind(mouseHandler));
-    event.addListener(mouseTarget, "dragend", this.onDragEnd.bind(mouseHandler));
-    event.addListener(mouseTarget, "dragenter", this.onDragEnter.bind(mouseHandler));
-    event.addListener(mouseTarget, "dragover", this.onDragOver.bind(mouseHandler));
-    event.addListener(mouseTarget, "dragleave", this.onDragLeave.bind(mouseHandler));
-    event.addListener(mouseTarget, "drop", this.onDrop.bind(mouseHandler));
+    event.addListener(mouseTarget, "dragstart", this.onDragStart.bind(mouseHandler), editor);
+    event.addListener(mouseTarget, "dragend", this.onDragEnd.bind(mouseHandler), editor);
+    event.addListener(mouseTarget, "dragenter", this.onDragEnter.bind(mouseHandler), editor);
+    event.addListener(mouseTarget, "dragover", this.onDragOver.bind(mouseHandler), editor);
+    event.addListener(mouseTarget, "dragleave", this.onDragLeave.bind(mouseHandler), editor);
+    event.addListener(mouseTarget, "drop", this.onDrop.bind(mouseHandler), editor);
 
     function scrollCursorIntoView(cursor, prevCursor) {
         var now = Date.now();

--- a/lib/ace/mouse/mouse_handler.js
+++ b/lib/ace/mouse/mouse_handler.js
@@ -59,28 +59,28 @@ var MouseHandler = function(editor) {
     };
 
     var mouseTarget = editor.renderer.getMouseEventTarget();
-    event.addListener(mouseTarget, "click", this.onMouseEvent.bind(this, "click"));
-    event.addListener(mouseTarget, "mousemove", this.onMouseMove.bind(this, "mousemove"));
+    event.addListener(mouseTarget, "click", this.onMouseEvent.bind(this, "click"), editor);
+    event.addListener(mouseTarget, "mousemove", this.onMouseMove.bind(this, "mousemove"), editor);
     event.addMultiMouseDownListener([
         mouseTarget,
         editor.renderer.scrollBarV && editor.renderer.scrollBarV.inner,
         editor.renderer.scrollBarH && editor.renderer.scrollBarH.inner,
         editor.textInput && editor.textInput.getElement()
-    ].filter(Boolean), [400, 300, 250], this, "onMouseEvent");
-    event.addMouseWheelListener(editor.container, this.onMouseWheel.bind(this, "mousewheel"));
+    ].filter(Boolean), [400, 300, 250], this, "onMouseEvent", editor);
+    event.addMouseWheelListener(editor.container, this.onMouseWheel.bind(this, "mousewheel"), editor);
     addTouchListeners(editor.container, editor);
 
     var gutterEl = editor.renderer.$gutter;
-    event.addListener(gutterEl, "mousedown", this.onMouseEvent.bind(this, "guttermousedown"));
-    event.addListener(gutterEl, "click", this.onMouseEvent.bind(this, "gutterclick"));
-    event.addListener(gutterEl, "dblclick", this.onMouseEvent.bind(this, "gutterdblclick"));
-    event.addListener(gutterEl, "mousemove", this.onMouseEvent.bind(this, "guttermousemove"));
+    event.addListener(gutterEl, "mousedown", this.onMouseEvent.bind(this, "guttermousedown"), editor);
+    event.addListener(gutterEl, "click", this.onMouseEvent.bind(this, "gutterclick"), editor);
+    event.addListener(gutterEl, "dblclick", this.onMouseEvent.bind(this, "gutterdblclick"), editor);
+    event.addListener(gutterEl, "mousemove", this.onMouseEvent.bind(this, "guttermousemove"), editor);
 
-    event.addListener(mouseTarget, "mousedown", focusEditor);
-    event.addListener(gutterEl, "mousedown", focusEditor);
+    event.addListener(mouseTarget, "mousedown", focusEditor, editor);
+    event.addListener(gutterEl, "mousedown", focusEditor, editor);
     if (useragent.isIE && editor.renderer.scrollBarV) {
-        event.addListener(editor.renderer.scrollBarV.element, "mousedown", focusEditor);
-        event.addListener(editor.renderer.scrollBarH.element, "mousedown", focusEditor);
+        event.addListener(editor.renderer.scrollBarV.element, "mousedown", focusEditor, editor);
+        event.addListener(editor.renderer.scrollBarH.element, "mousedown", focusEditor, editor);
     }
 
     editor.on("mousemove", function(e){
@@ -96,7 +96,7 @@ var MouseHandler = function(editor) {
         } else {
             renderer.setCursorStyle("");
         }
-    });
+    }, editor);
 };
 
 (function() {

--- a/lib/ace/mouse/touch_handler.js
+++ b/lib/ace/mouse/touch_handler.js
@@ -163,7 +163,7 @@ exports.addTouchListeners = function(el, editor) {
         if (!pressed) return;
         var textarea = editor.textInput.getElement();
         textarea.focus();
-    });
+    }, editor);
     event.addListener(el, "touchstart", function (e) {
         var touches = e.touches;
         if (longTouchTimer || touches.length > 1) {
@@ -237,7 +237,7 @@ exports.addTouchListeners = function(el, editor) {
             longTouchTimer = setTimeout(handleLongTap, 450);
         }
         touchStartT = t;
-    });
+    }, editor);
 
     event.addListener(el, "touchend", function (e) {
         pressed = editor.$mouseHandler.isMousePressed = false;
@@ -257,7 +257,7 @@ exports.addTouchListeners = function(el, editor) {
         }
         clearTimeout(longTouchTimer);
         longTouchTimer = null;
-    });
+    }, editor);
     event.addListener(el, "touchmove", function (e) {
         if (longTouchTimer) {
             clearTimeout(longTouchTimer);
@@ -313,7 +313,7 @@ exports.addTouchListeners = function(el, editor) {
             editor.renderer.scrollCursorIntoView(pos);
             e.preventDefault();
         }
-    });
+    }, editor);
 
     function animate() {
         animationSteps += 60;

--- a/lib/ace/multi_select.js
+++ b/lib/ace/multi_select.js
@@ -927,10 +927,10 @@ function addAltCursorListeners(editor){
         } else if (altCursor) {
             reset();
         }
-    });
+    }, editor);
 
-    event.addListener(el, "keyup", reset);
-    event.addListener(el, "blur", reset);
+    event.addListener(el, "keyup", reset, editor);
+    event.addListener(el, "blur", reset, editor);
     function reset(e) {
         if (altCursor) {
             editor.renderer.setMouseCursor("");

--- a/lib/ace/placeholder.js
+++ b/lib/ace/placeholder.js
@@ -232,8 +232,8 @@ var PlaceHolder = function(session, length, pos, others, mainClass, othersClass)
     this.detach = function() {
         this.session.removeMarker(this.pos && this.pos.markerId);
         this.hideOtherMarkers();
-        this.doc.removeEventListener("change", this.$onUpdate);
-        this.session.selection.removeEventListener("changeCursor", this.$onCursorChange);
+        this.doc.off("change", this.$onUpdate);
+        this.session.selection.off("changeCursor", this.$onCursorChange);
         this.session.setUndoSelect(true);
         this.session = null;
     };

--- a/lib/ace/test/all_browser.js
+++ b/lib/ace/test/all_browser.js
@@ -12,6 +12,7 @@ var log = document.getElementById("log");
 var el = document.createElement.bind(document);
 
 var testNames = [
+    "ace/ace_test",
     "ace/anchor_test",
     "ace/autocomplete_test",
     "ace/background_tokenizer_test",

--- a/lib/ace/test/mockdom.js
+++ b/lib/ace/test/mockdom.js
@@ -380,7 +380,7 @@ function Node(name) {
     this.removeEventListener = function(name, listener) {
         if (!this._events) return;
         if (!this._events[name]) return;
-        var i = this._events[name].indexOf(this._events[name]);
+        var i = this._events[name].indexOf(listener);
         if (i !== -1)
             this._events[name].splice(i, 1);
     };

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -107,11 +107,11 @@ var VirtualRenderer = function(container, theme) {
     this.scrollBar = 
     this.scrollBarV = new VScrollBar(this.container, this);
     this.scrollBarH = new HScrollBar(this.container, this);
-    this.scrollBarV.addEventListener("scroll", function(e) {
+    this.scrollBarV.on("scroll", function(e) {
         if (!_self.$scrollAnimation)
             _self.session.setScrollTop(e.data - _self.scrollMargin.top);
     });
-    this.scrollBarH.addEventListener("scroll", function(e) {
+    this.scrollBarH.on("scroll", function(e) {
         if (!_self.$scrollAnimation)
             _self.session.setScrollLeft(e.data - _self.scrollMargin.left);
     });
@@ -126,7 +126,7 @@ var VirtualRenderer = function(container, theme) {
 
     this.$fontMetrics = new FontMetrics(this.container);
     this.$textLayer.$setFontMetrics(this.$fontMetrics);
-    this.$textLayer.addEventListener("changeCharacterSize", function(e) {
+    this.$textLayer.on("changeCharacterSize", function(e) {
         _self.updateCharacterSize();
         _self.onResize(true, _self.gutterWidth, _self.$size.width, _self.$size.height);
         _self._signal("changeCharacterSize", e);
@@ -1724,6 +1724,8 @@ var VirtualRenderer = function(container, theme) {
         this.freeze();
         this.$fontMetrics.destroy();
         this.$cursorLayer.destroy();
+        this.removeAllListeners();
+        this.container.textContent = "";
     };
 
 }).call(VirtualRenderer.prototype);


### PR DESCRIPTION
Unfortunately looks like the chrome [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1012636), preventing textarea from being garbage collected, is not going to be fixed anytime soon, and setting session to 0 caused more problems, so we have too remove event listeners manually.
