### PR TITLE
fix error when destroying editor in iframe

### DIFF
--- a/lib/ace/editor.js
+++ b/lib/ace/editor.js
@@ -2764,6 +2764,8 @@ Editor.$uid = 0;
             });
             this.$toDestroy = null;
         }
+        if (this.$mouseHandler)
+            this.$mouseHandler.destroy();
         this.renderer.destroy();
         this._signal("destroy", this);
         if (this.session)

--- a/lib/ace/lib/event.js
+++ b/lib/ace/lib/event.js
@@ -108,18 +108,19 @@ exports.getButton = function(e) {
 };
 
 exports.capture = function(el, eventHandler, releaseCaptureHandler) {
+    var ownerDocument = el && el.ownerDocument || document;
     function onMouseUp(e) {
         eventHandler && eventHandler(e);
         releaseCaptureHandler && releaseCaptureHandler(e);
 
-        removeListener(document, "mousemove", eventHandler);
-        removeListener(document, "mouseup", onMouseUp);
-        removeListener(document, "dragstart", onMouseUp);
+        removeListener(ownerDocument, "mousemove", eventHandler);
+        removeListener(ownerDocument, "mouseup", onMouseUp);
+        removeListener(ownerDocument, "dragstart", onMouseUp);
     }
 
-    addListener(document, "mousemove", eventHandler);
-    addListener(document, "mouseup", onMouseUp);
-    addListener(document, "dragstart", onMouseUp);
+    addListener(ownerDocument, "mousemove", eventHandler);
+    addListener(ownerDocument, "mouseup", onMouseUp);
+    addListener(ownerDocument, "dragstart", onMouseUp);
     
     return onMouseUp;
 };

--- a/lib/ace/mouse/mouse_handler.js
+++ b/lib/ace/mouse/mouse_handler.js
@@ -205,6 +205,9 @@ var MouseHandler = function(editor) {
         setTimeout(stop, 10);
         this.editor.on("nativecontextmenu", stop);
     };
+    this.destroy = function() {
+        if (this.releaseMouse) this.releaseMouse();
+    };
 }).call(MouseHandler.prototype);
 
 config.defineOptions(MouseHandler.prototype, "mouseHandler", {

--- a/lib/ace/mouse/mouse_handler_test.js
+++ b/lib/ace/mouse/mouse_handler_test.js
@@ -265,8 +265,17 @@ module.exports = {
         assert.equal(editor.getSelectedText(), "Kin");
     },
     
+    "test: destroy while mouse is pressed": function() {
+        assert.ok(!this.editor.$mouseHandler.releaseMouse);
+        var target = this.editor.renderer.getMouseEventTarget();
+        target.dispatchEvent(MouseEvent("down", {x: 0, y: 0}));
+        assert.ok(this.editor.$mouseHandler.releaseMouse);
+        this.editor.destroy();
+        assert.ok(!this.editor.$mouseHandler.releaseMouse);
+    },
     tearDown : function() {
-         document.body.removeChild(this.editor.container);
+        this.editor.destroy();
+        document.body.removeChild(this.editor.container);
     }
 };
 


### PR DESCRIPTION
fixes error thrown if destroy is called while mouse is pressed, or when captureEnd was not fired because of iframe
