### PR TITLE
Support PHP 7.4 syntax

### DIFF
--- a/lib/ace/mode/php/php.js
+++ b/lib/ace/mode/php/php.js
@@ -21,141 +21,143 @@ define(function(require, exports, module) {
 
 var PHP = {Constants:{}};
 
-PHP.Constants.T_INCLUDE = 257;
-PHP.Constants.T_INCLUDE_ONCE = 258;
-PHP.Constants.T_EVAL = 259;
-PHP.Constants.T_REQUIRE = 260;
-PHP.Constants.T_REQUIRE_ONCE = 261;
-PHP.Constants.T_LOGICAL_OR = 262;
-PHP.Constants.T_LOGICAL_XOR = 263;
-PHP.Constants.T_LOGICAL_AND = 264;
-PHP.Constants.T_PRINT = 265;
-PHP.Constants.T_YIELD = 266;
-PHP.Constants.T_DOUBLE_ARROW = 267;
-PHP.Constants.T_YIELD_FROM = 268;
-PHP.Constants.T_PLUS_EQUAL = 269;
-PHP.Constants.T_MINUS_EQUAL = 270;
-PHP.Constants.T_MUL_EQUAL = 271;
-PHP.Constants.T_DIV_EQUAL = 272;
-PHP.Constants.T_CONCAT_EQUAL = 273;
-PHP.Constants.T_MOD_EQUAL = 274;
-PHP.Constants.T_AND_EQUAL = 275;
-PHP.Constants.T_OR_EQUAL = 276;
-PHP.Constants.T_XOR_EQUAL = 277;
-PHP.Constants.T_SL_EQUAL = 278;
-PHP.Constants.T_SR_EQUAL = 279;
-PHP.Constants.T_POW_EQUAL = 280;
-PHP.Constants.T_COALESCE = 281;
-PHP.Constants.T_BOOLEAN_OR = 282;
-PHP.Constants.T_BOOLEAN_AND = 283;
-PHP.Constants.T_IS_EQUAL = 284;
-PHP.Constants.T_IS_NOT_EQUAL = 285;
-PHP.Constants.T_IS_IDENTICAL = 286;
-PHP.Constants.T_IS_NOT_IDENTICAL = 287;
-PHP.Constants.T_SPACESHIP = 288;
-PHP.Constants.T_IS_SMALLER_OR_EQUAL = 289;
-PHP.Constants.T_IS_GREATER_OR_EQUAL = 290;
-PHP.Constants.T_SL = 291;
-PHP.Constants.T_SR = 292;
-PHP.Constants.T_INSTANCEOF = 293;
-PHP.Constants.T_INC = 294;
-PHP.Constants.T_DEC = 295;
-PHP.Constants.T_INT_CAST = 296;
-PHP.Constants.T_DOUBLE_CAST = 297;
-PHP.Constants.T_STRING_CAST = 298;
-PHP.Constants.T_ARRAY_CAST = 299;
-PHP.Constants.T_OBJECT_CAST = 300;
-PHP.Constants.T_BOOL_CAST = 301;
-PHP.Constants.T_UNSET_CAST = 302;
-PHP.Constants.T_POW = 303;
-PHP.Constants.T_NEW = 304;
-PHP.Constants.T_CLONE = 305;
-PHP.Constants.T_EXIT = 306;
-PHP.Constants.T_IF = 307;
-PHP.Constants.T_ELSEIF = 308;
-PHP.Constants.T_ELSE = 309;
-PHP.Constants.T_ENDIF = 310;
-PHP.Constants.T_LNUMBER = 311;
-PHP.Constants.T_DNUMBER = 312;
-PHP.Constants.T_STRING = 313;
-PHP.Constants.T_STRING_VARNAME = 314;
-PHP.Constants.T_VARIABLE = 315;
-PHP.Constants.T_NUM_STRING = 316;
-PHP.Constants.T_INLINE_HTML = 317;
-PHP.Constants.T_CHARACTER = 318;
-PHP.Constants.T_BAD_CHARACTER = 319;
-PHP.Constants.T_ENCAPSED_AND_WHITESPACE = 320;
-PHP.Constants.T_CONSTANT_ENCAPSED_STRING = 321;
-PHP.Constants.T_ECHO = 322;
-PHP.Constants.T_DO = 323;
-PHP.Constants.T_WHILE = 324;
-PHP.Constants.T_ENDWHILE = 325;
-PHP.Constants.T_FOR = 326;
-PHP.Constants.T_ENDFOR = 327;
-PHP.Constants.T_FOREACH = 328;
-PHP.Constants.T_ENDFOREACH = 329;
-PHP.Constants.T_DECLARE = 330;
-PHP.Constants.T_ENDDECLARE = 331;
-PHP.Constants.T_AS = 332;
-PHP.Constants.T_SWITCH = 333;
-PHP.Constants.T_ENDSWITCH = 334;
-PHP.Constants.T_CASE = 335;
-PHP.Constants.T_DEFAULT = 336;
-PHP.Constants.T_BREAK = 337;
-PHP.Constants.T_CONTINUE = 338;
-PHP.Constants.T_GOTO = 339;
-PHP.Constants.T_FUNCTION = 340;
-PHP.Constants.T_CONST = 341;
-PHP.Constants.T_RETURN = 342;
-PHP.Constants.T_TRY = 343;
-PHP.Constants.T_CATCH = 344;
-PHP.Constants.T_FINALLY = 345;
-PHP.Constants.T_THROW = 346;
-PHP.Constants.T_USE = 347;
-PHP.Constants.T_INSTEADOF = 348;
-PHP.Constants.T_GLOBAL = 349;
-PHP.Constants.T_STATIC = 350;
-PHP.Constants.T_ABSTRACT = 351;
-PHP.Constants.T_FINAL = 352;
-PHP.Constants.T_PRIVATE = 353;
-PHP.Constants.T_PROTECTED = 354;
-PHP.Constants.T_PUBLIC = 355;
-PHP.Constants.T_VAR = 356;
-PHP.Constants.T_UNSET = 357;
-PHP.Constants.T_ISSET = 358;
-PHP.Constants.T_EMPTY = 359;
-PHP.Constants.T_HALT_COMPILER = 360;
-PHP.Constants.T_CLASS = 361;
-PHP.Constants.T_TRAIT = 362;
-PHP.Constants.T_INTERFACE = 363;
-PHP.Constants.T_EXTENDS = 364;
-PHP.Constants.T_IMPLEMENTS = 365;
-PHP.Constants.T_OBJECT_OPERATOR = 366;
-PHP.Constants.T_LIST = 367;
-PHP.Constants.T_ARRAY = 368;
-PHP.Constants.T_CALLABLE = 369;
-PHP.Constants.T_CLASS_C = 370;
-PHP.Constants.T_TRAIT_C = 371;
-PHP.Constants.T_METHOD_C = 372;
-PHP.Constants.T_FUNC_C = 373;
-PHP.Constants.T_LINE = 374;
-PHP.Constants.T_FILE = 375;
-PHP.Constants.T_COMMENT = 376;
-PHP.Constants.T_DOC_COMMENT = 377;
-PHP.Constants.T_OPEN_TAG = 378;
-PHP.Constants.T_OPEN_TAG_WITH_ECHO = 379;
-PHP.Constants.T_CLOSE_TAG = 380;
-PHP.Constants.T_WHITESPACE = 381;
-PHP.Constants.T_START_HEREDOC = 382;
-PHP.Constants.T_END_HEREDOC = 383;
-PHP.Constants.T_DOLLAR_OPEN_CURLY_BRACES = 384;
-PHP.Constants.T_CURLY_OPEN = 385;
-PHP.Constants.T_PAAMAYIM_NEKUDOTAYIM = 386;
-PHP.Constants.T_NAMESPACE = 387;
-PHP.Constants.T_NS_C = 388;
-PHP.Constants.T_DIR = 389;
-PHP.Constants.T_NS_SEPARATOR = 390;
-PHP.Constants.T_ELLIPSIS = 391;
+PHP.Constants.T_INCLUDE = 259
+PHP.Constants.T_INCLUDE_ONCE = 260
+PHP.Constants.T_EVAL = 318
+PHP.Constants.T_REQUIRE = 261
+PHP.Constants.T_REQUIRE_ONCE = 262
+PHP.Constants.T_LOGICAL_OR = 263
+PHP.Constants.T_LOGICAL_XOR = 264
+PHP.Constants.T_LOGICAL_AND = 265
+PHP.Constants.T_PRINT = 266
+PHP.Constants.T_YIELD = 267
+PHP.Constants.T_DOUBLE_ARROW = 268
+PHP.Constants.T_YIELD_FROM = 269
+PHP.Constants.T_PLUS_EQUAL = 270
+PHP.Constants.T_MINUS_EQUAL = 271
+PHP.Constants.T_MUL_EQUAL = 272
+PHP.Constants.T_DIV_EQUAL = 273
+PHP.Constants.T_CONCAT_EQUAL = 274
+PHP.Constants.T_MOD_EQUAL = 275
+PHP.Constants.T_AND_EQUAL = 276
+PHP.Constants.T_OR_EQUAL = 277
+PHP.Constants.T_XOR_EQUAL = 278
+PHP.Constants.T_SL_EQUAL = 279
+PHP.Constants.T_SR_EQUAL = 280
+PHP.Constants.T_POW_EQUAL = 281
+PHP.Constants.T_COALESCE_EQUAL = 282
+PHP.Constants.T_COALESCE = 283
+PHP.Constants.T_BOOLEAN_OR = 284
+PHP.Constants.T_BOOLEAN_AND = 285
+PHP.Constants.T_IS_EQUAL = 286
+PHP.Constants.T_IS_NOT_EQUAL = 287
+PHP.Constants.T_IS_IDENTICAL = 288
+PHP.Constants.T_IS_NOT_IDENTICAL = 289
+PHP.Constants.T_SPACESHIP = 290
+PHP.Constants.T_IS_SMALLER_OR_EQUAL = 291
+PHP.Constants.T_IS_GREATER_OR_EQUAL = 292
+PHP.Constants.T_SL = 293
+PHP.Constants.T_SR = 294
+PHP.Constants.T_INSTANCEOF = 295
+PHP.Constants.T_INC = 319
+PHP.Constants.T_DEC = 320
+PHP.Constants.T_INT_CAST = 296
+PHP.Constants.T_DOUBLE_CAST = 297
+PHP.Constants.T_STRING_CAST = 298
+PHP.Constants.T_ARRAY_CAST = 299
+PHP.Constants.T_OBJECT_CAST = 300
+PHP.Constants.T_BOOL_CAST = 301
+PHP.Constants.T_UNSET_CAST = 302
+PHP.Constants.T_POW = 303
+PHP.Constants.T_NEW = 304
+PHP.Constants.T_CLONE = 305
+PHP.Constants.T_EXIT = 321
+PHP.Constants.T_IF = 322
+PHP.Constants.T_ELSEIF = 307
+PHP.Constants.T_ELSE = 308
+PHP.Constants.T_ENDIF = 323
+PHP.Constants.T_LNUMBER = 309
+PHP.Constants.T_DNUMBER = 310
+PHP.Constants.T_STRING = 311
+PHP.Constants.T_STRING_VARNAME = 316
+PHP.Constants.T_VARIABLE = 312
+PHP.Constants.T_NUM_STRING = 317
+PHP.Constants.T_INLINE_HTML = 313
+PHP.Constants.T_BAD_CHARACTER = 395
+PHP.Constants.T_ENCAPSED_AND_WHITESPACE = 314
+PHP.Constants.T_CONSTANT_ENCAPSED_STRING = 315
+PHP.Constants.T_ECHO = 324
+PHP.Constants.T_DO = 325
+PHP.Constants.T_WHILE = 326
+PHP.Constants.T_ENDWHILE = 327
+PHP.Constants.T_FOR = 328
+PHP.Constants.T_ENDFOR = 329
+PHP.Constants.T_FOREACH = 330
+PHP.Constants.T_ENDFOREACH = 331
+PHP.Constants.T_DECLARE = 332
+PHP.Constants.T_ENDDECLARE = 333
+PHP.Constants.T_AS = 334
+PHP.Constants.T_SWITCH = 335
+PHP.Constants.T_ENDSWITCH = 336
+PHP.Constants.T_CASE = 337
+PHP.Constants.T_DEFAULT = 338
+PHP.Constants.T_BREAK = 339
+PHP.Constants.T_CONTINUE = 340
+PHP.Constants.T_GOTO = 341
+PHP.Constants.T_FUNCTION = 342
+PHP.Constants.T_FN = 343
+PHP.Constants.T_CONST = 344
+PHP.Constants.T_RETURN = 345
+PHP.Constants.T_TRY = 346
+PHP.Constants.T_CATCH = 347
+PHP.Constants.T_FINALLY = 348
+PHP.Constants.T_THROW = 349
+PHP.Constants.T_USE = 350
+PHP.Constants.T_INSTEADOF = 351
+PHP.Constants.T_GLOBAL = 352
+PHP.Constants.T_STATIC = 353
+PHP.Constants.T_ABSTRACT = 354
+PHP.Constants.T_FINAL = 355
+PHP.Constants.T_PRIVATE = 356
+PHP.Constants.T_PROTECTED = 357
+PHP.Constants.T_PUBLIC = 358
+PHP.Constants.T_VAR = 359
+PHP.Constants.T_UNSET = 360
+PHP.Constants.T_ISSET = 361
+PHP.Constants.T_EMPTY = 362
+PHP.Constants.T_HALT_COMPILER = 363
+PHP.Constants.T_CLASS = 364
+PHP.Constants.T_TRAIT = 365
+PHP.Constants.T_INTERFACE = 366
+PHP.Constants.T_EXTENDS = 367
+PHP.Constants.T_IMPLEMENTS = 368
+PHP.Constants.T_OBJECT_OPERATOR = 369
+PHP.Constants.T_DOUBLE_ARROW = 268
+PHP.Constants.T_LIST = 370
+PHP.Constants.T_ARRAY = 371
+PHP.Constants.T_CALLABLE = 372
+PHP.Constants.T_CLASS_C = 376
+PHP.Constants.T_TRAIT_C = 377
+PHP.Constants.T_METHOD_C = 378
+PHP.Constants.T_FUNC_C = 379
+PHP.Constants.T_LINE = 373
+PHP.Constants.T_FILE = 374
+PHP.Constants.T_COMMENT = 380
+PHP.Constants.T_DOC_COMMENT = 381
+PHP.Constants.T_OPEN_TAG = 382
+PHP.Constants.T_OPEN_TAG_WITH_ECHO = 383
+PHP.Constants.T_CLOSE_TAG = 384
+PHP.Constants.T_WHITESPACE = 385
+PHP.Constants.T_START_HEREDOC = 386
+PHP.Constants.T_END_HEREDOC = 387
+PHP.Constants.T_DOLLAR_OPEN_CURLY_BRACES = 388
+PHP.Constants.T_CURLY_OPEN = 389
+PHP.Constants.T_PAAMAYIM_NEKUDOTAYIM = 390
+PHP.Constants.T_NAMESPACE = 391
+PHP.Constants.T_NS_C = 392
+PHP.Constants.T_DIR = 375
+PHP.Constants.T_NS_SEPARATOR = 393
+PHP.Constants.T_ELLIPSIS = 394
 
 PHP.Lexer = function(src, ini) {
     var heredoc, heredocEndAllowed,
@@ -375,6 +377,10 @@ PHP.Lexer = function(src, ini) {
             {
                 value: PHP.Constants.T_FINALLY,
                 re: /^finally\b/i
+            },
+            {
+                value: PHP.Constants.T_FN,
+                re: /^fn\b/i
             },
             {
                 value: PHP.Constants.T_FOR,
@@ -1293,7 +1299,7 @@ PHP.Parser.prototype.getNextToken = function( ) {
 };
 
 PHP.Parser.prototype.tokenName = function( token ) {
-    var constants = ["T_INCLUDE","T_INCLUDE_ONCE","T_EVAL","T_REQUIRE","T_REQUIRE_ONCE","T_LOGICAL_OR","T_LOGICAL_XOR","T_LOGICAL_AND","T_PRINT","T_YIELD","T_DOUBLE_ARROW","T_YIELD_FROM","T_PLUS_EQUAL","T_MINUS_EQUAL","T_MUL_EQUAL","T_DIV_EQUAL","T_CONCAT_EQUAL","T_MOD_EQUAL","T_AND_EQUAL","T_OR_EQUAL","T_XOR_EQUAL","T_SL_EQUAL","T_SR_EQUAL","T_POW_EQUAL","T_COALESCE","T_BOOLEAN_OR","T_BOOLEAN_AND","T_IS_EQUAL","T_IS_NOT_EQUAL","T_IS_IDENTICAL","T_IS_NOT_IDENTICAL","T_SPACESHIP","T_IS_SMALLER_OR_EQUAL","T_IS_GREATER_OR_EQUAL","T_SL","T_SR","T_INSTANCEOF","T_INC","T_DEC","T_INT_CAST","T_DOUBLE_CAST","T_STRING_CAST","T_ARRAY_CAST","T_OBJECT_CAST","T_BOOL_CAST","T_UNSET_CAST","T_POW","T_NEW","T_CLONE","T_EXIT","T_IF","T_ELSEIF","T_ELSE","T_ENDIF","T_LNUMBER","T_DNUMBER","T_STRING","T_STRING_VARNAME","T_VARIABLE","T_NUM_STRING","T_INLINE_HTML","T_CHARACTER","T_BAD_CHARACTER","T_ENCAPSED_AND_WHITESPACE","T_CONSTANT_ENCAPSED_STRING","T_ECHO","T_DO","T_WHILE","T_ENDWHILE","T_FOR","T_ENDFOR","T_FOREACH","T_ENDFOREACH","T_DECLARE","T_ENDDECLARE","T_AS","T_SWITCH","T_ENDSWITCH","T_CASE","T_DEFAULT","T_BREAK","T_CONTINUE","T_GOTO","T_FUNCTION","T_CONST","T_RETURN","T_TRY","T_CATCH","T_FINALLY","T_THROW","T_USE","T_INSTEADOF","T_GLOBAL","T_STATIC","T_ABSTRACT","T_FINAL","T_PRIVATE","T_PROTECTED","T_PUBLIC","T_VAR","T_UNSET","T_ISSET","T_EMPTY","T_HALT_COMPILER","T_CLASS","T_TRAIT","T_INTERFACE","T_EXTENDS","T_IMPLEMENTS","T_OBJECT_OPERATOR","T_DOUBLE_ARROW","T_LIST","T_ARRAY","T_CALLABLE","T_CLASS_C","T_TRAIT_C","T_METHOD_C","T_FUNC_C","T_LINE","T_FILE","T_COMMENT","T_DOC_COMMENT","T_OPEN_TAG","T_OPEN_TAG_WITH_ECHO","T_CLOSE_TAG","T_WHITESPACE","T_START_HEREDOC","T_END_HEREDOC","T_DOLLAR_OPEN_CURLY_BRACES","T_CURLY_OPEN","T_PAAMAYIM_NEKUDOTAYIM","T_NAMESPACE","T_NS_C","T_DIR","T_NS_SEPARATOR","T_ELLIPSIS"];
+    var constants = ["T_INCLUDE","T_INCLUDE_ONCE","T_EVAL","T_REQUIRE","T_REQUIRE_ONCE","T_LOGICAL_OR","T_LOGICAL_XOR","T_LOGICAL_AND","T_PRINT","T_YIELD","T_DOUBLE_ARROW","T_YIELD_FROM","T_PLUS_EQUAL","T_MINUS_EQUAL","T_MUL_EQUAL","T_DIV_EQUAL","T_CONCAT_EQUAL","T_MOD_EQUAL","T_AND_EQUAL","T_OR_EQUAL","T_XOR_EQUAL","T_SL_EQUAL","T_SR_EQUAL","T_POW_EQUAL","T_COALESCE_EQUAL","T_COALESCE","T_BOOLEAN_OR","T_BOOLEAN_AND","T_IS_EQUAL","T_IS_NOT_EQUAL","T_IS_IDENTICAL","T_IS_NOT_IDENTICAL","T_SPACESHIP","T_IS_SMALLER_OR_EQUAL","T_IS_GREATER_OR_EQUAL","T_SL","T_SR","T_INSTANCEOF","T_INC","T_DEC","T_INT_CAST","T_DOUBLE_CAST","T_STRING_CAST","T_ARRAY_CAST","T_OBJECT_CAST","T_BOOL_CAST","T_UNSET_CAST","T_POW","T_NEW","T_CLONE","T_EXIT","T_IF","T_ELSEIF","T_ELSE","T_ENDIF","T_LNUMBER","T_DNUMBER","T_STRING","T_STRING_VARNAME","T_VARIABLE","T_NUM_STRING","T_INLINE_HTML","T_CHARACTER","T_BAD_CHARACTER","T_ENCAPSED_AND_WHITESPACE","T_CONSTANT_ENCAPSED_STRING","T_ECHO","T_DO","T_WHILE","T_ENDWHILE","T_FOR","T_ENDFOR","T_FOREACH","T_ENDFOREACH","T_DECLARE","T_ENDDECLARE","T_AS","T_SWITCH","T_ENDSWITCH","T_CASE","T_DEFAULT","T_BREAK","T_CONTINUE","T_GOTO","T_FUNCTION","T_FN","T_CONST","T_RETURN","T_TRY","T_CATCH","T_FINALLY","T_THROW","T_USE","T_INSTEADOF","T_GLOBAL","T_STATIC","T_ABSTRACT","T_FINAL","T_PRIVATE","T_PROTECTED","T_PUBLIC","T_VAR","T_UNSET","T_ISSET","T_EMPTY","T_HALT_COMPILER","T_CLASS","T_TRAIT","T_INTERFACE","T_EXTENDS","T_IMPLEMENTS","T_OBJECT_OPERATOR","T_DOUBLE_ARROW","T_LIST","T_ARRAY","T_CALLABLE","T_CLASS_C","T_TRAIT_C","T_METHOD_C","T_FUNC_C","T_LINE","T_FILE","T_COMMENT","T_DOC_COMMENT","T_OPEN_TAG","T_OPEN_TAG_WITH_ECHO","T_CLOSE_TAG","T_WHITESPACE","T_START_HEREDOC","T_END_HEREDOC","T_DOLLAR_OPEN_CURLY_BRACES","T_CURLY_OPEN","T_PAAMAYIM_NEKUDOTAYIM","T_NAMESPACE","T_NS_C","T_DIR","T_NS_SEPARATOR","T_ELLIPSIS"];
     var current = "UNKNOWN";
     constants.some(function( constant ) {
         if (PHP.Constants[ constant ] === token) {
@@ -1339,6 +1345,7 @@ PHP.Parser.prototype.createTokenMap = function() {
 };
 
 
+
 /* This is an automatically GENERATED file, which should not be manually edited.
  * Instead edit one of the following:
  *  * the grammar file grammar/zend_language_parser.jsy
@@ -1351,14 +1358,14 @@ PHP.Parser.prototype.createTokenMap = function() {
  */
 
 PHP.Parser.prototype.TOKEN_NONE    = -1;
-PHP.Parser.prototype.TOKEN_INVALID = 157;
+PHP.Parser.prototype.TOKEN_INVALID = 159;
 
-PHP.Parser.prototype.TOKEN_MAP_SIZE = 392;
+PHP.Parser.prototype.TOKEN_MAP_SIZE = 394;
 
-PHP.Parser.prototype.YYLAST       = 889;
-PHP.Parser.prototype.YY2TBLSTATE  = 337;
-PHP.Parser.prototype.YYGLAST      = 410;
-PHP.Parser.prototype.YYNLSTATES   = 564;
+PHP.Parser.prototype.YYLAST       = 964;
+PHP.Parser.prototype.YY2TBLSTATE  = 348;
+PHP.Parser.prototype.YYGLAST      = 508;
+PHP.Parser.prototype.YYNLSTATES   = 602;
 PHP.Parser.prototype.YYUNEXPECTED = 32767;
 PHP.Parser.prototype.YYDEFAULT    = -32766;
 
@@ -1388,122 +1395,124 @@ PHP.Parser.prototype.T_XOR_EQUAL = 277;
 PHP.Parser.prototype.T_SL_EQUAL = 278;
 PHP.Parser.prototype.T_SR_EQUAL = 279;
 PHP.Parser.prototype.T_POW_EQUAL = 280;
-PHP.Parser.prototype.T_COALESCE = 281;
-PHP.Parser.prototype.T_BOOLEAN_OR = 282;
-PHP.Parser.prototype.T_BOOLEAN_AND = 283;
-PHP.Parser.prototype.T_IS_EQUAL = 284;
-PHP.Parser.prototype.T_IS_NOT_EQUAL = 285;
-PHP.Parser.prototype.T_IS_IDENTICAL = 286;
-PHP.Parser.prototype.T_IS_NOT_IDENTICAL = 287;
-PHP.Parser.prototype.T_SPACESHIP = 288;
-PHP.Parser.prototype.T_IS_SMALLER_OR_EQUAL = 289;
-PHP.Parser.prototype.T_IS_GREATER_OR_EQUAL = 290;
-PHP.Parser.prototype.T_SL = 291;
-PHP.Parser.prototype.T_SR = 292;
-PHP.Parser.prototype.T_INSTANCEOF = 293;
-PHP.Parser.prototype.T_INC = 294;
-PHP.Parser.prototype.T_DEC = 295;
-PHP.Parser.prototype.T_INT_CAST = 296;
-PHP.Parser.prototype.T_DOUBLE_CAST = 297;
-PHP.Parser.prototype.T_STRING_CAST = 298;
-PHP.Parser.prototype.T_ARRAY_CAST = 299;
-PHP.Parser.prototype.T_OBJECT_CAST = 300;
-PHP.Parser.prototype.T_BOOL_CAST = 301;
-PHP.Parser.prototype.T_UNSET_CAST = 302;
-PHP.Parser.prototype.T_POW = 303;
-PHP.Parser.prototype.T_NEW = 304;
-PHP.Parser.prototype.T_CLONE = 305;
-PHP.Parser.prototype.T_EXIT = 306;
-PHP.Parser.prototype.T_IF = 307;
-PHP.Parser.prototype.T_ELSEIF = 308;
-PHP.Parser.prototype.T_ELSE = 309;
-PHP.Parser.prototype.T_ENDIF = 310;
-PHP.Parser.prototype.T_LNUMBER = 311;
-PHP.Parser.prototype.T_DNUMBER = 312;
-PHP.Parser.prototype.T_STRING = 313;
-PHP.Parser.prototype.T_STRING_VARNAME = 314;
-PHP.Parser.prototype.T_VARIABLE = 315;
-PHP.Parser.prototype.T_NUM_STRING = 316;
-PHP.Parser.prototype.T_INLINE_HTML = 317;
-PHP.Parser.prototype.T_CHARACTER = 318;
-PHP.Parser.prototype.T_BAD_CHARACTER = 319;
-PHP.Parser.prototype.T_ENCAPSED_AND_WHITESPACE = 320;
-PHP.Parser.prototype.T_CONSTANT_ENCAPSED_STRING = 321;
-PHP.Parser.prototype.T_ECHO = 322;
-PHP.Parser.prototype.T_DO = 323;
-PHP.Parser.prototype.T_WHILE = 324;
-PHP.Parser.prototype.T_ENDWHILE = 325;
-PHP.Parser.prototype.T_FOR = 326;
-PHP.Parser.prototype.T_ENDFOR = 327;
-PHP.Parser.prototype.T_FOREACH = 328;
-PHP.Parser.prototype.T_ENDFOREACH = 329;
-PHP.Parser.prototype.T_DECLARE = 330;
-PHP.Parser.prototype.T_ENDDECLARE = 331;
-PHP.Parser.prototype.T_AS = 332;
-PHP.Parser.prototype.T_SWITCH = 333;
-PHP.Parser.prototype.T_ENDSWITCH = 334;
-PHP.Parser.prototype.T_CASE = 335;
-PHP.Parser.prototype.T_DEFAULT = 336;
-PHP.Parser.prototype.T_BREAK = 337;
-PHP.Parser.prototype.T_CONTINUE = 338;
-PHP.Parser.prototype.T_GOTO = 339;
-PHP.Parser.prototype.T_FUNCTION = 340;
-PHP.Parser.prototype.T_CONST = 341;
-PHP.Parser.prototype.T_RETURN = 342;
-PHP.Parser.prototype.T_TRY = 343;
-PHP.Parser.prototype.T_CATCH = 344;
-PHP.Parser.prototype.T_FINALLY = 345;
-PHP.Parser.prototype.T_THROW = 346;
-PHP.Parser.prototype.T_USE = 347;
-PHP.Parser.prototype.T_INSTEADOF = 348;
-PHP.Parser.prototype.T_GLOBAL = 349;
-PHP.Parser.prototype.T_STATIC = 350;
-PHP.Parser.prototype.T_ABSTRACT = 351;
-PHP.Parser.prototype.T_FINAL = 352;
-PHP.Parser.prototype.T_PRIVATE = 353;
-PHP.Parser.prototype.T_PROTECTED = 354;
-PHP.Parser.prototype.T_PUBLIC = 355;
-PHP.Parser.prototype.T_VAR = 356;
-PHP.Parser.prototype.T_UNSET = 357;
-PHP.Parser.prototype.T_ISSET = 358;
-PHP.Parser.prototype.T_EMPTY = 359;
-PHP.Parser.prototype.T_HALT_COMPILER = 360;
-PHP.Parser.prototype.T_CLASS = 361;
-PHP.Parser.prototype.T_TRAIT = 362;
-PHP.Parser.prototype.T_INTERFACE = 363;
-PHP.Parser.prototype.T_EXTENDS = 364;
-PHP.Parser.prototype.T_IMPLEMENTS = 365;
-PHP.Parser.prototype.T_OBJECT_OPERATOR = 366;
-PHP.Parser.prototype.T_LIST = 367;
-PHP.Parser.prototype.T_ARRAY = 368;
-PHP.Parser.prototype.T_CALLABLE = 369;
-PHP.Parser.prototype.T_CLASS_C = 370;
-PHP.Parser.prototype.T_TRAIT_C = 371;
-PHP.Parser.prototype.T_METHOD_C = 372;
-PHP.Parser.prototype.T_FUNC_C = 373;
-PHP.Parser.prototype.T_LINE = 374;
-PHP.Parser.prototype.T_FILE = 375;
-PHP.Parser.prototype.T_COMMENT = 376;
-PHP.Parser.prototype.T_DOC_COMMENT = 377;
-PHP.Parser.prototype.T_OPEN_TAG = 378;
-PHP.Parser.prototype.T_OPEN_TAG_WITH_ECHO = 379;
-PHP.Parser.prototype.T_CLOSE_TAG = 380;
-PHP.Parser.prototype.T_WHITESPACE = 381;
-PHP.Parser.prototype.T_START_HEREDOC = 382;
-PHP.Parser.prototype.T_END_HEREDOC = 383;
-PHP.Parser.prototype.T_DOLLAR_OPEN_CURLY_BRACES = 384;
-PHP.Parser.prototype.T_CURLY_OPEN = 385;
-PHP.Parser.prototype.T_PAAMAYIM_NEKUDOTAYIM = 386;
-PHP.Parser.prototype.T_NAMESPACE = 387;
-PHP.Parser.prototype.T_NS_C = 388;
-PHP.Parser.prototype.T_DIR = 389;
-PHP.Parser.prototype.T_NS_SEPARATOR = 390;
-PHP.Parser.prototype.T_ELLIPSIS = 391;
+PHP.Parser.prototype.T_COALESCE_EQUAL = 281;
+PHP.Parser.prototype.T_COALESCE = 282;
+PHP.Parser.prototype.T_BOOLEAN_OR = 283;
+PHP.Parser.prototype.T_BOOLEAN_AND = 284;
+PHP.Parser.prototype.T_IS_EQUAL = 285;
+PHP.Parser.prototype.T_IS_NOT_EQUAL = 286;
+PHP.Parser.prototype.T_IS_IDENTICAL = 287;
+PHP.Parser.prototype.T_IS_NOT_IDENTICAL = 288;
+PHP.Parser.prototype.T_SPACESHIP = 289;
+PHP.Parser.prototype.T_IS_SMALLER_OR_EQUAL = 290;
+PHP.Parser.prototype.T_IS_GREATER_OR_EQUAL = 291;
+PHP.Parser.prototype.T_SL = 292;
+PHP.Parser.prototype.T_SR = 293;
+PHP.Parser.prototype.T_INSTANCEOF = 294;
+PHP.Parser.prototype.T_INC = 295;
+PHP.Parser.prototype.T_DEC = 296;
+PHP.Parser.prototype.T_INT_CAST = 297;
+PHP.Parser.prototype.T_DOUBLE_CAST = 298;
+PHP.Parser.prototype.T_STRING_CAST = 299;
+PHP.Parser.prototype.T_ARRAY_CAST = 300;
+PHP.Parser.prototype.T_OBJECT_CAST = 301;
+PHP.Parser.prototype.T_BOOL_CAST = 302;
+PHP.Parser.prototype.T_UNSET_CAST = 303;
+PHP.Parser.prototype.T_POW = 304;
+PHP.Parser.prototype.T_NEW = 305;
+PHP.Parser.prototype.T_CLONE = 306;
+PHP.Parser.prototype.T_EXIT = 307;
+PHP.Parser.prototype.T_IF = 308;
+PHP.Parser.prototype.T_ELSEIF = 309;
+PHP.Parser.prototype.T_ELSE = 310;
+PHP.Parser.prototype.T_ENDIF = 311;
+PHP.Parser.prototype.T_LNUMBER = 312;
+PHP.Parser.prototype.T_DNUMBER = 313;
+PHP.Parser.prototype.T_STRING = 314;
+PHP.Parser.prototype.T_STRING_VARNAME = 315;
+PHP.Parser.prototype.T_VARIABLE = 316;
+PHP.Parser.prototype.T_NUM_STRING = 317;
+PHP.Parser.prototype.T_INLINE_HTML = 318;
+PHP.Parser.prototype.T_CHARACTER = 319;
+PHP.Parser.prototype.T_BAD_CHARACTER = 320;
+PHP.Parser.prototype.T_ENCAPSED_AND_WHITESPACE = 321;
+PHP.Parser.prototype.T_CONSTANT_ENCAPSED_STRING = 322;
+PHP.Parser.prototype.T_ECHO = 323;
+PHP.Parser.prototype.T_DO = 324;
+PHP.Parser.prototype.T_WHILE = 325;
+PHP.Parser.prototype.T_ENDWHILE = 326;
+PHP.Parser.prototype.T_FOR = 327;
+PHP.Parser.prototype.T_ENDFOR = 328;
+PHP.Parser.prototype.T_FOREACH = 329;
+PHP.Parser.prototype.T_ENDFOREACH = 330;
+PHP.Parser.prototype.T_DECLARE = 331;
+PHP.Parser.prototype.T_ENDDECLARE = 332;
+PHP.Parser.prototype.T_AS = 333;
+PHP.Parser.prototype.T_SWITCH = 334;
+PHP.Parser.prototype.T_ENDSWITCH = 335;
+PHP.Parser.prototype.T_CASE = 336;
+PHP.Parser.prototype.T_DEFAULT = 337;
+PHP.Parser.prototype.T_BREAK = 338;
+PHP.Parser.prototype.T_CONTINUE = 339;
+PHP.Parser.prototype.T_GOTO = 340;
+PHP.Parser.prototype.T_FUNCTION = 341;
+PHP.Parser.prototype.T_FN = 342;
+PHP.Parser.prototype.T_CONST = 343;
+PHP.Parser.prototype.T_RETURN = 344;
+PHP.Parser.prototype.T_TRY = 345;
+PHP.Parser.prototype.T_CATCH = 346;
+PHP.Parser.prototype.T_FINALLY = 347;
+PHP.Parser.prototype.T_THROW = 348;
+PHP.Parser.prototype.T_USE = 349;
+PHP.Parser.prototype.T_INSTEADOF = 350;
+PHP.Parser.prototype.T_GLOBAL = 351;
+PHP.Parser.prototype.T_STATIC = 352;
+PHP.Parser.prototype.T_ABSTRACT = 353;
+PHP.Parser.prototype.T_FINAL = 354;
+PHP.Parser.prototype.T_PRIVATE = 355;
+PHP.Parser.prototype.T_PROTECTED = 356;
+PHP.Parser.prototype.T_PUBLIC = 357;
+PHP.Parser.prototype.T_VAR = 358;
+PHP.Parser.prototype.T_UNSET = 359;
+PHP.Parser.prototype.T_ISSET = 360;
+PHP.Parser.prototype.T_EMPTY = 361;
+PHP.Parser.prototype.T_HALT_COMPILER = 362;
+PHP.Parser.prototype.T_CLASS = 363;
+PHP.Parser.prototype.T_TRAIT = 364;
+PHP.Parser.prototype.T_INTERFACE = 365;
+PHP.Parser.prototype.T_EXTENDS = 366;
+PHP.Parser.prototype.T_IMPLEMENTS = 367;
+PHP.Parser.prototype.T_OBJECT_OPERATOR = 368;
+PHP.Parser.prototype.T_LIST = 369;
+PHP.Parser.prototype.T_ARRAY = 370;
+PHP.Parser.prototype.T_CALLABLE = 371;
+PHP.Parser.prototype.T_CLASS_C = 372;
+PHP.Parser.prototype.T_TRAIT_C = 373;
+PHP.Parser.prototype.T_METHOD_C = 374;
+PHP.Parser.prototype.T_FUNC_C = 375;
+PHP.Parser.prototype.T_LINE = 376;
+PHP.Parser.prototype.T_FILE = 377;
+PHP.Parser.prototype.T_COMMENT = 378;
+PHP.Parser.prototype.T_DOC_COMMENT = 379;
+PHP.Parser.prototype.T_OPEN_TAG = 380;
+PHP.Parser.prototype.T_OPEN_TAG_WITH_ECHO = 381;
+PHP.Parser.prototype.T_CLOSE_TAG = 382;
+PHP.Parser.prototype.T_WHITESPACE = 383;
+PHP.Parser.prototype.T_START_HEREDOC = 384;
+PHP.Parser.prototype.T_END_HEREDOC = 385;
+PHP.Parser.prototype.T_DOLLAR_OPEN_CURLY_BRACES = 386;
+PHP.Parser.prototype.T_CURLY_OPEN = 387;
+PHP.Parser.prototype.T_PAAMAYIM_NEKUDOTAYIM = 388;
+PHP.Parser.prototype.T_NAMESPACE = 389;
+PHP.Parser.prototype.T_NS_C = 390;
+PHP.Parser.prototype.T_DIR = 391;
+PHP.Parser.prototype.T_NS_SEPARATOR = 392;
+PHP.Parser.prototype.T_ELLIPSIS = 393;
 // }}}
 
 /* @var array Map of token ids to their respective names */
 PHP.Parser.prototype.terminals = [
-    "$EOF",
+    "EOF",
     "error",
     "T_INCLUDE",
     "T_INCLUDE_ONCE",
@@ -1531,6 +1540,7 @@ PHP.Parser.prototype.terminals = [
     "T_SL_EQUAL",
     "T_SR_EQUAL",
     "T_POW_EQUAL",
+    "T_COALESCE_EQUAL",
     "'?'",
     "':'",
     "T_COALESCE",
@@ -1606,6 +1616,7 @@ PHP.Parser.prototype.terminals = [
     "T_CONTINUE",
     "T_GOTO",
     "T_FUNCTION",
+    "T_FN",
     "T_CONST",
     "T_RETURN",
     "T_TRY",
@@ -1665,504 +1676,554 @@ PHP.Parser.prototype.terminals = [
 
 /* @var Map which translates lexer tokens to internal tokens */
 PHP.Parser.prototype.translate = [
-        0,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,   53,  155,  157,  156,   52,   35,  157,
-      151,  152,   50,   47,    7,   48,   49,   51,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,   29,  148,
-       41,   15,   43,   28,   65,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,   67,  157,  154,   34,  157,  153,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  149,   33,  150,   55,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,    1,    2,    3,    4,
+        0,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,   54,  157,  159,  158,   53,   36,  159,
+      153,  154,   51,   48,    7,   49,   50,   52,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,   30,  150,
+       42,   15,   44,   29,   66,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,   68,  159,  156,   35,  159,  155,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  151,   34,  152,   56,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,  159,  159,  159,  159,
+      159,  159,  159,  159,  159,  159,    1,    2,    3,    4,
         5,    6,    8,    9,   10,   11,   12,   13,   14,   16,
        17,   18,   19,   20,   21,   22,   23,   24,   25,   26,
-       27,   30,   31,   32,   36,   37,   38,   39,   40,   42,
-       44,   45,   46,   54,   56,   57,   58,   59,   60,   61,
-       62,   63,   64,   66,   68,   69,   70,   71,   72,   73,
-       74,   75,   76,   77,   78,   79,   80,   81,  157,  157,
-       82,   83,   84,   85,   86,   87,   88,   89,   90,   91,
+       27,   28,   31,   32,   33,   37,   38,   39,   40,   41,
+       43,   45,   46,   47,   55,   57,   58,   59,   60,   61,
+       62,   63,   64,   65,   67,   69,   70,   71,   72,   73,
+       74,   75,   76,   77,   78,   79,   80,   81,   82,  159,
+      159,   83,   84,   85,   86,   87,   88,   89,   90,   91,
        92,   93,   94,   95,   96,   97,   98,   99,  100,  101,
       102,  103,  104,  105,  106,  107,  108,  109,  110,  111,
       112,  113,  114,  115,  116,  117,  118,  119,  120,  121,
       122,  123,  124,  125,  126,  127,  128,  129,  130,  131,
-      132,  133,  134,  135,  136,  137,  157,  157,  157,  157,
-      157,  157,  138,  139,  140,  141,  142,  143,  144,  145,
-      146,  147
+      132,  133,  134,  135,  136,  137,  138,  139,  159,  159,
+      159,  159,  159,  159,  140,  141,  142,  143,  144,  145,
+      146,  147,  148,  149
 ];
 
 PHP.Parser.prototype.yyaction = [
-      569,  570,  571,  572,  573,  215,  574,  575,  576,  612,
-      613,    0,   27,   99,  100,  101,  102,  103,  104,  105,
-      106,  107,  108,  109,  110,-32766,-32766,-32766,   95,   96,
-       97,   24,  240,  226, -267,-32766,-32766,-32766,-32766,-32766,
-    -32766,  530,  344,  114,   98,-32766,  286,-32766,-32766,-32766,
-    -32766,-32766,  577,  870,  872,-32766,-32766,-32766,-32766,-32766,
-    -32766,-32766,-32766,  224,-32766,  714,  578,  579,  580,  581,
-      582,  583,  584,-32766,  264,  644,  840,  841,  842,  839,
-      838,  837,  585,  586,  587,  588,  589,  590,  591,  592,
-      593,  594,  595,  615,  616,  617,  618,  619,  607,  608,
-      609,  610,  611,  596,  597,  598,  599,  600,  601,  602,
-      638,  639,  640,  641,  642,  643,  603,  604,  605,  606,
-      636,  627,  625,  626,  622,  623,  116,  614,  620,  621,
-      628,  629,  631,  630,  632,  633,   42,   43,  381,   44,
-       45,  624,  635,  634, -214,   46,   47,  289,   48,-32767,
-    -32767,-32767,-32767,   90,   91,   92,   93,   94,  267,  241,
-       22,  840,  841,  842,  839,  838,  837,  832,-32766,-32766,
-    -32766,  306, 1000, 1000, 1037,  120,  966,  436, -423,  244,
-      797,   49,   50,  660,  661,  272,  362,   51,-32766,   52,
-      219,  220,   53,   54,   55,   56,   57,   58,   59,   60,
-     1016,   22,  238,   61,  351,  945,-32766,-32766,-32766,  967,
-      968,  646,  705, 1000,   28, -456,  125,  966,-32766,-32766,
-    -32766,  715,  398,  399,  216, 1000,-32766,  339,-32766,-32766,
-    -32766,-32766,   25,  222,  980,  552,  355,  378,-32766, -423,
-    -32766,-32766,-32766,  121,   65, 1045,  408, 1047, 1046,  274,
-      274,  131,  244, -423,  394,  395,  358,  519,  945,  537,
-     -423,  111, -426,  398,  399,  130,  972,  973,  974,  975,
-      969,  970,  243,  128, -422, -421, 1013,  409,  976,  971,
-      353,  791,  792,    7, -162,   63,  124,  255,  701,  256,
-      274,  382, -122, -122, -122,   -4,  715,  383,  646, 1042,
-     -421,  704,  274, -219,   33,   17,  384, -122,  385, -122,
-      386, -122,  387, -122,  369,  388, -122, -122, -122,   34,
-       35,  389,  352,  520,   36,  390,  353,  702,   62,  112,
-      818,  287,  288,  391,  392, -422, -421, -161,  350,  393,
-       40,   38,  690,  735,  396,  397,  361,   22,  122, -422,
-     -421,-32766,-32766,-32766,  791,  792, -422, -421, -425, 1000,
-     -456, -421, -238,  966,  409,   41,  382,  353,  717,  535,
-     -122,-32766,  383,-32766,-32766, -421,  704,   21,  813,   33,
-       17,  384, -421,  385, -466,  386,  224,  387, -467,  273,
-      388,  367,  945, -458,   34,   35,  389,  352,  345,   36,
-      390,  248,  247,   62,  254,  715,  287,  288,  391,  392,
-      399,-32766,-32766,-32766,  393,  295, 1000,  652,  735,  396,
-      397,  117,  115,  113,  814,  119,   72,   73,   74, -162,
-      764,   65,  240,  541,  370,  518,  274,  118,  270,   92,
-       93,   94,  242,  717,  535,   -4,   26, 1000,   75,   76,
-       77,   78,   79,   80,   81,   82,   83,   84,   85,   86,
-       87,   88,   89,   90,   91,   92,   93,   94,   95,   96,
-       97,  547,  240,  713,  715,  382,  276,-32766,-32766,  126,
-      945,  383, -161,  938,   98,  704,  225,  659,   33,   17,
-      384,  346,  385,  274,  386,  728,  387,  221,  120,  388,
-      505,  506,  540,   34,   35,  389,  715, -238,   36,  390,
-     1017,  223,   62,  494,   18,  287,  288,  127,  297,  376,
-        6,   98,  798,  393,  274,  660,  661,  490,  491, -466,
-       39, -466,  514, -467,  539, -467,   16,  458, -458,  315,
-      791,  792,  829,  553,  382,  817,  563,  653,  538,  765,
-      383,  449,  751,  535,  704,  448,  435,   33,   17,  384,
-      430,  385,  646,  386,  359,  387,  357,  647,  388,  673,
-      429, 1040,   34,   35,  389,  715,  382,   36,  390,  941,
-      492,   62,  383,  503,  287,  288,  704,  434,  440,   33,
-       17,  384,  393,  385,-32766,  386,  445,  387,  495,  509,
-      388,   10,  529,  542,   34,   35,  389,  715,  515,   36,
-      390,  499,  500,   62,  214,  -80,  287,  288,  452,  269,
-      736,  717,  535,  488,  393,  356,  266,  979,  265,  730,
-      982,  722,  358,  338,  493,  548,    0,  294,  737,    0,
-        3,    0,  309,    0,    0,  382,    0,    0,  271,    0,
-        0,  383,    0,  717,  535,  704,  227,    0,   33,   17,
-      384,    9,  385,    0,  386,    0,  387, -382,    0,  388,
-        0,    0,  325,   34,   35,  389,  715,  382,   36,  390,
-      321,  341,   62,  383,  340,  287,  288,  704,   22,  320,
-       33,   17,  384,  393,  385,  442,  386,  337,  387,  562,
-     1000,  388,   32,   31,  966,   34,   35,  389,  823,  657,
-       36,  390,  656,  821,   62,  703,  711,  287,  288,  561,
-      822,  825,  717,  535,  695,  393,  747,  749,  693,  759,
-      758,  752,  767,  945,  824,  706,  700,  712,  699,  698,
-      658,    0,  263,  262,  559,  558,  382,  556,  554,  551,
-      398,  399,  383,  550,  717,  535,  704,  546,  545,   33,
-       17,  384,  543,  385,  536,  386,   71,  387,  933,  932,
-      388,   30,   65,  731,   34,   35,  389,  274,  724,   36,
-      390,  830,  734,   62,  663,  662,  287,  288,-32766,-32766,
-    -32766,  733,  732,  934,  393,  665,  664,  756,  555,  691,
-     1041, 1001,  994, 1006, 1011, 1014,  757, 1043,-32766,  654,
-    -32766,-32766,-32766,-32766,-32766,-32766,-32767,-32767,-32767,-32767,
-    -32767,  655, 1044,  717,  535, -446,  926,  348,  343,  268,
-      237,  236,  235,  234,  218,  217,  132,  129, -426, -425,
-     -424,  123,   20,   23,   70,   69,   29,   37,   64,   68,
-       66,   67, -448,    0,   15,   19,  250,  910,  296, -217,
-      467,  484,  909,  472,  528,  913,   11,  964,  955, -215,
-      525,  379,  375,  373,  371,   14,   13,   12, -214,    0,
-     -393,    0, 1005, 1039,  992,  993,  963,    0,  981
+      607,  608,  609,  610,  611,  685,  612,  613,  614,  650,
+      651,    0,   32,  103,  104,  105,  106,  107,  108,  109,
+      110,  111,  112,  113,  114,  115,-32767,-32767,-32767,-32767,
+       94,   95,   96,   97,   98,-32766,-32766,-32766,  687,  491,
+     -497,  904,  905,  906,  903,  902,  901,  904,  905,  906,
+      903,  902,  901,  615,  938,  940,-32766,    9,-32766,-32766,
+    -32766,-32766,-32766,-32766,-32766,-32766,-32766,  616,  617,  618,
+      619,  620,  621,  622,  333, 1104,  683,-32766,-32766,-32766,
+      846, 1103,  119,  623,  624,  625,  626,  627,  628,  629,
+      630,  631,  632,  633,  653,  654,  655,  656,  657,  645,
+      646,  647,  675,  648,  649,  634,  635,  636,  637,  638,
+      639,  640,  677,  678,  679,  680,  681,  682,  641,  642,
+      643,  644,  674,  665,  663,  664,  660,  661,  402,  652,
+      658,  659,  666,  667,  669,  668,  670,  671,   45,   46,
+      421,   47,   48,  662,  673,  672,   27,   49,   50,  233,
+       51,-32766,-32766,-32766,   96,   97,   98,   24,-32766,-32766,
+    -32766, -458,  261,  121, 1023,-32766,-32766,-32766, 1091, 1073,
+    -32766,-32766,-32766, 1039,-32766,-32766,-32766,-32766,-32766,-32766,
+     -496,-32766,-32766,-32766,   52,   53,-32766, -497,-32766,-32766,
+       54,  687,   55,  231,  232,   56,   57,   58,   59,   60,
+       61,   62,   63, 1016,   24,  242,   64,  369,-32766,-32766,
+    -32766,  226, 1040, 1041,  423, 1076, 1073, -493,  880,  508,
+     1039,  436, 1023, -458,  768, 1073,  239,  333, -500,-32766,
+     -500,-32766,-32766,-32766,-32766,  856,  253, -458,  276,  378,
+      372,  786,   68, 1073, -458,  685, -461,  278, 1126,  403,
+      289, 1127,  288,   99,  100,  101,  303,  252,  433,  434,
+      822,-32766,   69,  261,  237,  850,  851,  435,  436,  102,
+     1045, 1046, 1047, 1048, 1042, 1043,  256, 1016, -456, -456,
+      306,  444, 1049, 1044,  375,  133,  561, -239,  363,   66,
+      237,  268,  692,  273,  278,  422, -137, -137, -137,   -4,
+      768, 1073,  310,  278, 1035,  757,  687,  362,   37,   20,
+      424, -137,  425, -137,  426, -137,  427, -137,  127,  428,
+     -295,  278, -295,   38,   39,  370,  371, -496,  271,   40,
+      429,  277,  687,   65,  261, 1016,  302,  896,  430,  431,
+     -456, -456,  333, -494,  432,   44,   42,  743,  791,  373,
+      374, -457, -234,  562, -456, -456,  375,-32766,-32766,-32766,
+      882, -456, -456,  124, -493,   75,  850,  851,  333, -273,
+     -260,  422,  768,  770,  576, -137,  261,  125,-32766,  278,
+      823,  757,  857, 1073,   37,   20,  424,  240,  425, -178,
+      426,  589,  427,  393,  503,  428,  687,  235,  241,   38,
+       39,  370,  371,  125,  354,   40,  429,  260,  259,   65,
+      267,  687,  302, -457,  430,  431, -296, -177, -296,   24,
+      432,  305,  365,  700,  791,  373,  374, -457,  120,  118,
+       24, 1073,   30,  366, -457, 1039, -460,  850,  851,  687,
+      367,  691, 1073,  422,  291,  768, 1039,  333,  -83,  770,
+      576,   -4,  467,  757,  126,  368,   37,   20,  424,  -92,
+      425,  278,  426,  444,  427, 1016,  375,  428, -219, -219,
+     -219,   38,   39,  370,  371,  333, 1016,   40,  429,  850,
+      851,   65,  435,  436,  302,  236,  430,  431,  225,  708,
+     -494,  709,  432,  435,  436,  743,  791,  373,  374,  690,
+      387,  136, 1117,  578,   68,  413,  238,    8,   33,  278,
+     1053,  227,  708,  687,  709,   68,  422, -260,  535,   21,
+      278,  770,  576, -219,  550,  551,  757,  687,  116,   37,
+       20,  424,  117,  425,  358,  426, -178,  427,  132,  328,
+      428, -218, -218, -218,   38,   39,  370,  371,  687,  333,
+       40,  429,  122,  768,   65,  383,  384,  302,  123,  430,
+      431,   29,  234,  333, -177,  432,  528,  529,  743,  791,
+      373,  374,  129,  850,  851,  135,   76,   77,   78, 1092,
+      881,  599,  582,  254,  333,  137,  138,  782,  590,  593,
+      293,  767,  131,  252,  770,  576, -218,   31,  102,   79,
+       80,   81,   82,   83,   84,   85,   86,   87,   88,   89,
+       90,   91,   92,   93,   94,   95,   96,   97,   98,   99,
+      100,  101,   43,  252,  422,  558,  768,  687,  690,-32766,
+      471,  130,  476,  685,  757,  102,  553,   37,   20,  424,
+      526,  425,  688,  426,  272,  427,  910, 1016,  428,  792,
+     1128,  793,   38,   39,  370,  583,  269,  570,   40,  429,
+      536, 1052,   65,  275, 1055,  302, -415,  541,  270,  -81,
+       10,  391,  768,  432,  542,  554,  784,  594,    5,    0,
+       12,  577,    0,    0,  304,    0,    0,    0,    0,  336,
+      342,    0,    0,    0,    0,    0,    0,  422,    0,    0,
+        0,  584,  770,  576,    0,    0,    0,  757,    0,    0,
+       37,   20,  424,  343,  425,    0,  426,    0,  427,  768,
+        0,  428,    0,    0,    0,   38,   39,  370,  347,  387,
+      473,   40,  429,  359,  360,   65,  744,   35,  302,   36,
+      597,  598,  748,  422,  825,  809,  432,  816,  587,  876,
+      877,  806,  817,  757,  746,  804,   37,   20,  424,  885,
+      425,  888,  426,  889,  427,  768,  886,  428,  887,  893,
+     -485,   38,   39,  370,  579,  770,  576,   40,  429,  581,
+      585,   65,  586,  588,  302,  592,  286,  287,  352,  353,
+      422,  580,  432, 1123,  591, 1125,  703,  790,  702,  712,
+      757,  789,  713,   37,   20,  424,  710,  425, 1124,  426,
+      788,  427,  768, 1004,  428,  711,  777,  785,   38,   39,
+      370,  808,  576, -483,   40,  429,  775,  814,   65,  815,
+     1122,  302, 1074, 1067, 1081, 1086,  422, 1089, -237,  432,
+     -461, -460, -459,   23,   25,   28,  757,   34,   41,   37,
+       20,  424,   67,  425,   70,  426,   71,  427,   72,   73,
+      428,   74,  128,  134,   38,   39,  370,  139,  770,  576,
+       40,  429,  229,  230,   65,  246,  247,  302,  248,  249,
+      250,  251,  290,  422,  355,  432,  357, -427, -235, -234,
+       14,   15,   16,  757,   17,   19,   37,   20,  424,  325,
+      425,  404,  426,  406,  427,  409,  411,  428,  412,  419,
+      567,   38,   39,  370,  770,  576, 1027,   40,  429,  977,
+     1037,   65,  858, 1008,  302,-32766,-32766,-32766,  -92,   13,
+       18,   22,  432,  263,  324,  501,  522,  569,  981,  978,
+        0,  994,    0, 1036, 1065, 1066,-32766, 1080,-32766,-32766,
+    -32766,-32766,-32766,-32766,-32767,-32767,-32767,-32767,-32767, 1120,
+      532,  770,  576, 1054
 ];
 
 PHP.Parser.prototype.yycheck = [
-        2,    3,    4,    5,    6,   13,    8,    9,   10,   11,
+        2,    3,    4,    5,    6,   78,    8,    9,   10,   11,
        12,    0,   15,   16,   17,   18,   19,   20,   21,   22,
-       23,   24,   25,   26,   27,    8,    9,   10,   50,   51,
-       52,    7,   54,    7,   79,    8,    9,   10,    8,    9,
-       10,   77,    7,   13,   66,   28,    7,   30,   31,   32,
-       33,   34,   54,   56,   57,   28,    8,   30,   31,   32,
-       33,   34,   35,   35,  109,    1,   68,   69,   70,   71,
-       72,   73,   74,  118,    7,   77,  112,  113,  114,  115,
-      116,  117,   84,   85,   86,   87,   88,   89,   90,   91,
+       23,   24,   25,   26,   27,   28,   42,   43,   44,   45,
+       46,   47,   48,   49,   50,    8,    9,   10,   78,   79,
+        7,  114,  115,  116,  117,  118,  119,  114,  115,  116,
+      117,  118,  119,   55,   57,   58,   29,    7,   31,   32,
+       33,   34,   35,   36,    8,    9,   10,   69,   70,   71,
+       72,   73,   74,   75,  114,    1,   78,    8,    9,   10,
+        1,    7,   13,   85,   86,   87,   88,   89,   90,   91,
        92,   93,   94,   95,   96,   97,   98,   99,  100,  101,
       102,  103,  104,  105,  106,  107,  108,  109,  110,  111,
       112,  113,  114,  115,  116,  117,  118,  119,  120,  121,
-      122,  123,  124,  125,  126,  127,    7,  129,  130,  131,
-      132,  133,  134,  135,  136,  137,    2,    3,    4,    5,
-        6,  143,  144,  145,  152,   11,   12,    7,   14,   41,
-       42,   43,   44,   45,   46,   47,   48,   49,  109,    7,
-       67,  112,  113,  114,  115,  116,  117,  118,    8,    9,
-       10,   79,   79,   79,   82,  147,   83,   82,   67,   28,
-      152,   47,   48,  102,  103,    7,    7,   53,   28,   55,
-       56,   57,   58,   59,   60,   61,   62,   63,   64,   65,
-        1,   67,   68,   69,   70,  112,    8,    9,   10,   75,
-       76,   77,  148,   79,   13,    7,   67,   83,    8,    9,
-       10,    1,  129,  130,   13,   79,   28,  146,   30,   31,
-       32,   33,  140,  141,  139,   29,  102,    7,   28,  128,
-       30,   31,   32,  149,  151,   77,  112,   79,   80,  156,
-      156,   15,   28,  142,  120,  121,  146,   77,  112,  149,
-      149,   15,  151,  129,  130,   15,  132,  133,  134,  135,
-      136,  137,  138,   15,   67,   67,   77,  143,  144,  145,
-      146,  130,  131,    7,    7,  151,   15,  153,  148,  155,
-      156,   71,   72,   73,   74,    0,    1,   77,   77,  150,
-       67,   81,  156,  152,   84,   85,   86,   87,   88,   89,
-       90,   91,   92,   93,   29,   95,   96,   97,   98,   99,
-      100,  101,  102,  143,  104,  105,  146,  148,  108,   15,
-      150,  111,  112,  113,  114,  128,  128,    7,    7,  119,
-       67,   67,  122,  123,  124,  125,    7,   67,  149,  142,
-      142,    8,    9,   10,  130,  131,  149,  149,  151,   79,
-      152,  128,    7,   83,  143,    7,   71,  146,  148,  149,
-      150,   28,   77,   30,   31,  142,   81,    7,  148,   84,
-       85,   86,  149,   88,    7,   90,   35,   92,    7,   33,
-       95,    7,  112,    7,   99,  100,  101,  102,  103,  104,
-      105,  128,  128,  108,  109,    1,  111,  112,  113,  114,
-      130,    8,    9,   10,  119,  142,   79,  122,  123,  124,
-      125,   15,  149,  149,  148,   29,    8,    9,   10,  152,
-       29,  151,   54,   29,  149,   79,  156,   15,  143,   47,
-       48,   49,   29,  148,  149,  150,   28,   79,   30,   31,
+      122,  123,  124,  125,  126,  127,  128,  129,   30,  131,
+      132,  133,  134,  135,  136,  137,  138,  139,    2,    3,
+        4,    5,    6,  145,  146,  147,    7,   11,   12,   36,
+       14,    8,    9,   10,   48,   49,   50,   68,    8,    9,
+       10,   68,   29,    7,    1,    8,    9,   10,    1,   80,
+        8,    9,   29,   84,   31,   32,   33,   34,   35,   29,
+        7,   31,   32,   33,   48,   49,   29,  154,   31,   32,
+       54,   78,   56,   57,   58,   59,   60,   61,   62,   63,
+       64,   65,   66,  114,   68,   69,   70,   71,    8,    9,
+       10,   13,   76,   77,   78,    1,   80,    7,    1,   49,
+       84,  132,    1,  130,    1,   80,    7,  114,  154,   29,
+      156,   31,   32,   33,   34,    1,    7,  144,    7,  103,
+      104,    1,  153,   80,  151,   78,  153,  158,   78,  151,
+      114,   81,    7,   51,   52,   53,    7,   55,  122,  123,
+       30,    8,  149,   29,   36,  132,  133,  131,  132,   67,
+      134,  135,  136,  137,  138,  139,  140,  114,   68,   68,
+        7,  145,  146,  147,  148,   13,   78,  154,  125,  153,
+       36,  155,    1,  157,  158,   72,   73,   74,   75,    0,
+        1,   80,    7,  158,    1,   82,   78,    7,   85,   86,
+       87,   88,   89,   90,   91,   92,   93,   94,  151,   96,
+      103,  158,  105,  100,  101,  102,  103,  154,  111,  106,
+      107,   68,   78,  110,   29,  114,  113,  120,  115,  116,
+      130,  130,  114,    7,  121,   68,   68,  124,  125,  126,
+      127,   68,  154,  145,  144,  144,  148,    8,    9,   10,
+      152,  151,  151,   30,  154,  151,  132,  133,  114,  152,
+        7,   72,    1,  150,  151,  152,   29,  149,   29,  158,
+      150,   82,  154,   80,   85,   86,   87,   36,   89,    7,
+       91,  151,   93,  130,    1,   96,   78,   36,   36,  100,
+      101,  102,  103,  149,  105,  106,  107,  130,  130,  110,
+      111,   78,  113,  130,  115,  116,  103,    7,  105,   68,
+      121,  144,    7,  124,  125,  126,  127,  144,  151,  151,
+       68,   80,    7,    7,  151,   84,  153,  132,  133,   78,
+        7,  150,   80,   72,  145,    1,   84,  114,   30,  150,
+      151,  152,   83,   82,  151,    7,   85,   86,   87,  154,
+       89,  158,   91,  145,   93,  114,  148,   96,   97,   98,
+       99,  100,  101,  102,  103,  114,  114,  106,  107,  132,
+      133,  110,  131,  132,  113,   36,  115,  116,   95,  103,
+      154,  105,  121,  131,  132,  124,  125,  126,  127,   80,
+      148,   13,   83,  151,  153,  103,   36,  105,   13,  158,
+      141,   13,  103,   78,  105,  153,   72,  154,   73,   74,
+      158,  150,  151,  152,   73,   74,   82,   78,   15,   85,
+       86,   87,   15,   89,  148,   91,  154,   93,   98,   99,
+       96,   97,   98,   99,  100,  101,  102,  103,   78,  114,
+      106,  107,   15,    1,  110,  103,  104,  113,   15,  115,
+      116,  142,  143,  114,  154,  121,  108,  109,  124,  125,
+      126,  127,   15,  132,  133,   15,    8,    9,   10,  154,
+      150,  151,   30,   30,  114,   15,   15,   36,   30,   30,
+       34,   30,   30,   55,  150,  151,  152,   29,   67,   31,
        32,   33,   34,   35,   36,   37,   38,   39,   40,   41,
        42,   43,   44,   45,   46,   47,   48,   49,   50,   51,
-       52,   29,   54,   29,    1,   71,   67,    8,    9,   29,
-      112,   77,  152,  152,   66,   81,   35,  148,   84,   85,
-       86,  123,   88,  156,   90,   35,   92,   35,  147,   95,
-       72,   73,   29,   99,  100,  101,    1,  152,  104,  105,
-      152,   35,  108,   72,   73,  111,  112,   97,   98,  102,
-      103,   66,  152,  119,  156,  102,  103,  106,  107,  152,
-       67,  154,   74,  152,   29,  154,  152,  128,  152,   78,
-      130,  131,  148,  149,   71,  148,  149,  148,  149,  148,
-       77,   77,  148,  149,   81,   77,   77,   84,   85,   86,
-       77,   88,   77,   90,   77,   92,   77,   77,   95,   77,
-       77,   77,   99,  100,  101,    1,   71,  104,  105,   79,
-       79,  108,   77,   79,  111,  112,   81,   79,   82,   84,
-       85,   86,  119,   88,   82,   90,   86,   92,   87,   96,
-       95,   94,   89,   29,   99,  100,  101,    1,   91,  104,
-      105,   93,   96,  108,   94,   94,  111,  112,   94,  110,
-      123,  148,  149,  109,  119,  102,  127,  139,  126,  147,
-      139,  150,  146,  149,  154,   29,   -1,  142,  123,   -1,
-      142,   -1,  146,   -1,   -1,   71,   -1,   -1,  126,   -1,
-       -1,   77,   -1,  148,  149,   81,   35,   -1,   84,   85,
-       86,  142,   88,   -1,   90,   -1,   92,  142,   -1,   95,
-       -1,   -1,  146,   99,  100,  101,    1,   71,  104,  105,
-      146,  146,  108,   77,  146,  111,  112,   81,   67,  146,
-       84,   85,   86,  119,   88,  146,   90,  149,   92,  148,
-       79,   95,  148,  148,   83,   99,  100,  101,  148,  148,
-      104,  105,  148,  148,  108,  148,  148,  111,  112,  148,
-      148,  148,  148,  149,  148,  119,  148,  148,  148,  148,
-      148,  148,  148,  112,  148,  148,  148,  148,  148,  148,
-      148,   -1,  149,  149,  149,  149,   71,  149,  149,  149,
-      129,  130,   77,  149,  148,  149,   81,  149,  149,   84,
-       85,   86,  149,   88,  149,   90,  149,   92,  150,  150,
-       95,  151,  151,  150,   99,  100,  101,  156,  150,  104,
-      105,  150,  150,  108,  150,  150,  111,  112,    8,    9,
-       10,  150,  150,  150,  119,  150,  150,  150,  150,  150,
-      150,  150,  150,  150,  150,  150,  150,  150,   28,  150,
-       30,   31,   32,   33,   34,   35,   36,   37,   38,   39,
-       40,  150,  150,  148,  149,  151,  153,  151,  151,  151,
-      151,  151,  151,  151,  151,  151,  151,  151,  151,  151,
-      151,  151,  151,  151,  151,  151,  151,  151,  151,  151,
-      151,  151,  151,   -1,  152,  152,  152,  152,  152,  152,
-      152,  152,  152,  152,  152,  152,  152,  152,  152,  152,
-      152,  152,  152,  152,  152,  152,  152,  152,  152,   -1,
-      153,   -1,  154,  154,  154,  154,  154,   -1,  155
+       52,   53,   68,   55,   72,   75,    1,   78,   80,   83,
+       83,   68,   87,   78,   82,   67,   92,   85,   86,   87,
+      111,   89,   78,   91,  112,   93,   80,  114,   96,  125,
+       81,  125,  100,  101,  102,   30,  128,   90,  106,  107,
+       88,  141,  110,  128,  141,  113,  144,   94,  129,   95,
+       95,   95,    1,  121,   97,   97,  149,  152,  144,   -1,
+      144,  151,   -1,   -1,  144,   -1,   -1,   -1,   -1,  148,
+      148,   -1,   -1,   -1,   -1,   -1,   -1,   72,   -1,   -1,
+       -1,   30,  150,  151,   -1,   -1,   -1,   82,   -1,   -1,
+       85,   86,   87,  148,   89,   -1,   91,   -1,   93,    1,
+       -1,   96,   -1,   -1,   -1,  100,  101,  102,  148,  148,
+      148,  106,  107,  148,  148,  110,  152,  150,  113,  150,
+      150,  150,  150,   72,  150,  150,  121,  150,   30,  150,
+      150,  150,  150,   82,  150,  150,   85,   86,   87,  150,
+       89,  150,   91,  150,   93,    1,  150,   96,  150,  150,
+      153,  100,  101,  102,  151,  150,  151,  106,  107,  151,
+      151,  110,  151,  151,  113,  151,  151,  151,  151,  151,
+       72,  151,  121,  152,   30,  152,  152,  152,  152,  152,
+       82,  152,  152,   85,   86,   87,  152,   89,  152,   91,
+      152,   93,    1,  152,   96,  152,  152,  152,  100,  101,
+      102,  150,  151,  153,  106,  107,  152,  152,  110,  152,
+      152,  113,  152,  152,  152,  152,   72,  152,  154,  121,
+      153,  153,  153,  153,  153,  153,   82,  153,  153,   85,
+       86,   87,  153,   89,  153,   91,  153,   93,  153,  153,
+       96,  153,  153,  153,  100,  101,  102,  153,  150,  151,
+      106,  107,  153,  153,  110,  153,  153,  113,  153,  153,
+      153,  153,  153,   72,  153,  121,  153,  155,  154,  154,
+      154,  154,  154,   82,  154,  154,   85,   86,   87,  154,
+       89,  154,   91,  154,   93,  154,  154,   96,  154,  154,
+      154,  100,  101,  102,  150,  151,  154,  106,  107,  154,
+      154,  110,  154,  154,  113,    8,    9,   10,  154,  154,
+      154,  154,  121,  154,  154,  154,  154,  154,  154,  154,
+       -1,  155,   -1,  156,  156,  156,   29,  156,   31,   32,
+       33,   34,   35,   36,   37,   38,   39,   40,   41,  156,
+      156,  150,  151,  157
 ];
 
 PHP.Parser.prototype.yybase = [
-        0,  220,  295,   94,  180,  560,   -2,   -2,   -2,   -2,
-      -36,  473,  574,  606,  574,  505,  404,  675,  675,  675,
-       28,  351,  462,  462,  462,  461,  396,  476,  451,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,  401,   64,  201,  568,  704,  713,  708,
-      702,  714,  520,  706,  705,  211,  650,  651,  450,  652,
-      653,  654,  655,  709,  480,  703,  712,  418,  418,  418,
-      418,  418,  418,  418,  418,  418,  418,  418,  418,  418,
-      418,  418,  418,   48,   30,  469,  403,  403,  403,  403,
-      403,  403,  403,  403,  403,  403,  403,  403,  403,  403,
-      403,  403,  403,  403,  403,  160,  160,  160,  343,  210,
-      208,  198,   17,  233,   27,  780,  780,  780,  780,  780,
-      108,  108,  108,  108,  621,  621,   93,  280,  280,  280,
-      280,  280,  280,  280,  280,  280,  280,  280,  632,  641,
-      642,  643,  392,  392,  151,  151,  151,  151,  368,  -45,
-      146,  224,  224,   95,  410,  491,  733,  199,  199,  111,
-      207,  -22,  -22,  -22,   81,  506,   92,   92,  233,  233,
-      273,  233,  423,  423,  423,  221,  221,  221,  221,  221,
-      110,  221,  221,  221,  617,  512,  168,  516,  647,  397,
-      503,  656,  274,  381,  377,  538,  535,  337,  523,  337,
-      421,  441,  428,  525,  337,  337,  285,  401,  394,  378,
-      567,  474,  339,  564,  140,  179,  409,  399,  384,  594,
-      561,  711,  330,  710,  358,  149,  378,  378,  378,  370,
-      593,  548,  355,   -8,  646,  484,  277,  417,  386,  645,
-      635,  230,  634,  276,  331,  356,  565,  485,  485,  485,
-      485,  485,  485,  460,  485,  483,  691,  691,  478,  501,
-      460,  696,  460,  485,  691,  460,  460,  502,  485,  522,
-      522,  483,  508,  499,  691,  691,  499,  478,  460,  571,
-      551,  514,  482,  413,  413,  514,  460,  413,  501,  413,
-       11,  697,  699,  444,  700,  695,  698,  676,  694,  493,
-      615,  497,  515,  684,  683,  693,  479,  489,  620,  692,
-      549,  592,  487,  246,  314,  498,  463,  689,  523,  486,
-      455,  455,  455,  463,  687,  455,  455,  455,  455,  455,
-      455,  455,  455,  732,   24,  495,  510,  591,  590,  589,
-      406,  588,  496,  524,  422,  599,  488,  549,  549,  649,
-      727,  673,  490,  682,  716,  690,  555,  119,  271,  681,
-      648,  543,  492,  534,  680,  598,  246,  715,  494,  672,
-      549,  671,  455,  674,  701,  730,  731,  688,  728,  722,
-      152,  526,  587,  178,  729,  659,  596,  595,  554,  725,
-      707,  721,  720,  178,  576,  511,  717,  518,  677,  504,
-      678,  613,  258,  657,  686,  584,  724,  723,  726,  583,
-      582,  609,  608,  250,  236,  685,  442,  458,  517,  581,
-      500,  628,  604,  679,  580,  579,  623,  619,  718,  521,
-      486,  519,  509,  507,  513,  600,  618,  719,  206,  578,
-      586,  573,  481,  572,  631,    0,    0,    0,    0,    0,
+        0,  223,  299,  371,  444,  303,  208,  618,   -2,   -2,
+      -73,   -2,   -2,  625,  718,  718,  764,  718,  552,  671,
+      811,  811,  811,  228,  113,  113,  113,  254,  361,  -40,
+      361,  333,  449,  470,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  435,  435,  435,
+      291,  291,  230,  393,  495,  779,  784,  781,  776,  775,
+      780,  785,  498,  678,  680,  562,  681,  682,  683,  685,
+      782,  804,  777,  783,  568,  568,  568,  568,  568,  568,
+      568,  568,  568,  568,  568,  568,  568,  568,  568,  568,
+      568,  253,   69,  162,   56,   56,   56,   56,   56,   56,
+       56,   56,   56,   56,   56,   56,   56,   56,   56,   56,
+       56,   56,   56,   56,   56,   56,  349,  349,  349,  157,
+      210,  150,  200,  211,  143,   27,  917,  917,  917,  917,
+      917,  -16,  -16,  -16,  -16,  351,  351,  362,  217,   89,
+       89,   89,   89,   89,   89,   89,   89,   89,   89,   89,
+       89,   89,  163,  313,  106,  106,  133,  133,  133,  133,
+      133,  133,  221,  305,  234,  347,  369,  523,  806,  167,
+      167,  441,   93,  283,  202,  202,  202,  386,  547,  533,
+      533,  533,  533,  419,  419,  533,  533,  170,  214,   74,
+      211,  211,  277,  211,  211,  211,  409,  409,  409,  452,
+      318,  352,  546,  318,  619,  640,  577,  675,  578,  677,
+      278,  585,  145,  586,  145,  145,  145,  458,  445,  451,
+      774,  291,  522,  291,  291,  291,  291,  722,  291,  291,
+      291,  291,  291,  291,   98,  291,   79,  430,  230,  240,
+      240,  556,  240,  452,  538,  263,  635,  410,  425,  538,
+      538,  538,  636,  637,  336,  363,  198,  638,  382,  402,
+      173,   33,  549,  549,  555,  555,  566,  551,  549,  549,
+      549,  549,  549,  690,  690,  555,  548,  555,  566,  695,
+      555,  551,  551,  555,  555,  549,  555,  690,  551,  156,
+      415,  249,  273,  551,  551,  426,  528,  549,  535,  535,
+      433,  555,  219,  555,  139,  539,  690,  690,  539,  229,
+      551,  231,  590,  591,  529,  527,  553,  245,  553,  553,
+      300,  529,  553,  551,  553,  448,   50,  548,  295,  553,
+       11,  699,  701,  418,  703,  694,  705,  731,  706,  530,
+      524,  526,  719,  720,  708,  692,  691,  561,  582,  513,
+      517,  534,  554,  689,  581,  531,  531,  531,  554,  687,
+      531,  531,  531,  531,  531,  531,  531,  531,  787,  540,
+      545,  723,  537,  541,  576,  543,  623,  520,  582,  582,
+      584,  732,  786,  564,  722,  762,  709,  587,  557,  741,
+      725,  525,  542,  565,  726,  727,  745,  765,  628,  513,
+      766,  641,  563,  643,  582,  644,  531,  670,  617,  788,
+      789,  688,  791,  736,  747,  749,  580,  645,  569,  803,
+      646,  768,  629,  631,  589,  737,  684,  751,  647,  752,
+      754,  649,  592,  572,  734,  573,  733,  272,  729,  632,
+      650,  654,  656,  658,  661,  710,  594,  738,  544,  740,
+      735,  595,  597,  560,  663,  488,  599,  570,  571,  600,
+      714,  558,  550,  601,  602,  769,  664,  728,  604,  665,
+      756,  574,  581,  536,  532,  575,  567,  634,  755,  559,
+      605,  609,  611,  613,  674,  616,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,  134,  134,   -2,   -2,   -2,
-        0,    0,    0,    0,   -2,  134,  134,  134,  134,  134,
-      134,  134,  134,  134,  134,  134,  134,  134,  134,  134,
-      134,  134,  134,    0,    0,    0,    0,    0,    0,    0,
+        0,    0,    0,  136,  136,  136,  136,   -2,   -2,   -2,
+        0,    0,   -2,    0,    0,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  136,  136,  136,  136,  136,  136,  136,  136,
+      136,  136,  568,  568,  568,  568,  568,  568,  568,  568,
+      568,  568,  568,  568,  568,  568,  568,  568,  568,  568,
+      568,  568,  568,  568,  568,  568,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,  418,  418,  418,
-      418,  418,  418,  418,  418,  418,  418,  418,  418,  418,
-      418,  418,  418,  418,  418,  418,  418,  418,  418,  418,
-      418,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,  418,  418,  418,
-      418,  418,  418,  418,  418,  418,  418,  418,  418,  418,
-      418,  418,  418,  418,  418,  418,  418,  418,  418,  418,
-      418,  418,  418,  418,   -3,  418,  418,   -3,  418,  418,
-      418,  418,  418,  418,  -22,  -22,  -22,  -22,  221,  221,
-      221,  221,  221,  221,  221,  221,  221,  221,  221,  221,
-      221,  221,   49,   49,   49,   49,  -22,  -22,  221,  221,
-      221,  221,  221,   49,  221,  221,  221,   92,  221,   92,
-       92,  337,  337,    0,    0,    0,    0,    0,  485,   92,
-        0,    0,    0,    0,    0,    0,  485,  485,  485,    0,
-        0,    0,    0,    0,  485,    0,    0,    0,  337,   92,
-        0,  420,  420,  178,  420,  420,    0,    0,    0,  485,
-      485,    0,  508,    0,    0,    0,    0,  691,    0,    0,
-        0,    0,    0,  455,  119,  682,    0,   39,    0,    0,
-        0,    0,    0,  490,   39,   26,    0,   26,    0,    0,
-      455,  455,  455,    0,  490,  490,    0,    0,   67,  490,
-        0,    0,    0,   67,   35,    0,   35,    0,    0,    0,
-      178
+        0,    0,    0,  568,  568,  568,  568,  568,  568,  568,
+      568,  568,  568,  568,  568,  568,  568,  568,  568,  568,
+      568,  568,  568,  568,  568,  568,  568,  568,  568,  568,
+      568,  568,   -3,  568,  568,   -3,  568,  568,  568,  568,
+      568,  568,  568,  202,  202,  202,  202,  318,  318,  318,
+      -67,  318,  318,  318,  318,  318,  318,  318,  318,  318,
+      318,  318,  318,  318,  318,  -67,  202,  202,  318,  318,
+      318,  318,  318,  318,  318,  318,  318,  318,  419,  419,
+      419,  145,  145,  318,    0,    0,    0,    0,    0,  549,
+      419,  318,  318,  318,  318,    0,    0,  318,  318,  548,
+      145,    0,    0,    0,    0,    0,    0,    0,  549,  549,
+      549,  548,    0,  549,  419,    0,  240,  291,  440,  440,
+      440,  440,    0,  549,    0,  549,    0,    0,    0,    0,
+        0,    0,  551,    0,  690,    0,    0,    0,    0,  555,
+        0,    0,    0,    0,    0,    0,    0,    0,  548,    0,
+        0,    0,    0,  548,    0,    0,  531,    0,  564,    0,
+        0,  531,  531,  531,  564,  564,    0,    0,    0,  564
 ];
 
 PHP.Parser.prototype.yydefault = [
-        3,32767,32767,32767,32767,32767,32767,32767,32767,32767,
+        3,32767,32767,32767,32767,32767,32767,32767,32767,   92,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
-    32767,32767,  468,  468,  468,32767,32767,32767,32767,  285,
-      460,  285,  285,32767,  419,  419,  419,  419,  419,  419,
-      419,  460,32767,32767,32767,32767,32767,  364,32767,32767,
-    32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
-    32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
-    32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
+    32767,32767,32767,32767,  510,  510,  510,   94,  499,32767,
+      499,32767,32767,32767,  314,  314,  314,32767,  454,  454,
+      454,  454,  454,  454,  454,32767,32767,32767,32767,32767,
+      394,32767,32767,32767,32767,32767,32767,32767,32767,32767,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
-    32767,32767,32767,32767,32767,  465,32767,32767,32767,32767,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
-    32767,32767,32767,32767,32767,32767,32767,  347,  348,  350,
-      351,  284,  420,  237,  464,  283,  116,  246,  239,  191,
-      282,  223,  119,  312,  365,  314,  363,  367,  313,  290,
-      294,  295,  296,  297,  298,  299,  300,  301,  302,  303,
-      304,  305,  288,  289,  366,  344,  343,  342,  310,  311,
-      287,  315,  317,  287,  316,  333,  334,  331,  332,  335,
-      336,  337,  338,  339,32767,32767,32767,32767,32767,32767,
-    32767,32767,32767,32767,32767,32767,32767,32767,  269,  269,
-      269,  269,  324,  325,  229,  229,  229,  229,32767,  270,
-    32767,  229,32767,32767,32767,32767,32767,32767,32767,  413,
-      341,  319,  320,  318,32767,  392,32767,  394,  307,  309,
-      387,  291,32767,32767,32767,32767,32767,32767,32767,32767,
+    32767,   92,32767,32767,32767,32767,32767,32767,32767,32767,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
-    32767,32767,  389,  421,  421,32767,32767,32767,  381,32767,
-      159,  210,  212,  397,32767,32767,32767,32767,32767,  329,
-    32767,32767,32767,32767,32767,32767,  474,32767,32767,32767,
-    32767,32767,  421,32767,32767,32767,  321,  322,  323,32767,
-    32767,32767,  421,  421,32767,32767,  421,32767,  421,32767,
+    32767,32767,32767,32767,  506,32767,32767,32767,32767,32767,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
-    32767,32767,32767,  163,32767,32767,  395,  395,32767,32767,
-      163,  390,  163,32767,32767,  163,  163,  176,32767,  174,
-      174,32767,32767,  178,32767,  435,  178,32767,  163,  196,
-      196,  373,  165,  231,  231,  373,  163,  231,32767,  231,
-    32767,32767,32767,   82,32767,32767,32767,32767,32767,32767,
+    32767,32767,32767,32767,  377,  378,  380,  381,  313,  455,
+      509,  259,  505,  312,  130,  270,  261,  211,  243,  310,
+      134,  342,  395,  344,  393,  397,  343,  319,  323,  324,
+      325,  326,  327,  328,  329,  330,  331,  332,  333,  334,
+      335,  317,  318,  396,  398,  399,  374,  373,  372,  340,
+      316,  341,  345,  316,  347,  346,  363,  364,  361,  362,
+      365,  366,  367,  368,  369,32767,32767,32767,32767,32767,
+    32767,32767,32767,32767,32767,32767,32767,32767,32767,   94,
+    32767,32767,32767,  293,  354,  355,  250,  250,  250,  250,
+      250,  250,32767,  250,32767,  250,32767,32767,32767,32767,
+    32767,32767,  448,  371,  349,  350,  348,32767,  426,32767,
+    32767,32767,32767,32767,  428,32767,   92,32767,32767,32767,
+      337,  339,  420,  508,  320,  507,32767,32767,   94,  414,
     32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
-      383,32767,32767,32767,  401,32767,  414,  433,  381,32767,
-      327,  328,  330,32767,  423,  352,  353,  354,  355,  356,
-      357,  358,  360,32767,  461,  386,32767,32767,32767,32767,
-    32767,32767,   84,  108,  245,32767,  473,   84,  384,32767,
-      473,32767,32767,32767,32767,32767,32767,  286,32767,32767,
-    32767,   84,32767,   84,32767,32767,  457,32767,32767,  421,
-      385,32767,  326,  398,  439,32767,32767,  422,32767,32767,
-      218,   84,32767,  177,32767,32767,32767,32767,32767,32767,
-      401,32767,32767,  179,32767,32767,  421,32767,32767,32767,
-    32767,32767,  281,32767,32767,32767,32767,32767,  421,32767,
-    32767,32767,32767,  222,32767,32767,32767,32767,32767,32767,
-    32767,32767,32767,32767,32767,32767,32767,32767,32767,   82,
-       60,32767,  263,32767,32767,32767,32767,32767,32767,32767,
-    32767,32767,32767,32767,32767,  121,  121,    3,    3,  121,
-      121,  121,  121,  121,  121,  121,  121,  121,  121,  121,
-      121,  121,  121,  121,  248,  154,  248,  204,  248,  248,
-      207,  196,  196,  255
+      423,32767,32767,   92,32767,32767,   92,  174,  230,  232,
+      179,32767,  431,32767,32767,32767,32767,32767,32767,32767,
+    32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
+    32767,32767,32767,  414,  359,  517,32767,  456,32767,  351,
+      352,  353,32767,32767,  456,  456,  456,32767,  456,32767,
+      456,  456,32767,32767,32767,32767,32767,  179,32767,32767,
+    32767,32767,   94,  429,  429,   92,   92,   92,   92,  424,
+    32767,  179,  179,32767,32767,32767,32767,32767,  179,   91,
+       91,   91,   91,  179,  179,   91,  194,32767,  192,  192,
+       91,32767,   93,32767,   93,  196,32767,  470,  196,   91,
+      179,   91,  216,  216,  405,  181,  252,   93,  252,  252,
+       93,  405,  252,  179,  252,   91,   91,32767,   91,  252,
+    32767,32767,32767,   85,32767,32767,32767,32767,32767,32767,
+    32767,32767,32767,32767,32767,32767,32767,32767,  416,32767,
+      436,32767,  449,  468,32767,  357,  358,  360,32767,  458,
+      382,  383,  384,  385,  386,  387,  388,  390,32767,  419,
+    32767,32767,32767,   87,  121,  269,32767,  515,   87,  417,
+    32767,  515,32767,32767,32767,32767,32767,32767,32767,32767,
+    32767,32767,   87,   87,32767,32767,32767,32767,32767,  495,
+    32767,  516,32767,  456,  418,32767,  356,  432,  475,32767,
+    32767,  457,32767,32767,32767,32767,   87,32767,32767,32767,
+    32767,32767,32767,32767,32767,32767,  436,32767,32767,32767,
+    32767,32767,32767,32767,  456,32767,32767,32767,32767,32767,
+    32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
+      456,32767,32767,  242,32767,32767,32767,  309,32767,32767,
+    32767,32767,32767,32767,32767,32767,32767,32767,32767,32767,
+    32767,   85,   60,32767,  289,32767,32767,32767,32767,32767,
+    32767,32767,32767,32767,32767,32767,  136,  136,    3,  272,
+        3,  272,  136,  136,  136,  272,  272,  136,  136,  136,
+      136,  136,  136,  136,  169,  224,  227,  216,  216,  281,
+      136,  136
 ];
 
 PHP.Parser.prototype.yygoto = [
-      163,  163,  135,  135,  135,  146,  148,  179,  164,  161,
-      145,  161,  161,  161,  162,  162,  162,  162,  162,  162,
-      162,  145,  157,  158,  159,  160,  176,  174,  177,  410,
-      411,  299,  412,  415,  416,  417,  418,  419,  420,  421,
-      422,  857,  136,  137,  138,  139,  140,  141,  142,  143,
-      144,  147,  173,  175,  178,  195,  198,  199,  201,  202,
-      204,  205,  206,  207,  208,  209,  210,  211,  212,  213,
-      232,  233,  251,  252,  253,  316,  317,  318,  462,  180,
-      181,  182,  183,  184,  185,  186,  187,  188,  189,  190,
-      191,  192,  193,  149,  194,  150,  165,  166,  167,  196,
-      168,  151,  152,  153,  169,  154,  197,  133,  170,  155,
-      171,  172,  156,  521,  200,  257,  246,  464,  432,  687,
-      649,  278,  481,  482,  527,  200,  437,  437,  437,  766,
-        5,  746,  650,  557,  437,  426,  775,  770,  428,  431,
-      444,  465,  466,  468,  483,  279,  651,  336,  450,  453,
-      437,  560,  485,  487,  508,  511,  763,  516,  517,  777,
-      524,  762,  526,  532,  773,  534,  480,  480,  965,  965,
-      965,  965,  965,  965,  965,  965,  965,  965,  965,  965,
-      413,  413,  413,  413,  413,  413,  413,  413,  413,  413,
-      413,  413,  413,  413,  942,  502,  478,  496,  512,  456,
-      298,  437,  437,  451,  471,  437,  437,  674,  437,  229,
-      456,  230,  231,  463,  828,  533,  681,  438,  513,  826,
-      461,  475,  460,  414,  414,  414,  414,  414,  414,  414,
-      414,  414,  414,  414,  414,  414,  414,  301,  674,  674,
-      443,  454, 1033, 1033, 1034, 1034,  425,  531,  425,  708,
-      750,  800,  457,  372, 1033,  943, 1034, 1026,  300, 1018,
-      497,    8,  313,  904,  796,  944,  996,  785,  789, 1007,
-      285,  670, 1036,  329,  307,  310,  804,  668,  544,  332,
-      935,  940,  366,  807,  678,  477,  377,  754,  844,    0,
-      667,  667,  675,  675,  675,  677,    0,  666,  323,  498,
-      328,  312,  312,  258,  259,  283,  459,  261,  322,  284,
-      326,  486,  280,  281,    0,    0,    0,    0,    0,    0,
+      171,  144,  144,  144,  171,  152,  153,  152,  155,  187,
+      172,  168,  168,  168,  168,  169,  169,  169,  169,  169,
+      169,  169,  164,  165,  166,  167,  184,  182,  185,  445,
+      446,  334,  447,  450,  451,  452,  453,  454,  455,  456,
+      457,  924,  141,  145,  146,  147,  170,  148,  149,  143,
+      150,  151,  154,  181,  183,  186,  206,  209,  211,  212,
+      214,  215,  216,  217,  218,  219,  220,  221,  222,  223,
+      224,  244,  245,  264,  265,  266,  339,  340,  341,  496,
+      188,  189,  190,  191,  192,  193,  194,  195,  196,  197,
+      198,  199,  200,  201,  202,  156,  203,  157,  173,  174,
+      175,  207,  176,  158,  159,  160,  177,  161,  208,  142,
+      204,  162,  178,  205,  179,  180,  163,  563,  210,  463,
+      210,  516,  516, 1038,  572, 1038, 1038, 1038, 1038, 1038,
+     1038, 1038, 1038, 1038, 1038, 1038, 1038, 1038,  468,  468,
+      468,  514,  537,  468,  297,  489,  521,  489,  498,  274,
+      533,  534,  698,  483,  258,  468,  448,  448,  448,  725,
+      448,  448,  448,  448,  448,  448,  448,  448,  448,  448,
+      448,  448,  448,  449,  449,  449,  699,  449,  449,  449,
+      449,  449,  449,  449,  449,  449,  449,  449,  449,  449,
+     1114, 1114,  734,  725,  899,  725,  315,  319,  475,  499,
+      500,  502, 1083, 1084,  468,  468,  760, 1114,  761,  900,
+      482,  506,  468,  468,  468,  329,  330,  686,  481,  545,
+      495,  332,  510,  596,  523,  525,  294,  469,  538,  556,
+      559,  835,  566,  574,  831,  765,  729,  717,  864,  494,
+      807,  868,  490,  860,  716,  716,  810,  697, 1013, 1105,
+      726,  726,  726,  728,  715,  840, 1093,  800,  824,  805,
+      805,  803,  805,  595,  313,  460,  833,  828,  459,    3,
+        4,  907,  733,  539, 1009,  487,  317,  461,  459,  497,
+      892,  575,  972,  474,  843,  557,  890, 1129,  484,  485,
+      505,  517,  519,  520,  568,  801,  801,  801,  801,  465,
+      855,  795,  802, 1002,  787,  405, 1003,  799,  327,  571,
+      356, 1082,  530, 1014,  848,  346,  540,  350,   11,  337,
+      337,  280,  281,  283,  493,  344,  284,  345,  285,  348,
+      524,  351, 1015, 1069, 1113, 1113,  543,  301,  298,  299,
+      721,  560,  838,  838, 1100,  295,  865,  718,  600,  323,
+      544, 1113, 1010, 1017,  511, 1005,  869,  849,  849,  849,
+      849,  849,  849, 1017,  849,  849,  849,  720,  730, 1116,
+      714,  812,  849, 1088, 1088,  909,  465,  398,  513,  414,
+     1017, 1017, 1017, 1017,    0, 1079, 1017, 1017,    0,  701,
+        0,    0,    0,    0,    0, 1079,    0,    0,    0,    0,
+        0,  773, 1090, 1090,  774,  706,    0,  756,  751,  752,
+      766,    0,  707,  753,  704,  754,  755,  705,    0,  759,
+        0, 1075,    0,    0,    0,    0,    0, 1012,    0,    0,
+        0,  480,    0,    0,    0,    0,    0,    0,    0,    0,
+        0,    0,    0,    0,    0,  867,    0, 1077, 1077,  867,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,  790,  790,  790,  790,  946,    0,  946,
-      790,  790, 1004,  790, 1004,    0,    0,    0,    0,  836,
-        0, 1015, 1015,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,  744,  744,  744,  720,  744,    0,
-      739,  745,  721,  780,  780, 1023,    0,    0, 1002,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,  806,    0,  806,    0,    0,    0,    0, 1008, 1009
+        0,    0,    0,    0,    0,    0,    0,    0,  462,  478,
+        0,    0,    0,    0,    0,    0,    0,    0,    0,  462,
+        0,  478,    0,    0,  316,    0,    0,  466,  386,    0,
+      388,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+        0,    0,    0,    0,    0,  724,    0, 1121
 ];
 
 PHP.Parser.prototype.yygcheck = [
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   52,   45,  112,  112,   80,    8,   10,
-       10,   64,   55,   55,   55,   45,    8,    8,    8,   10,
-       92,   10,   11,   10,    8,   10,   10,   10,   38,   38,
-       38,   38,   38,   38,   62,   62,   12,   62,   28,    8,
-        8,   28,   28,   28,   28,   28,   28,   28,   28,   28,
-       28,   28,   28,   28,   28,   28,   70,   70,   70,   70,
-       70,   70,   70,   70,   70,   70,   70,   70,   70,   70,
-      113,  113,  113,  113,  113,  113,  113,  113,  113,  113,
-      113,  113,  113,  113,   76,   56,   35,   35,   56,   69,
-       56,    8,    8,    8,    8,    8,    8,   19,    8,   60,
-       69,   60,   60,    7,    7,    7,   25,    8,    7,    7,
-        2,    2,    8,  115,  115,  115,  115,  115,  115,  115,
-      115,  115,  115,  115,  115,  115,  115,   53,   19,   19,
-       53,   53,  123,  123,  124,  124,  109,    5,  109,   44,
-       29,   78,  114,   53,  123,   76,  124,  122,   41,  120,
-       43,   53,   42,   96,   74,   76,   76,   72,   75,  117,
-       14,   21,  123,   18,    9,   13,   79,   20,   66,   17,
-      102,  104,   58,   81,   22,   59,  100,   63,   94,   -1,
-       19,   19,   19,   19,   19,   19,   -1,   19,   45,   45,
-       45,   45,   45,   45,   45,   45,   45,   45,   45,   45,
-       45,   45,   64,   64,   -1,   -1,   -1,   -1,   -1,   -1,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   63,   56,   10,
+       56,   86,   86,   86,    8,   86,   86,   86,   86,   86,
+       86,   86,   86,   86,   86,   86,   86,   86,   10,   10,
+       10,   46,   46,   10,   80,   85,   73,   85,   97,  134,
+       73,   73,   17,   10,  134,   10,  135,  135,  135,   26,
+      135,  135,  135,  135,  135,  135,  135,  135,  135,  135,
+      135,  135,  135,  137,  137,  137,   18,  137,  137,  137,
+      137,  137,  137,  137,  137,  137,  137,  137,  137,  137,
+      148,  148,   36,   26,  111,   26,   49,   49,   49,   49,
+       49,   49,  141,  141,   10,   10,   55,  148,   55,  111,
+       10,   10,   10,   10,   10,   69,   69,    5,   39,   69,
+        2,   69,    2,   39,   39,   39,   69,   10,   39,   39,
+       39,   39,   39,   39,   39,   13,   14,   14,   14,   10,
+       40,   14,  136,   94,   26,   26,   14,   16,   92,  146,
+       26,   26,   26,   26,   26,   14,  143,   14,   16,   16,
+       16,   16,   16,   16,   52,   16,   16,   16,   75,   37,
+       37,   14,   14,   54,   14,   53,   65,   65,   75,    7,
+        7,    7,  118,   65,   88,    7,    7,   12,   65,   65,
+       68,   68,   68,   68,   68,   75,   75,   75,   75,   12,
+       90,   75,   75,   67,   67,   65,   67,   76,   76,   76,
+       89,  139,   24,   92,   91,   56,   56,   56,   65,   56,
+       56,   56,   56,   56,   56,   56,   56,   56,   56,   56,
+       56,   56,   92,   92,  147,  147,   12,   20,   80,   80,
+       30,   12,   85,   85,   85,   11,   96,   28,   82,   19,
+       23,  147,  127,   63,   15,  124,   99,   63,   63,   63,
+       63,   63,   63,   63,   63,   63,   63,   15,   32,  147,
+       15,   79,   63,    8,    8,  114,   12,   71,   72,  122,
+       63,   63,   63,   63,   -1,   97,   63,   63,   -1,   13,
+       -1,   -1,   -1,   -1,   -1,   97,   -1,   -1,   -1,   -1,
+       -1,   63,   97,   97,   63,   13,   -1,   13,   13,   13,
+       13,   -1,   13,   13,   13,   13,   13,   13,   -1,   13,
+       -1,   97,   -1,   -1,   -1,   -1,   -1,   12,   -1,   -1,
+       -1,    8,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
+       -1,   -1,   -1,   -1,   -1,   97,   -1,   97,   97,   97,
        -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-       -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-       -1,   -1,   -1,   52,   52,   52,   52,   52,   -1,   52,
-       52,   52,   80,   52,   80,   -1,   -1,   -1,   -1,   92,
-       -1,   80,   80,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-       -1,   -1,   -1,   -1,   52,   52,   52,   52,   52,   -1,
-       52,   52,   52,   69,   69,   69,   -1,   -1,   80,   -1,
-       -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-       -1,   80,   -1,   80,   -1,   -1,   -1,   -1,   80,   80
+       -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,    8,    8,
+       -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,    8,
+       -1,    8,   -1,   -1,    8,   -1,   -1,    8,    8,   -1,
+        8,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
+       -1,   -1,   -1,   -1,   -1,    8,   -1,    8
 ];
 
 PHP.Parser.prototype.yygbase = [
-        0,    0, -317,    0,    0,  237,    0,  210, -136,    4,
-      118,  130,  144,  -10,   16,    0,    0,  -59,   10,  -47,
-       -9,    7,  -77,  -20,    0,  209,    0,    0, -388,  234,
-        0,    0,    0,    0,    0,  165,    0,    0,  103,    0,
-        0,  225,   44,   45,  235,   84,    0,    0,    0,    0,
-        0,    0,  109, -115,    0, -113, -179,    0,  -78,  -81,
-     -347,    0, -122,  -80, -249,    0,  -19,    0,    0,  169,
-      -48,    0,   26,    0,   22,   24,  -99,    0,  230,  -13,
-      114,  -79,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,  120,    0,  -90,    0,   23,    0,    0,    0,
-      -89,    0,  -67,    0,  -69,    0,    0,    0,    0,    8,
-        0,    0, -140,  -34,  229,    9,    0,   21,    0,    0,
-      218,    0,  233,   -3,   -1,    0
+        0,    0, -358,    0,    0,  207,    0,  274,  114,    0,
+     -148,   54,   10,   94, -144,  -40,  245,  150,  174,   48,
+       70,    0,    0,   -3,   25,    0, -108,    0,   44,    0,
+       52,    0,    3,  -23,    0,    0,  183, -331,    0, -359,
+      221,    0,    0,    0,    0,    0,  106,    0,    0,  157,
+        0,    0,  227,   45,   47,  191,   90,    0,    0,    0,
+        0,    0,    0,  111,    0,  -95,    0,  -26,   43, -193,
+        0,  -12,  -20, -435,    0,   26,   37,    0,    0,    4,
+     -259,    0,   20,    0,    0,  117, -104,    0,   31,   55,
+       46,   53,  -64,    0,  216,    0,   40,  143,    0,  -10,
+        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+        0,  -34,    0,    0,    7,    0,    0,    0,   30,    0,
+        0,    0,  -32,    0,   -9,    0,    0,   -5,    0,    0,
+        0,    0,    0,    0, -119,  -69,  217,  -52,    0,   51,
+        0, -102,    0,  226,    0,    0,  223,   77,  -67,    0,
+        0
 ];
 
 PHP.Parser.prototype.yygdefault = [
-    -32768,  380,  565,    2,  566,  637,  645,  504,  400,  433,
-      748,  688,  689,  303,  342,  401,  302,  330,  324,  676,
-      669,  671,  679,  134,  333,  682,    1,  684,  439,  716,
-      291,  692,  292,  507,  694,  446,  696,  697,  427,  304,
-      305,  447,  311,  479,  707,  203,  308,  709,  290,  710,
-      719,  335,  293,  510,  489,  469,  501,  402,  363,  476,
-      228,  455,  473,  753,  277,  761,  549,  769,  772,  403,
-      404,  470,  784,  368,  794,  788,  960,  319,  799,  805,
-      991,  808,  811,  349,  331,  327,  815,  816,    4,  820,
-      522,  523,  835,  239,  843,  856,  347,  923,  925,  441,
-      374,  936,  360,  334,  939,  995,  354,  405,  364,  952,
-      260,  282,  245,  406,  423,  249,  407,  365,  998,  314,
-     1019,  424, 1027, 1035,  275,  474
+    -32768,  420,  603,    2,  604,  676,  684,  548,  437,  573,
+      438,  464,  335,  758,  913,  778,  740,  741,  742,  320,
+      361,  311,  318,  531,  518,  410,  727,  381,  719,  407,
+      722,  380,  731,  140,  549,  416,  735,    1,  737,  470,
+      769,  308,  745,  309,  552,  747,  477,  749,  750,  314,
+      321,  322,  917,  486,  515,  762,  213,  479,  763,  307,
+      764,  772,  331,  312,  392,  417,  326,  894,  504,  527,
+      376,  395,  512,  507,  488, 1024,  797,  401,  390,  811,
+      296,  819,  601,  827,  830,  439,  440,  399,  842,  400,
+      853,  847, 1032,  394,  859,  382,  866, 1064,  385,  870,
+      228,  873,  255,  546,  349,  878,  879,    6,  884,  564,
+      565,    7,  243,  415,  908,  547,  379,  923,  364,  991,
+      993,  472,  408, 1006,  389,  555,  418, 1011, 1068,  377,
+      441,  396,  282,  300,  257,  442,  458,  262,  443,  397,
+     1071, 1078,  338, 1094,  279,   26, 1106, 1115,  292,  492,
+      509
 ];
 
 PHP.Parser.prototype.yylhs = [
@@ -2173,48 +2234,52 @@ PHP.Parser.prototype.yylhs = [
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
         5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
-        5,    5,    5,    6,    6,    6,    6,    6,    6,    6,
-        7,    7,    8,    8,    9,    4,    4,    4,    4,    4,
-        4,    4,    4,    4,    4,    4,   14,   14,   15,   15,
-       15,   15,   17,   17,   13,   13,   18,   18,   19,   19,
-       20,   20,   21,   21,   16,   16,   22,   24,   24,   25,
-       26,   26,   28,   27,   27,   27,   27,   29,   29,   29,
-       29,   29,   29,   29,   29,   29,   29,   29,   29,   29,
-       29,   29,   29,   29,   29,   29,   29,   29,   29,   29,
-       29,   29,   10,   10,   48,   48,   51,   51,   50,   49,
-       49,   42,   42,   53,   53,   54,   54,   11,   12,   12,
-       12,   57,   57,   57,   58,   58,   61,   61,   59,   59,
-       62,   62,   36,   36,   44,   44,   47,   47,   47,   46,
-       46,   63,   37,   37,   37,   37,   64,   64,   65,   65,
-       66,   66,   34,   34,   30,   30,   67,   32,   32,   68,
-       31,   31,   33,   33,   43,   43,   43,   43,   55,   55,
-       71,   71,   72,   72,   74,   74,   75,   75,   75,   73,
-       73,   56,   56,   76,   76,   77,   77,   78,   78,   78,
-       39,   39,   79,   40,   40,   81,   81,   60,   60,   82,
-       82,   82,   82,   87,   87,   88,   88,   89,   89,   89,
-       89,   89,   90,   91,   91,   86,   86,   83,   83,   85,
-       85,   93,   93,   92,   92,   92,   92,   92,   92,   84,
-       84,   94,   94,   41,   41,   35,   35,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-       23,   23,   23,   23,   23,   23,   23,   23,   23,   23,
-      101,   95,   95,  100,  100,  103,  103,  104,  105,  105,
-      105,  109,  109,   52,   52,   52,   96,   96,  107,  107,
-       97,   97,   99,   99,   99,  102,  102,  113,  113,   70,
-      115,  115,  115,   98,   98,   98,   98,   98,   98,   98,
-       98,   98,   98,   98,   98,   98,   98,   98,   98,   38,
-       38,  111,  111,  111,  106,  106,  106,  116,  116,  116,
-      116,  116,  116,   45,   45,   45,   80,   80,   80,  118,
-      110,  110,  110,  110,  110,  110,  108,  108,  108,  117,
-      117,  117,  117,   69,  119,  119,  120,  120,  120,  120,
-      120,  114,  121,  121,  122,  122,  122,  122,  122,  112,
-      112,  112,  112,  124,  123,  123,  123,  123,  123,  123,
-      123,  125,  125,  125
+        5,    5,    5,    5,    6,    6,    6,    6,    6,    6,
+        6,    7,    7,    8,    9,   10,   10,   11,   12,   13,
+       13,   14,   14,   15,   15,    4,    4,    4,    4,    4,
+        4,    4,    4,    4,    4,    4,   20,   20,   21,   21,
+       21,   21,   23,   25,   25,   19,   27,   27,   24,   29,
+       29,   26,   26,   28,   28,   30,   30,   22,   31,   31,
+       32,   34,   35,   35,   36,   37,   37,   39,   38,   38,
+       38,   38,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,   40,   40,   16,   16,   59,
+       59,   62,   62,   61,   60,   60,   53,   64,   64,   65,
+       65,   66,   66,   67,   67,   17,   18,   18,   18,   70,
+       70,   70,   71,   71,   74,   74,   72,   72,   76,   77,
+       77,   47,   47,   55,   55,   58,   58,   58,   57,   78,
+       78,   79,   48,   48,   48,   48,   80,   80,   81,   81,
+       82,   82,   45,   45,   41,   41,   83,   43,   43,   84,
+       42,   42,   44,   44,   54,   54,   54,   54,   68,   68,
+       87,   87,   88,   88,   88,   90,   90,   91,   91,   91,
+       89,   89,   69,   69,   69,   92,   92,   93,   93,   94,
+       94,   94,   50,   95,   95,   96,   51,   98,   98,   99,
+       99,  100,  100,   73,  101,  101,  101,  101,  101,  106,
+      106,  107,  107,  108,  108,  108,  108,  108,  109,  110,
+      110,  105,  105,  102,  102,  104,  104,  112,  112,  111,
+      111,  111,  111,  111,  111,  103,  113,  113,  115,  114,
+      114,   52,  116,  116,   46,   46,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,   33,   33,   33,   33,   33,   33,   33,   33,
+       33,   33,  123,  117,  117,  122,  122,  125,  126,  126,
+      127,  128,  128,  128,   75,   75,   63,   63,   63,  118,
+      118,  118,  130,  130,  119,  119,  121,  121,  121,  124,
+      124,  135,  135,  135,   86,  137,  137,  137,  120,  120,
+      120,  120,  120,  120,  120,  120,  120,  120,  120,  120,
+      120,  120,  120,  120,   49,   49,  133,  133,  133,  129,
+      129,  129,  138,  138,  138,  138,  138,  138,   56,   56,
+       56,   97,   97,   97,   97,  141,  140,  132,  132,  132,
+      132,  132,  132,  131,  131,  131,  139,  139,  139,  139,
+       85,  142,  142,  143,  143,  143,  143,  143,  143,  143,
+      136,  145,  145,  144,  144,  146,  146,  146,  146,  146,
+      146,  134,  134,  134,  134,  148,  149,  147,  147,  147,
+      147,  147,  147,  147,  150,  150,  150,  150
 ];
 
 PHP.Parser.prototype.yylen = [
@@ -2226,47 +2291,51 @@ PHP.Parser.prototype.yylen = [
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    3,    1,    1,    1,    1,    1,    3,
+        1,    1,    1,    1,    1,    1,    3,    1,    1,    1,
+        1,    0,    1,    0,    1,    1,    1,    1,    1,    3,
         5,    4,    3,    4,    2,    3,    1,    1,    7,    8,
-        6,    7,    3,    1,    3,    1,    3,    1,    1,    3,
-        1,    2,    1,    2,    3,    1,    3,    3,    1,    3,
-        2,    0,    1,    1,    1,    1,    1,    3,    7,   10,
-        5,    7,    9,    5,    3,    3,    3,    3,    3,    3,
-        1,    2,    5,    7,    9,    5,    6,    3,    3,    2,
-        2,    1,    1,    1,    0,    2,    1,    3,    8,    0,
-        4,    1,    3,    0,    1,    0,    1,   10,    7,    6,
-        5,    1,    2,    2,    0,    2,    0,    2,    0,    2,
-        1,    3,    1,    4,    1,    4,    1,    1,    4,    1,
+        6,    7,    2,    3,    1,    2,    3,    1,    2,    3,
+        1,    1,    3,    1,    2,    1,    2,    2,    3,    1,
+        3,    2,    3,    1,    3,    2,    0,    1,    1,    1,
+        1,    1,    3,    7,   10,    5,    7,    9,    5,    3,
+        3,    3,    3,    3,    3,    1,    2,    5,    7,    9,
+        6,    5,    6,    3,    3,    2,    1,    1,    1,    0,
+        2,    1,    3,    8,    0,    4,    2,    1,    3,    0,
+        1,    0,    1,    3,    1,    8,    7,    6,    5,    1,
+        2,    2,    0,    2,    0,    2,    0,    2,    2,    1,
+        3,    1,    4,    1,    4,    1,    1,    4,    2,    1,
         3,    3,    3,    4,    4,    5,    0,    2,    4,    3,
         1,    1,    1,    4,    0,    2,    5,    0,    2,    6,
-        0,    2,    0,    3,    1,    2,    1,    1,    1,    0,
-        1,    3,    4,    6,    1,    2,    1,    1,    1,    0,
-        1,    0,    2,    2,    3,    1,    3,    1,    2,    2,
-        3,    1,    1,    3,    1,    1,    3,    2,    0,    3,
-        4,    9,    3,    1,    3,    0,    2,    4,    5,    4,
-        4,    4,    3,    1,    1,    1,    3,    1,    1,    0,
-        1,    1,    2,    1,    1,    1,    1,    1,    1,    1,
-        3,    1,    3,    3,    1,    0,    1,    1,    3,    3,
-        3,    4,    1,    2,    3,    3,    3,    3,    3,    3,
+        0,    2,    0,    3,    1,    2,    1,    1,    2,    0,
+        1,    3,    4,    6,    4,    1,    2,    1,    1,    1,
+        0,    1,    0,    2,    2,    2,    4,    1,    3,    1,
+        2,    2,    2,    3,    1,    1,    2,    3,    1,    1,
+        3,    2,    0,    1,    4,    4,    9,    3,    1,    1,
+        3,    0,    2,    4,    5,    4,    4,    4,    3,    1,
+        1,    1,    1,    1,    1,    0,    1,    1,    2,    1,
+        1,    1,    1,    1,    1,    2,    1,    3,    1,    1,
+        3,    2,    3,    1,    0,    1,    1,    3,    3,    3,
+        4,    1,    2,    3,    3,    3,    3,    3,    3,    3,
         3,    3,    3,    3,    3,    3,    2,    2,    2,    2,
         3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
         3,    3,    3,    3,    3,    3,    3,    2,    2,    2,
         2,    3,    3,    3,    3,    3,    3,    3,    3,    3,
         3,    3,    5,    4,    3,    4,    4,    2,    2,    4,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2,    1,    3,    2,    1,    2,    4,    2,   10,   11,
-        7,    3,    2,    0,    4,    1,    3,    2,    2,    2,
-        4,    1,    1,    1,    2,    3,    1,    1,    1,    1,
-        0,    3,    0,    1,    1,    0,    1,    1,    3,    3,
-        4,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    3,    2,    3,    3,    0,
-        1,    1,    3,    1,    1,    3,    1,    1,    4,    4,
-        4,    1,    4,    1,    1,    3,    1,    4,    2,    3,
-        1,    4,    4,    3,    3,    3,    1,    3,    1,    1,
-        3,    1,    1,    4,    3,    1,    1,    1,    3,    3,
-        0,    1,    3,    1,    3,    1,    4,    2,    0,    2,
-        2,    1,    2,    1,    1,    4,    3,    3,    3,    6,
-        3,    1,    1,    1
+        2,    1,    3,    2,    1,    2,    4,    2,    8,    9,
+        8,    9,    7,    3,    2,    0,    4,    2,    1,    3,
+        2,    2,    2,    4,    1,    1,    1,    2,    3,    1,
+        1,    1,    1,    1,    0,    3,    0,    1,    1,    0,
+        1,    1,    3,    3,    3,    4,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        3,    2,    3,    3,    0,    1,    1,    3,    1,    1,
+        3,    1,    1,    4,    4,    4,    1,    4,    1,    1,
+        3,    1,    4,    2,    2,    1,    3,    1,    4,    4,
+        3,    3,    3,    1,    3,    1,    1,    3,    1,    1,
+        4,    3,    1,    1,    2,    1,    3,    4,    3,    0,
+        1,    1,    1,    3,    1,    3,    1,    4,    2,    2,
+        0,    2,    2,    1,    2,    1,    1,    1,    4,    3,
+        3,    3,    6,    3,    1,    1,    2,    1
 ];
 
 


### PR DESCRIPTION
this repeats #3107, but for 7.4, instead of the kmyacc binary
I used https://github.com/ircmaxell/PHP-Yacc

here is the rebuildParser that I used:

```php
<?php

const GRAMMAR_REPO  = 'https://raw.githubusercontent.com/nikic/PHP-Parser';
const PARSER_REPO  = 'https://raw.githubusercontent.com/niklasvh/php.js';

const GRAMMAR_FILE = GRAMMAR_REPO .'/master/grammar/php7.y';
const TOKENS_FILE  = GRAMMAR_REPO .'/master/grammar/tokens.y';
const TMP_FILE     = './tmp_parser.jsy';
const RESULT_FILE  = './tmp_parser.js';

file_put_contents('kmyacc.js.parser', file_get_contents(PARSER_REPO .'/master/grammar/kmyacc.js.parser'));

$tokens = file_get_contents(TOKENS_FILE);
$grammarCode = file_get_contents(GRAMMAR_FILE);
$grammarCode = str_replace('%tokens', $tokens, $grammarCode);

file_put_contents(TMP_FILE, $grammarCode);

echo 'Building parser. Output: "',
     trim(shell_exec('./PHP-Yacc/bin/phpyacc -m kmyacc.js.parser ' . TMP_FILE . ' 2>&1')),
     '"', "\n";

preg_match_all('/T_\w+/', $tokens, $matches);
foreach ($matches[0] as $match)
    echo '"' . $match . '",';

echo "\n". str_repeat('-', 45). "\n";
foreach ($matches[0] as $match)
        if (NULL != constant($match))
            echo 'PHP.Constants.' . $match . ' = ' . constant($match) . "\n";
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.