### PR TITLE
Add identifierRegexps variable in Completer interface

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -857,6 +857,7 @@ export namespace Ace {
   type CompleterCallback = (error: any, completions: Completion[]) => void;
 
   interface Completer {
+    identifierRegexps?: Array<RegExp>,
     getCompletions(editor: Editor,
       session: EditSession,
       position: Point,


### PR DESCRIPTION
*Related issues https://github.com/ajaxorg/ace/issues/1670*

*Description of changes:*

added to make it possible to change the identifierRegexps variable in the Completer interface of the type script module.

#### Example
```ts
import {Ace} from "ace-builds";

const completers: RegexpsCompleter = {
      identifierRegexps: [/[a-zA-Z_0-9\\$\-\u00A2-\u2000\u2070-\uFFFF.]/],
      getCompletions (editor: Ace.Editor, session: Ace.EditSession, pos: Ace.Point, prefix: string, callback: Ace.CompleterCallback): void {
            ...
      }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
