### PR TITLE
Fix typing in Editor `blur` event

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -746,7 +746,7 @@ export namespace Ace {
     setFontSize(size: string): void;
     focus(): void;
     isFocused(): boolean;
-    flur(): void;
+    blur(): void;
     getSelectedText(): string;
     getCopyText(): string;
     execCommand(command: string | string[], args?: any): boolean;


### PR DESCRIPTION
Fixes #4263

*Issue #, if available:* #4263
*Description of changes:* Fix typing in Editor `blur` event


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
