### PR TITLE
docs: Fix simple typo, triger -> trigger

### DIFF
--- a/api/resources/javascripts/jquery-scrollspy.js
+++ b/api/resources/javascripts/jquery-scrollspy.js
@@ -69,7 +69,7 @@
                       
                      }
                      
-                     /* triger tick event */
+                     /* trigger tick event */
                      $(element).trigger('scrollTick', {position: position, inside: inside, enters: enters, leaves: leaves})
                      if($.isFunction(o.onTick)){
                        o.onTick(element, position, inside, enters, leaves);

--- a/doc/template/resources/javascripts/jquery-scrollspy.js
+++ b/doc/template/resources/javascripts/jquery-scrollspy.js
@@ -69,7 +69,7 @@
                       
                      }
                      
-                     /* triger tick event */
+                     /* trigger tick event */
                      $(element).trigger('scrollTick', {position: position, inside: inside, enters: enters, leaves: leaves})
                      if($.isFunction(o.onTick)){
                        o.onTick(element, position, inside, enters, leaves);


### PR DESCRIPTION
There is a small typo in api/resources/javascripts/jquery-scrollspy.js, doc/template/resources/javascripts/jquery-scrollspy.js.

Should read `trigger` rather than `triger`.

