### PR TITLE
Added ES6 Default Parameters States

### DIFF
--- a/lib/ace/mode/javascript_highlight_rules.js
+++ b/lib/ace/mode/javascript_highlight_rules.js
@@ -305,10 +305,43 @@ var JavaScriptHighlightRules = function(options) {
                 defaultToken: "string.regexp.charachterclass"
             }
         ],
+        "default_parameter": [
+            {
+                token : "string",
+                regex : "'(?=.)"
+            }, {
+                token : "string",
+                regex : '"(?=.)'
+            }, {
+                token : "constant.language",
+                regex : "null|Infinity|NaN|undefined"
+            }, {
+                token : "constant.numeric", // hexadecimal, octal and binary
+                regex : /0(?:[xX][0-9a-fA-F]+|[oO][0-7]+|[bB][01]+)\b/
+            }, {
+                token : "constant.numeric", // decimal integers and floats
+                regex : /(?:\d\d*(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+\b)?/
+            }, {
+                token: "punctuation.operator",
+                regex: "[, ]+",
+                next: "function_arguments"
+            }, {
+                token: "punctuation.operator",
+                regex: "$"
+            }, {
+                token: "empty",
+                regex: "",
+                next: "no_regex"
+            }
+        ],
         "function_arguments": [
             {
                 token: "variable.parameter",
                 regex: identifierRe
+            }, {
+                token : "keyword.operator",
+                regex : "[= ]+",
+                next : "default_parameter"
             }, {
                 token: "punctuation.operator",
                 regex: "[, ]+"


### PR DESCRIPTION
*Description of changes:*

Comparison between with default parameters states (left) & without (right) :

![2020-10-26 17_23_44-TMPmachine_ Temporary Web App Code Editor](https://user-images.githubusercontent.com/18110223/97161215-10e41c80-17b0-11eb-9ac0-7c9dddb6623b.png)

 It's important to write __default parameters__ states as its own group for two reasons :
- __function arguments__ states handles identifiers
- __default parameter__ states handles value

Below image is the proposed states for ES6 default parameters highlighting rules (JavaScript).

![Untitled Diagram-Page-4](https://user-images.githubusercontent.com/18110223/97164783-3c1d3a80-17b5-11eb-8171-427314a6f4b1.jpg)


The actual states are more complex than this, and I know I'm missing something here. But the point is to show you the flow of the states.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
