### PR TITLE
Fix vim replace in range command where replacement includes line breaks

### DIFF
--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -5890,7 +5890,9 @@ dom.importCssString(".normal-mode .ace_cursor{\
         var text = cm.getRange(searchCursor.from(), searchCursor.to());
         var newText = text.replace(query, replaceWith);
         searchCursor.replace(newText);
-        lineEnd += lineBreakCount(newText) - lineBreakCount(text);
+        var lineBreakDifference = lineBreakCount(newText) - lineBreakCount(text);
+        lineEnd += lineBreakDifference
+        lastPos.line += lineBreakDifference
       }
       function next() {
         // The below only loops to skip over multiple occurrences on the same

--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -5883,10 +5883,14 @@ dom.importCssString(".normal-mode .ace_cursor{\
           stop();
         });
       }
+      function lineBreakCount(text) {
+        return (text.match(/[\n\r]/g) || []).length;
+      }
       function replace() {
         var text = cm.getRange(searchCursor.from(), searchCursor.to());
         var newText = text.replace(query, replaceWith);
         searchCursor.replace(newText);
+        lineEnd += lineBreakCount(newText) - lineBreakCount(text);
       }
       function next() {
         // The below only loops to skip over multiple occurrences on the same

--- a/lib/ace/keyboard/vim.js
+++ b/lib/ace/keyboard/vim.js
@@ -140,10 +140,10 @@ define(function(require, exports, module) {
     TextModeTokenRe.lastIndex = 0;
     return TextModeTokenRe.test(ch);
   };
-  
+
 (function() {
   oop.implement(CodeMirror.prototype, EventEmitter);
-  
+
   this.destroy = function() {
     this.ace.off('change', this.onChange);
     this.ace.off('changeSelection', this.onSelectionChange);
@@ -263,7 +263,7 @@ define(function(require, exports, module) {
       r.cursor = Range.comparePoints(r.start, head) ? r.end : r.start;
       return r;
     });
-    
+
     if (this.ace.inVirtualSelectionMode) {
       this.ace.selection.fromOrientedRange(ranges[0]);
       return;
@@ -306,7 +306,7 @@ define(function(require, exports, module) {
     var rowShift = (end.row - start.row) * (isInsert ? 1 : -1);
     var colShift = (end.column - start.column) * (isInsert ? 1 : -1);
     if (isInsert) end = start;
-    
+
     for (var i in this.marks) {
       var point = this.marks[i];
       var cmp = Range.comparePoints(point, start);
@@ -473,7 +473,7 @@ define(function(require, exports, module) {
     if (!e) e = s;
     return this.ace.session.replace(new Range(s.line, s.ch, e.line, e.ch), text);
   };
-  this.replaceSelection = 
+  this.replaceSelection =
   this.replaceSelections = function(p) {
     var sel = this.ace.selection;
     if (this.ace.inVirtualSelectionMode) {
@@ -790,12 +790,12 @@ dom.importCssString(".normal-mode .ace_cursor{\
         inp.value = newVal;
       } else {
         if (closed) return;
-        
+
         if (newVal && newVal.type == "blur") {
           if (document.activeElement === inp)
             return;
         }
-        
+
         me.state.dialog = null;
         closed = true;
         dialog.parentNode.removeChild(dialog);
@@ -869,7 +869,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
   });
 })();
 
-  
+
   var defaultKeymap = [
     // Key to key mapping. This goes first to make it possible to override
     // existing mappings.
@@ -6378,7 +6378,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
     } else if (wasMultiselect && vim.visualBlock) {
        vim.wasInVisualBlock = true;
     }
-    
+
     if (key == '<Esc>' && !vim.insertMode && !vim.visualMode && wasMultiselect) {
       cm.ace.exitMultiSelectMode();
     } else if (visualBlock || !wasMultiselect || cm.ace.inVirtualSelectionMode) {
@@ -6397,7 +6397,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
           anchor = offsetCursor(anchor, 0, anchorOffset);
           cm.state.vim.sel.head = head;
           cm.state.vim.sel.anchor = anchor;
-          
+
           isHandled = handleKey(cm, key, origin);
           sel.$desiredColumn = cm.state.vim.lastHPos == -1 ? null : cm.state.vim.lastHPos;
           if (cm.virtualSelectionMode()) {
@@ -6425,12 +6425,12 @@ dom.importCssString(".normal-mode .ace_cursor{\
       var top = pixelPos.top;
       var left = pixelPos.left;
       if (!vim.insertMode) {
-        var isbackwards = !sel.cursor 
+        var isbackwards = !sel.cursor
             ? session.selection.isBackwards() || session.selection.isEmpty()
             : Range.comparePoints(sel.cursor, sel.start) <= 0;
         if (!isbackwards && left > w)
           left -= w;
-      }     
+      }
       if (!vim.insertMode && vim.status) {
         h = h / 2;
         top += h;
@@ -6444,7 +6444,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
       var cm = editor.state.cm;
       var vim = getVim(cm);
       if (keyCode == -1) return;
-      
+
       // in non-insert mode we try to find the ascii key corresponding to the text in textarea
       // this is needed because in languages that use latin alphabet we want to get the key that browser sends to the textarea
       // and in non
@@ -6475,7 +6475,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
           data.inputChar = data.inputKey = null;
         }
       }
-      
+
       // ctrl-c is special it both exits mode and copies text
       if (key == "c" && hashId == 1) { // key == "ctrl-c"
         if (!useragent.isMac && editor.getCopyText()) {
@@ -6485,13 +6485,13 @@ dom.importCssString(".normal-mode .ace_cursor{\
           return {command: "null", passEvent: true};
         }
       }
-      
+
       if (key == "esc" && !vim.insertMode && !vim.visualMode && !cm.ace.inMultiSelectMode) {
         var searchState = getSearchState(cm);
         var overlay = searchState.getOverlay();
         if (overlay) cm.removeOverlay(overlay);
       }
-      
+
       if (hashId == -1 || hashId & 1 || hashId === 0 && key.length > 1) {
         var insertMode = vim.insertMode;
         var name = lookupKey(hashId, key, e || {});
@@ -6590,7 +6590,7 @@ dom.importCssString(".normal-mode .ace_cursor{\
     { keys: 'zA', type: 'action', action: 'fold', actionArgs: { toggle: true, all: true } },
     { keys: 'zf', type: 'action', action: 'fold', actionArgs: { open: true, all: true } },
     { keys: 'zd', type: 'action', action: 'fold', actionArgs: { open: true, all: true } },
-    
+
     { keys: '<C-A-k>', type: 'action', action: 'aceCommand', actionArgs: { name: "addCursorAbove" } },
     { keys: '<C-A-j>', type: 'action', action: 'aceCommand', actionArgs: { name: "addCursorBelow" } },
     { keys: '<C-A-S-k>', type: 'action', action: 'aceCommand', actionArgs: { name: "addCursorAboveSkipCurrent" } },

--- a/lib/ace/keyboard/vim_test.js
+++ b/lib/ace/keyboard/vim_test.js
@@ -3969,16 +3969,21 @@ testVim('ex_substitute_alternate_separator', function(cm, vim, helpers) {
   helpers.doEx('s#o/e#two#g');
   eq('o/e o/e\n two two', cm.getValue());
 }, { value: 'o/e o/e\n o/e o/e'});
-testVim('ex_substitute_global_with_newline (\\r)', function(cm, vim, helpers) {
+testVim('ex_substitute_with_newline (\\n)', function(cm, vim, helpers) {
+  cm.setCursor(1, 0);
+  helpers.doEx('s/\\.\\s/.\\n/');
+  eq('a. b. c.\n1.\n2. 3.', cm.getValue());
+}, { value: 'a. b. c.\n1. 2. 3.'});
+testVim('ex_substitute_all_in_range_with_newline (\\n)', function(cm, vim, helpers) {
   cm.setCursor(1, 0);
   helpers.doEx('1,2s/\\.\\s/.\\n/g');
-  eq('a.\na bb.\n1.\n1 1.', cm.getValue());
-}, { value: 'a. a bb.\n1. 1 1.'});
-testVim('ex_substitute_global_with_newline (\\n)', function(cm, vim, helpers) {
+  eq('a.\nb.\nc.\n1.\n2.\n3.', cm.getValue());
+}, { value: 'a. b. c.\n1. 2. 3.'});
+testVim('ex_substitute_all_in_range_with_newline (\\r)', function(cm, vim, helpers) {
   cm.setCursor(1, 0);
   helpers.doEx('1,2s/\\.\\s/.\\r/g');
-  eq('a.\ra bb.\r1.\r1 1.', cm.getValue());
-}, { value: 'a. a bb.\r1. 1 1.'});
+  eq('a.\rb.\rc.\r1.\r2.\r3.', cm.getValue());
+}, { value: 'a. b. c.\r1. 2. 3.'});
 testVim('ex_substitute_full_file', function(cm, vim, helpers) {
   cm.setCursor(1, 0);
   helpers.doEx('%s/one/two/g');

--- a/lib/ace/keyboard/vim_test.js
+++ b/lib/ace/keyboard/vim_test.js
@@ -3984,6 +3984,11 @@ testVim('ex_substitute_all_in_range_with_newline (\\r)', function(cm, vim, helpe
   helpers.doEx('1,2s/\\.\\s/.\\r/g');
   eq('a.\rb.\rc.\r1.\r2.\r3.', cm.getValue());
 }, { value: 'a. b. c.\r1. 2. 3.'});
+testVim('ex_substitute_all_in_range_with_multiple newlines (\\r)', function(cm, vim, helpers) {
+  cm.setCursor(1, 0);
+  helpers.doEx('1,2s/\\.\\s/.\\r\\r/g');
+  eq('a.\r\rb.\r\rc.\r1.\r\r2.\r\r3.', cm.getValue());
+}, { value: 'a. b. c.\r1. 2. 3.'});
 testVim('ex_substitute_full_file', function(cm, vim, helpers) {
   cm.setCursor(1, 0);
   helpers.doEx('%s/one/two/g');

--- a/lib/ace/keyboard/vim_test.js
+++ b/lib/ace/keyboard/vim_test.js
@@ -3969,6 +3969,16 @@ testVim('ex_substitute_alternate_separator', function(cm, vim, helpers) {
   helpers.doEx('s#o/e#two#g');
   eq('o/e o/e\n two two', cm.getValue());
 }, { value: 'o/e o/e\n o/e o/e'});
+testVim('ex_substitute_global_with_newline (\\r)', function(cm, vim, helpers) {
+  cm.setCursor(1, 0);
+  helpers.doEx('1,2s/\\.\\s/.\\n/g');
+  eq('a.\na bb.\n1.\n1 1.', cm.getValue());
+}, { value: 'a. a bb.\n1. 1 1.'});
+testVim('ex_substitute_global_with_newline (\\n)', function(cm, vim, helpers) {
+  cm.setCursor(1, 0);
+  helpers.doEx('1,2s/\\.\\s/.\\r/g');
+  eq('a.\ra bb.\r1.\r1 1.', cm.getValue());
+}, { value: 'a. a bb.\r1. 1 1.'});
 testVim('ex_substitute_full_file', function(cm, vim, helpers) {
   cm.setCursor(1, 0);
   helpers.doEx('%s/one/two/g');


### PR DESCRIPTION
This fixes vim replace all where a range is being replaced with added newlines.
For instance, when executing command `:s/\.\s/.\r/g` on the first line of the text
```
sentence one. sentence two. sentence three. sentence four.
sentence five. sentence six.
```
the text should become
```
sentence one.
sentence two.
sentence three.
sentence four.
sentence five. sentence six.
```
Currently, only the first match would be replaced because the code looks at only the lines in the initial range without considering that new text in each replacement iteration has more lines than the previous.

Consequently, this leads to odd behaviour when selecting a larger range as, e.g. `:1,2s/\.\s/.\r/g` for the same example text would result in  
```
sentence one.
sentence two. 
sentence three. line four.
sentence four. sentence five.
```

I added an increase to line end value depending on added newlines in the used replacement function to fix this.
Also, I added tests for both `\n` and `\r` newline replacements, single replacement and replacement with multiple line breaks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
