### PR TITLE
Added highlight rule for C stdint Integer Types in c_cpp mode

### DIFF
--- a/lib/ace/mode/c_cpp_highlight_rules.js
+++ b/lib/ace/mode/c_cpp_highlight_rules.js
@@ -17,7 +17,7 @@ var c_cppHighlightRules = function() {
     
     var storageType = (
         "asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|" +
-        "_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void|" +
+        "_Imaginary|int|int8_t|int16_t|int32_t|long|short|signed|struct|typedef|uint8_t|uint16_t|uint32_t|union|unsigned|void|" +
         "class|wchar_t|template|char16_t|char32_t"
     );
 


### PR DESCRIPTION
*Description of changes:*
Added C stdint Integer Types to 'storageType' rule of c_cpp_highlight.js

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
