### PR TITLE
Make setAnnotations could use custom className

### DIFF
--- a/lib/ace/layer/gutter.js
+++ b/lib/ace/layer/gutter.js
@@ -93,7 +93,10 @@ var Gutter = function(parentEl) {
                 rowInfo.text.push(annoText);
 
             var type = annotation.type;
-            if (type == "error")
+            var className = annotation.className;
+            if (className) 
+                rowInfo.className = className;
+            else if (type == "error")
                 rowInfo.className = " ace_error";
             else if (type == "warning" && rowInfo.className != " ace_error")
                 rowInfo.className = " ace_warning";


### PR DESCRIPTION
### Example 
```css
.ace_gutter-cell.ace_my_class_name{
    background: darkorange no-repeat 2px center;
}
```
```js
editor.session.setAnnotations([{
                            row: 0,
                            text: ["some message will show when mouse hover"],
                            className: "ace_error"  // show the error icon
                        }, {
                            row: 0,
                            text: ["other message"],
                            className: "ace_my_class_name"  // show the background color instead of the default icon
                        }])
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
