### PR TITLE
Remove Unnecessary New Line on <canvas> HTML Snippet

### DIFF
--- a/lib/ace/snippets/html.snippets
+++ b/lib/ace/snippets/html.snippets
@@ -234,9 +234,7 @@ snippet button:s
 snippet button:r
 	<button type="reset">${1}</button>
 snippet canvas
-	<canvas>
-		${1}
-	</canvas>
+	<canvas id="${1:canvas}"></canvas>
 snippet caption
 	<caption>${1}</caption>
 snippet cite


### PR DESCRIPTION
*Description of changes:*
1. Removed unnecessary new line character on `<canvas>` element snippet.
2. Added default `id` attribute and cursor focus.

Reference :
[Canvas API - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
