### PR TITLE
A base for 3rd-party ACE workers

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -424,6 +424,17 @@ function buildAce(options, callback) {
             }]
         }, "worker-" + name, addCb());
     });
+    // worker base
+    buildSubmodule(options, {
+        projectType: "worker",
+        require: ["ace/worker/mirror"],
+        ignore: [],
+        additional: [{
+            id: "ace/worker/worker",
+            transforms: [],
+            order: -1000
+        }]
+    }, "worker-base", addCb());
     // 
     function addCb() {
         addCb.count = (addCb.count || 0) + 1; 


### PR DESCRIPTION
The [ANTLR documentation for use with ACE](https://github.com/antlr/antlr4/blob/master/doc/ace-javascript-target.md) refers to a worker-base.js that was constructed by manually stripping out code from one of the pre-built workers.

A base makes building 3rd-party ACE workers much easier, so it would be great to have one that comes with ACE, is version-aligned, and is not handcrafted.

This pull request modifies the build script to generate such a base worker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.