### PR TITLE
Avoid substitutions when Webpack was introduced

### DIFF
--- a/lib/ace/worker/worker.js
+++ b/lib/ace/worker/worker.js
@@ -153,10 +153,10 @@ window.define = function(id, deps, factory) {
     };
 };
 window.define.amd = {};
-require.tlns = {};
+window.require.tlns = {};
 window.initBaseUrls  = function initBaseUrls(topLevelNamespaces) {
     for (var i in topLevelNamespaces)
-        require.tlns[i] = topLevelNamespaces[i];
+        window.require.tlns[i] = topLevelNamespaces[i];
 };
 
 window.initSender = function initSender() {
@@ -210,7 +210,7 @@ window.onmessage = function(e) {
     else if (msg.init) {
         window.initBaseUrls(msg.tlns);
         sender = window.sender = window.initSender();
-        var clazz = require(msg.module)[msg.classname];
+        var clazz = window.require(msg.module)[msg.classname];
         main = window.main = new clazz(sender);
     }
 };

--- a/lib/ace/worker/worker.js
+++ b/lib/ace/worker/worker.js
@@ -156,7 +156,7 @@ window.define.amd = {};
 window.require.tlns = {};
 window.initBaseUrls  = function initBaseUrls(topLevelNamespaces) {
     for (var i in topLevelNamespaces)
-        window.require.tlns[i] = topLevelNamespaces[i];
+        this.require.tlns[i] = topLevelNamespaces[i];
 };
 
 window.initSender = function initSender() {
@@ -210,7 +210,7 @@ window.onmessage = function(e) {
     else if (msg.init) {
         window.initBaseUrls(msg.tlns);
         sender = window.sender = window.initSender();
-        var clazz = window.require(msg.module)[msg.classname];
+        var clazz = this.require(msg.module)[msg.classname];
         main = window.main = new clazz(sender);
     }
 };


### PR DESCRIPTION
Avoid 'require' being replaced with Webpack's unique declaration '__non_webpack_require__' when Webpack introduces packaging

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
