### PR TITLE
improved mobile context menu positioning

### DIFF
--- a/lib/ace/mouse/touch_handler.js
+++ b/lib/ace/mouse/touch_handler.js
@@ -120,9 +120,17 @@ exports.addTouchListeners = function(el, editor) {
         if (!contextMenu) createContextMenu();
         var cursor = editor.selection.cursor;
         var pagePos = editor.renderer.textToScreenCoordinates(cursor.row, cursor.column);
+        var leftOffset = editor.renderer.textToScreenCoordinates(0, 0).pageX;
+        var scrollLeft = editor.renderer.scrollLeft;
         var rect = editor.container.getBoundingClientRect();
         contextMenu.style.top = pagePos.pageY - rect.top - 3 + "px";
-        contextMenu.style.right = "10px";
+        if(pagePos.pageX - rect.left < rect.width - 70) {
+          contextMenu.style.removeProperty('left');
+          contextMenu.style.right = "10px";
+        } else {
+          contextMenu.style.removeProperty('right');
+          contextMenu.style.left = leftOffset + scrollLeft - rect.left + "px";
+        }
         contextMenu.style.display = "";
         contextMenu.firstChild.style.display = "none";
         editor.on("input", hideContextMenu);


### PR DESCRIPTION
*Issue #4320*

*Description of changes:*
Mobile context menu position will move to the left of editor screen if cursor x-position distance is **under 70px** from the right of editor screen.

```javascript
function showContextMenu() {
       .
       . 
       // 70px x-offset tolerance from right of editor screen
       if(pagePos.pageX - rect.left < rect.width - 70) {
          contextMenu.style.removeProperty('left');
          contextMenu.style.right = "10px";
        } else {
          contextMenu.style.removeProperty('right');
          contextMenu.style.left = leftOffset + scrollLeft - rect.left + "px";
        }
        .
        .
    }
```

Tested with/without wrap mode & editor left margin

| with wrap mode | without wrap mode |
|-----------------------|---------------------------|
| <img src="https://user-images.githubusercontent.com/18110223/85013136-43d92c80-b18e-11ea-9b3b-445978becc98.png">  | <img src="https://user-images.githubusercontent.com/18110223/85013179-57849300-b18e-11ea-95e3-d8bb12ed38ae.png"> |
| <img src="https://user-images.githubusercontent.com/18110223/85013145-489de080-b18e-11ea-85c8-ce1a37edfc32.png"> | <img src="https://user-images.githubusercontent.com/18110223/85013161-4f2c5800-b18e-11ea-8d52-0e174e157bf1.png">  |

---
Menus order are remain unchanged.
![Screenshot 2020-06-18 at 5 14 29 PM](https://user-images.githubusercontent.com/18110223/85014245-19886e80-b190-11ea-8c23-a5e4f5d52838.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
