### PR TITLE
reset cached horizontal scroll position

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -386,7 +386,7 @@ var VirtualRenderer = function(container, theme) {
             this.resizing = 0;
         // reset cached values on scrollbars, needs to be removed when switching to non-native scrollbars
         // see https://github.com/ajaxorg/ace/issues/2195
-        this.scrollBarV.scrollLeft = this.scrollBarV.scrollTop = null;
+        this.scrollBarH.scrollLeft = this.scrollBarV.scrollTop = null;
     };
     
     this.$updateCachedSize = function(force, gutterWidth, width, height) {


### PR DESCRIPTION
Fix typo for resetting cached horizontal scroll position

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
