### PR TITLE
fix scrollTo coordinates issue

### DIFF
--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -1428,7 +1428,7 @@ var VirtualRenderer = function(container, theme) {
      **/
     this.scrollTo = function(x, y) {
         this.session.setScrollTop(y);
-        this.session.setScrollLeft(y);
+        this.session.setScrollLeft(x);
     };
     
     /**


### PR DESCRIPTION
*Issue #, if available:*
scrollTo(x, y) will actually scrollTo(y, y).

*Description of changes:*
Called setScrollLeft() with x-coordinate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
