### PR TITLE
Minimal SQL folding mode

### DIFF
--- a/lib/ace/mode/folding/sql.js
+++ b/lib/ace/mode/folding/sql.js
@@ -31,8 +31,7 @@
 define(function(require, exports, module) {
 "use strict";
 
-var Range = require("../../range").Range;
-
+var oop = require("../../lib/oop");
 var BaseFoldMode = require("./cstyle").FoldMode;
 
 var FoldMode = exports.FoldMode = function() {};

--- a/lib/ace/mode/folding/sql.js
+++ b/lib/ace/mode/folding/sql.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,28 +31,23 @@
 define(function(require, exports, module) {
 "use strict";
 
-console.log('hello from here');
-var oop = require("../lib/oop");
-var TextMode = require("./text").Mode;
-var SqlHighlightRules = require("./sql_highlight_rules").SqlHighlightRules;
-var SqlFoldMode = require("./folding/sql").FoldMode;
-console.log(SqlFoldMode);
-var Mode = function() {
-    this.HighlightRules = SqlHighlightRules;
-    this.foldingRules = new SqlFoldMode();
-    this.$behaviour = this.$defaultBehaviour;
-};
-oop.inherits(Mode, TextMode);
+var Range = require("../../range").Range;
+
+var BaseFoldMode = require("./cstyle").FoldMode;
+
+var FoldMode = exports.FoldMode = function() {};
+
+oop.inherits(FoldMode, BaseFoldMode);
 
 (function() {
+    /** 
+     * Inheriting cstyle folding because it handles the region comment folding 
+     * and special block comment folding appropriately.
+     * 
+     * Cstyle's getCommentRegionBlock() contains the sql comment characters '--' for end region block.
+     */
+    
 
-    this.lineCommentStart = "--";
-    this.blockComment = {start: "/*", end: "*/"};
-
-    this.$id = "ace/mode/sql";
-    this.snippetFileId = "ace/snippets/sql";
-}).call(Mode.prototype);
-
-exports.Mode = Mode;
+}).call(FoldMode.prototype);
 
 });

--- a/lib/ace/mode/sql.js
+++ b/lib/ace/mode/sql.js
@@ -35,7 +35,7 @@ var oop = require("../lib/oop");
 var TextMode = require("./text").Mode;
 var SqlHighlightRules = require("./sql_highlight_rules").SqlHighlightRules;
 var SqlFoldMode = require("./folding/sql").FoldMode;
-console.log(SqlFoldMode);
+
 var Mode = function() {
     this.HighlightRules = SqlHighlightRules;
     this.foldingRules = new SqlFoldMode();

--- a/lib/ace/mode/sql.js
+++ b/lib/ace/mode/sql.js
@@ -31,7 +31,6 @@
 define(function(require, exports, module) {
 "use strict";
 
-console.log('hello from here');
 var oop = require("../lib/oop");
 var TextMode = require("./text").Mode;
 var SqlHighlightRules = require("./sql_highlight_rules").SqlHighlightRules;


### PR DESCRIPTION
*Description of changes:*

Added a minimal folding mode for SQL, that's basically the C/CPP one.

This is very useful when making long queries that either have other subqueries or make use of Common Table Expressions.
Thanks to folding, you can more clearly see the structure of you 300-line SQL query.

CTE expanded:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/1240572/88115769-9e1b4200-cbbf-11ea-9aaa-68fbf70e8e52.png">

CTE Folded:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/1240572/88115782-a4a9b980-cbbf-11ea-8f36-53018376ae66.png">

Subquery expanded:
<img width="310" alt="image" src="https://user-images.githubusercontent.com/1240572/88115854-d458c180-cbbf-11ea-911c-20229a0266cd.png">

Subquery folded:
<img width="203" alt="image" src="https://user-images.githubusercontent.com/1240572/88115885-e8042800-cbbf-11ea-9cff-b69107a14add.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
