### PR TITLE
Fix vim's `dG` when performed over the whole range

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -2921,7 +2921,8 @@ dom.importCssString(".normal-mode .ace_cursor{\
           }
           var prevLineEnd = new Pos(anchor.line - 1, Number.MAX_VALUE);
           var wasLastLine = cm.firstLine() == cm.lastLine();
-          if (head.line > cm.lastLine() && args.linewise && !wasLastLine) {
+          var isFirstLine = cm.firstLine() == anchor.line;
+          if (head.line > cm.lastLine() && args.linewise && !wasLastLine && !isFirstLine) {
             cm.replaceRange('', prevLineEnd, head);
           } else {
             cm.replaceRange('', anchor, head);

--- a/lib/ace/keyboard/vim_test.js
+++ b/lib/ace/keyboard/vim_test.js
@@ -1091,6 +1091,12 @@ testVim('dd_only_line', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq(expectedRegister, register.toString());
 }, { value: "thisistheonlyline" });
+testVim('cG', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('c', 'G', 'inserted');
+  eq('inserted\n', cm.getValue());
+  helpers.assertCursorAt(0, 8);
+}, { value: 'line1\nline2'});
 // Yank commands should behave the exact same as d commands, expect that nothing
 // gets deleted.
 testVim('yw_repeat', function(cm, vim, helpers) {


### PR DESCRIPTION
This fixes #4411, discovered on the rust playground (integer32llc/rust-playground#649).

We need to handle the special case of deleting the entire range of text, where we can't effectively move `anchor` to the previous line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.