### PR TITLE
Fix removeCommand signature in TS def

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -549,7 +549,7 @@ export namespace Ace {
     toggleRecording(editor: Editor): void;
     replay(editor: Editor): void;
     addCommand(command: Command): void;
-    removeCommand(command: Command, keepCommand?: boolean): void;
+    removeCommand(command: Command | string, keepCommand?: boolean): void;
     bindKey(key: string | { mac?: string, win?: string },
       command: CommandLike,
       position?: number): void;


### PR DESCRIPTION
*Issue #, if available:* Not available

*Description of changes:* According to the test:

https://github.com/ajaxorg/ace/blob/a0cf0e371677d35236c74c27353ad93f52ece750/lib/ace/commands/command_manager_test.js#L103-L111

It's ok to remove a command by name
