### PR TITLE
Remove/reclassify some csslint rules

### DIFF
--- a/lib/ace/mode/css/csslint.js
+++ b/lib/ace/mode/css/csslint.js
@@ -7155,52 +7155,6 @@ CSSLint.Util = {
 };
 
 /*
- * Rule: Don't use adjoining classes (.foo.bar).
- */
-
-CSSLint.addRule({
-
-    //rule information
-    id: "adjoining-classes",
-    name: "Disallow adjoining classes",
-    desc: "Don't use adjoining classes.",
-    browsers: "IE6",
-
-    //initialization
-    init: function(parser, reporter){
-        var rule = this;
-        parser.addListener("startrule", function(event){
-            var selectors = event.selectors,
-                selector,
-                part,
-                modifier,
-                classCount,
-                i, j, k;
-
-            for (i=0; i < selectors.length; i++){
-                selector = selectors[i];
-                for (j=0; j < selector.parts.length; j++){
-                    part = selector.parts[j];
-                    if (part.type === parser.SELECTOR_PART_TYPE){
-                        classCount = 0;
-                        for (k=0; k < part.modifiers.length; k++){
-                            modifier = part.modifiers[k];
-                            if (modifier.type === "class"){
-                                classCount++;
-                            }
-                            if (classCount > 1){
-                                reporter.report("Don't use adjoining classes.", part.line, part.col, rule);
-                            }
-                        }
-                    }
-                }
-            }
-        });
-    }
-
-});
-
-/*
  * Rule: Don't use width or height when using padding or border.
  */
 CSSLint.addRule({
@@ -8718,81 +8672,6 @@ CSSLint.addRule({
             }
         });
     }
-});
-
-/*
- * Rule: Headings (h1-h6) should be defined only once.
- */
-
-CSSLint.addRule({
-
-    //rule information
-    id: "unique-headings",
-    name: "Headings should only be defined once",
-    desc: "Headings should be defined only once.",
-    browsers: "All",
-
-    //initialization
-    init: function(parser, reporter){
-        var rule = this;
-
-        var headings = {
-                h1: 0,
-                h2: 0,
-                h3: 0,
-                h4: 0,
-                h5: 0,
-                h6: 0
-            };
-
-        parser.addListener("startrule", function(event){
-            var selectors = event.selectors,
-                selector,
-                part,
-                pseudo,
-                i, j;
-
-            for (i=0; i < selectors.length; i++){
-                selector = selectors[i];
-                part = selector.parts[selector.parts.length-1];
-
-                if (part.elementName && /(h[1-6])/i.test(part.elementName.toString())){
-
-                    for (j=0; j < part.modifiers.length; j++){
-                        if (part.modifiers[j].type === "pseudo"){
-                            pseudo = true;
-                            break;
-                        }
-                    }
-
-                    if (!pseudo){
-                        headings[RegExp.$1]++;
-                        if (headings[RegExp.$1] > 1) {
-                            reporter.report("Heading (" + part.elementName + ") has already been defined.", part.line, part.col, rule);
-                        }
-                    }
-                }
-            }
-        });
-
-        parser.addListener("endstylesheet", function(){
-            var prop,
-                messages = [];
-
-            for (prop in headings){
-                if (headings.hasOwnProperty(prop)){
-                    if (headings[prop] > 1){
-                        messages.push(headings[prop] + " " + prop + "s");
-                    }
-                }
-            }
-
-            if (messages.length){
-                reporter.rollupWarn("You have " + messages.join(", ") + " defined in this stylesheet.", rule);
-            }
-        });
-    }
-
 });
 
 /*

--- a/lib/ace/mode/css/csslint.js
+++ b/lib/ace/mode/css/csslint.js
@@ -8264,45 +8264,6 @@ CSSLint.addRule({
 });
 
 /*
- * Rule: Headings (h1-h6) should not be qualified (namespaced).
- */
-
-CSSLint.addRule({
-
-    //rule information
-    id: "qualified-headings",
-    name: "Disallow qualified headings",
-    desc: "Headings should not be qualified (namespaced).",
-    browsers: "All",
-
-    //initialization
-    init: function(parser, reporter){
-        var rule = this;
-
-        parser.addListener("startrule", function(event){
-            var selectors = event.selectors,
-                selector,
-                part,
-                i, j;
-
-            for (i=0; i < selectors.length; i++){
-                selector = selectors[i];
-
-                for (j=0; j < selector.parts.length; j++){
-                    part = selector.parts[j];
-                    if (part.type === parser.SELECTOR_PART_TYPE){
-                        if (part.elementName && /h[1-6]/.test(part.elementName.toString()) && j > 0){
-                            reporter.report("Heading (" + part.elementName + ") should not be qualified.", part.line, part.col, rule);
-                        }
-                    }
-                }
-            }
-        });
-    }
-
-});
-
-/*
  * Rule: Selectors that look like regular expressions are slow and should be avoided.
  */
 

--- a/lib/ace/mode/css_worker.js
+++ b/lib/ace/mode/css_worker.js
@@ -42,7 +42,7 @@ var Worker = exports.Worker = function(sender) {
     this.ruleset = null;
     this.setDisabledRules("ids|order-alphabetical");
     this.setInfoRules(
-      "adjoining-classes|zero-units|gradients|box-model" +
+      "adjoining-classes|zero-units|gradients|box-model|" +
       "import|outline-none|vendor-prefix"
     );
 };

--- a/lib/ace/mode/css_worker.js
+++ b/lib/ace/mode/css_worker.js
@@ -42,7 +42,7 @@ var Worker = exports.Worker = function(sender) {
     this.ruleset = null;
     this.setDisabledRules("ids|order-alphabetical");
     this.setInfoRules(
-      "adjoining-classes|qualified-headings|zero-units|gradients|" +
+      "adjoining-classes|zero-units|gradients|box-model" +
       "import|outline-none|vendor-prefix"
     );
 };


### PR DESCRIPTION
This removes the rule for adjoining classes, which was there because of an ancient ie6 bug.
It also removes two rules pertaining headings (h1 - h6) - one saying they should not be qualified and one saying there should be only one definition containing each of them. This seems to be the opinion of the original author of csslint, but doesn't seem to be grounded in any reasoning I could find. Especially with CMSes you might need to style different headings differently, using multiple qualified headings is often necessary.

Additionally, I have demoted the warning that height/width with padding could cause element sizes to not be what you expect to an info, since it will show up quite frequently, and is a pretty unavoidable fact of life when writing CSS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
