### PR TITLE
remove 2 csslint rules that only target ancient browsers

### DIFF
--- a/lib/ace/mode/css/csslint.js
+++ b/lib/ace/mode/css/csslint.js
@@ -7301,34 +7301,6 @@ CSSLint.addRule({
 });
 
 /*
- * Rule: box-sizing doesn't work in IE6 and IE7.
- */
-
-CSSLint.addRule({
-
-    //rule information
-    id: "box-sizing",
-    name: "Disallow use of box-sizing",
-    desc: "The box-sizing properties isn't supported in IE6 and IE7.",
-    browsers: "IE6, IE7",
-    tags: ["Compatibility"],
-
-    //initialization
-    init: function(parser, reporter){
-        var rule = this;
-
-        parser.addListener("property", function(event){
-            var name = event.property.text.toLowerCase();
-
-            if (name === "box-sizing"){
-                reporter.report("The box-sizing property isn't supported in IE6 and IE7.", event.line, event.col, rule);
-            }
-        });
-    }
-
-});
-
-/*
  * Rule: Use the bulletproof @font-face syntax to avoid 404's in old IE
  * (http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax)
  */
@@ -7837,82 +7809,6 @@ CSSLint.addRule({
 
         parser.addListener("error", function(event){
             reporter.error(event.message, event.line, event.col, rule);
-        });
-
-    }
-
-});
-
-CSSLint.addRule({
-
-    //rule information
-    id: "fallback-colors",
-    name: "Require fallback colors",
-    desc: "For older browsers that don't support RGBA, HSL, or HSLA, provide a fallback color.",
-    browsers: "IE6,IE7,IE8",
-
-    //initialization
-    init: function(parser, reporter){
-        var rule = this,
-            lastProperty,
-            propertiesToCheck = {
-                color: 1,
-                background: 1,
-                "border-color": 1,
-                "border-top-color": 1,
-                "border-right-color": 1,
-                "border-bottom-color": 1,
-                "border-left-color": 1,
-                border: 1,
-                "border-top": 1,
-                "border-right": 1,
-                "border-bottom": 1,
-                "border-left": 1,
-                "background-color": 1
-            },
-            properties;
-
-        function startRule(){
-            properties = {};
-            lastProperty = null;
-        }
-
-        parser.addListener("startrule", startRule);
-        parser.addListener("startfontface", startRule);
-        parser.addListener("startpage", startRule);
-        parser.addListener("startpagemargin", startRule);
-        parser.addListener("startkeyframerule", startRule);
-
-        parser.addListener("property", function(event){
-            var property = event.property,
-                name = property.text.toLowerCase(),
-                parts = event.value.parts,
-                i = 0,
-                colorType = "",
-                len = parts.length;
-
-            if(propertiesToCheck[name]){
-                while(i < len){
-                    if (parts[i].type === "color"){
-                        if ("alpha" in parts[i] || "hue" in parts[i]){
-
-                            if (/([^\)]+)\(/.test(parts[i])){
-                                colorType = RegExp.$1.toUpperCase();
-                            }
-
-                            if (!lastProperty || (lastProperty.property.text.toLowerCase() !== name || lastProperty.colorType !== "compat")){
-                                reporter.report("Fallback " + name + " (hex or RGB) should precede " + colorType + " " + name + ".", event.line, event.col, rule);
-                            }
-                        } else {
-                            event.colorType = "compat";
-                        }
-                    }
-
-                    i++;
-                }
-            }
-
-            lastProperty = event;
         });
 
     }


### PR DESCRIPTION
These two rules no longer serve any purpose, all modern and even fairly old browsers support these features now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
