### PR TITLE
Delete unnecessary line in dom.js

### DIFF
--- a/lib/ace/lib/dom.js
+++ b/lib/ace/lib/dom.js
@@ -235,11 +235,7 @@ exports.scrollbarWidth = function(document) {
     var noScrollbar = inner.offsetWidth;
 
     style.overflow = "scroll";
-    var withScrollbar = inner.offsetWidth;
-
-    if (noScrollbar == withScrollbar) {
-        withScrollbar = outer.clientWidth;
-    }
+    var withScrollbar = outer.clientWidth;
 
     body.removeChild(outer);
 


### PR DESCRIPTION
 noScrollbar == widthScrollbar always evaluate true. so delete this line

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
