### PR TITLE
Rename Perl 6 to Raku

### DIFF
--- a/demo/kitchen-sink/docs/raku.raku
+++ b/demo/kitchen-sink/docs/raku.raku
@@ -1,5 +1,5 @@
 =begin comment
-Perl 6 example for ace
+Raku example for ace
 =end comment
 class Cook is Employee {
     has @.utensils  is rw;
@@ -38,4 +38,4 @@ my $baker = Baker.new(
 $baker.cook('brioche');      # OUTPUT: «Baking a tasty brioche␤»
 say $baker.utensils.perl;    # OUTPUT: «["self cleaning oven"]␤»
 say $baker.cookbooks.perl;   # OUTPUT: «["The Baker's Apprentice"]␤»
-say $baker.salary;           # OUTPUT: «50000␤» 
+say $baker.salary;           # OUTPUT: «50000␤»

--- a/lib/ace/ext/modelist.js
+++ b/lib/ace/ext/modelist.js
@@ -148,7 +148,6 @@ var supportedModes = {
     OCaml:       ["ml|mli"],
     Pascal:      ["pas|p"],
     Perl:        ["pl|pm"],
-    Perl6:       ["p6|pl6|pm6"],
     pgSQL:       ["pgsql"],
     PHP:         ["php|inc|phtml|shtml|php3|php4|php5|phps|phpt|aw|ctp|module"],
     PHP_Laravel_blade: ["blade.php"],
@@ -163,6 +162,7 @@ var supportedModes = {
     Python:      ["py"],
     QML:         ["qml"],
     R:           ["r"],
+    Raku:        ["raku|rakumod|rakutest|p6|pl6|pm6"],
     Razor:       ["cshtml|asp"],
     RDoc:        ["Rd"],
     Red:         ["red|reds"],
@@ -228,6 +228,7 @@ var nameOverrides = {
     Perl6: "Perl 6",
     AutoHotKey: "AutoHotkey / AutoIt"
 };
+
 var modesByName = {};
 for (var name in supportedModes) {
     var data = supportedModes[name];

--- a/lib/ace/mode/_test/tokens_raku.json
+++ b/lib/ace/mode/_test/tokens_raku.json
@@ -3,7 +3,7 @@
   ["comment.doc","=begin comment"]
 ],[
    "block_comment",
-  ["comment.doc","Perl 6 example for ace"]
+  ["comment.doc","Raku example for ace"]
 ],[
    "start",
   ["comment.doc","=end comment"]

--- a/lib/ace/mode/raku.js
+++ b/lib/ace/mode/raku.js
@@ -33,7 +33,7 @@ define(function(require, exports, module) {
 
 var oop = require("../lib/oop");
 var TextMode = require("./text").Mode;
-var RakuHighlightRules = require("./Raku_highlight_rules").RakuHighlightRules;
+var RakuHighlightRules = require("./raku_highlight_rules").RakuHighlightRules;
 var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutdent;
 var CStyleFoldMode = require("./folding/cstyle").FoldMode;
 

--- a/lib/ace/mode/raku.js
+++ b/lib/ace/mode/raku.js
@@ -33,12 +33,12 @@ define(function(require, exports, module) {
 
 var oop = require("../lib/oop");
 var TextMode = require("./text").Mode;
-var Perl6HighlightRules = require("./perl6_highlight_rules").Perl6HighlightRules;
+var RakuHighlightRules = require("./Raku_highlight_rules").RakuHighlightRules;
 var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutdent;
 var CStyleFoldMode = require("./folding/cstyle").FoldMode;
 
 var Mode = function() {
-    this.HighlightRules = Perl6HighlightRules;
+    this.HighlightRules = RakuHighlightRules;
 
     this.$outdent = new MatchingBraceOutdent();
     this.foldingRules = new CStyleFoldMode({start: "^=(begin)\\b", end: "^=(end)\\b"});
@@ -83,7 +83,7 @@ oop.inherits(Mode, TextMode);
         this.$outdent.autoOutdent(doc, row);
     };
 
-    this.$id = "ace/mode/perl6";
+    this.$id = "ace/mode/raku";
 }).call(Mode.prototype);
 
 exports.Mode = Mode;

--- a/lib/ace/mode/raku_highlight_rules.js
+++ b/lib/ace/mode/raku_highlight_rules.js
@@ -34,7 +34,7 @@ define(function(require, exports, module) {
 var oop = require("../lib/oop");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 
-var Perl6HighlightRules = function() {
+var RakuHighlightRules = function() {
 
     var keywords = (
         "my|our|class|role|grammar|is|does|sub|method|submethod|try|" +
@@ -64,7 +64,7 @@ var Perl6HighlightRules = function() {
         "Pod::Block|Pod::Block::Code|Pod::Block::Comment|Pod::Block::Declarator|"+
         "Pod::Block::Named|Pod::Block::Para|Pod::Block::Table|Pod::Heading|Pod::Item|"+
         "Positional|PositionalBindFailover|Proc|Proc::Async|Promise|Proxy|PseudoStash|"+
-        "QuantHash|Range|Rat|Rational|RatStr|Real|Regex|Routine|Scalar|Scheduler|"+
+        "Raku|QuantHash|Range|Rat|Rational|RatStr|Real|Regex|Routine|Scalar|Scheduler|"+
         "Semaphore|Seq|Set|SetHash|Setty|Signature|Slip|Stash|Str|StrDistance|Stringy|"+
         "Sub|Submethod|Supplier|Supplier::Preserving|Supply|Systemic|Tap|Telemetry|"+
         "Telemetry::Instrument::Thread|Telemetry::Instrument::Usage|Telemetry::Period|"+
@@ -150,7 +150,7 @@ var Perl6HighlightRules = function() {
         "positional|posix|postfix|postmatch|precomp-ext|precomp-target|pred|prefix|prematch|prepend|"+
         "print|printf|print-nl|print-to|private|private_method_table|proc|produce|Promise|prompt|"+
         "protect|pull-one|push|push-all|push-at-least|push-exactly|push-until-lazy|put|"+
-        "qualifier-type|quit|r|race|radix|rand|range|raw|re|read|readchars|readonly|"+
+        "qualifier-type|quit|r|race|radix|raku|rand|range|raw|re|read|readchars|readonly|"+
         "ready|Real|reallocate|reals|reason|rebless|receive|recv|redispatcher|redo|reduce|"+
         "rel2abs|relative|release|rename|repeated|replacement|report|reserved|resolve|"+
         "restore|result|resume|rethrow|reverse|right|rindex|rmdir|roles_to_compose|"+
@@ -389,7 +389,7 @@ var Perl6HighlightRules = function() {
 	};
 };
 
-oop.inherits(Perl6HighlightRules, TextHighlightRules);
+oop.inherits(RakuHighlightRules, TextHighlightRules);
 
-exports.Perl6HighlightRules = Perl6HighlightRules;
+exports.RakuHighlightRules = RakuHighlightRules;
 });


### PR DESCRIPTION
As per language renaming:
https://github.com/Raku/problem-solving/pull/89

This renames the perl6* files to raku* and updates the modelist with the new name.

I considered retaining Perl 6 mode but did not want to duplicate the parser code. I wondered about adding an alias mechanism but decided to send PR as is to get feedback.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
