### PR TITLE
twilight.css: Removed duplicate definition

### DIFF
--- a/lib/ace/theme/twilight.css
+++ b/lib/ace/theme/twilight.css
@@ -96,8 +96,7 @@
 }
 
 .ace-twilight .ace_entity.ace_name.ace_function,
-.ace-twilight .ace_meta.ace_tag,
-.ace-twilight .ace_variable {
+.ace-twilight .ace_meta.ace_tag {
   color: #AC885B
 }
 


### PR DESCRIPTION
Removed duplicate ace_variable definition

*Description of changes:*
Looked through styles for the twilight theme. There was a duplicate definition for `ace_variable`. Removed the first, as the second overwrites the first anyway.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
