### PR TITLE
Update italic highlighting rules to avoid intra word highlights in Markdown Mode. #4358

### DIFF
--- a/lib/ace/mode/markdown_highlight_rules.js
+++ b/lib/ace/mode/markdown_highlight_rules.js
@@ -148,7 +148,7 @@ var MarkdownHighlightRules = function() {
             regex : "([*]{2}|[_]{2}(?=\\S))(.*?\\S[*_]*)(\\1)"
         }, { // emphasis * _
             token : "string.emphasis",
-            regex : "([*]|[_](?=\\S))(.*?\\S[*_]*)(\\1)"
+            regex : "(?<=\\s|^)([*_])[^*_]*\\1(?=\\s|$)"
         }, { //
             token : ["text", "url", "text"],
             regex : "(<)("+


### PR DESCRIPTION
*Issue #4358

This address italic highlighting in Markdown Syntax.

*Description of changes:*

Changes the regex to check for word boundaries or beginning/end of line endings to avoid intra-word highlighting of italic text.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
