### PR TITLE
Fix type of wrap in typescript definition

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -152,7 +152,7 @@ export namespace Ace {
   }
 
   export interface EditSessionOptions {
-    wrap: string | number;
+    wrap: boolean | number;
     wrapMethod: 'code' | 'text' | 'auto';
     indentedSoftWrap: boolean;
     firstLineNumber: number;

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -152,7 +152,7 @@ export namespace Ace {
   }
 
   export interface EditSessionOptions {
-    wrap: boolean | number;
+    wrap: "off" | "free" | "printmargin" | boolean | number;
     wrapMethod: 'code' | 'text' | 'auto';
     indentedSoftWrap: boolean;
     firstLineNumber: number;


### PR DESCRIPTION
*Issue #, if available:* Not available

*Description of changes:* As noted here https://github.com/ajaxorg/ace/wiki/Configuring-Ace#session-options wrap should be `boolean | number`, not `string | number`
