### PR TITLE
fix foldOther command not folding all possible ranges

### DIFF
--- a/lib/ace/edit_session/folding.js
+++ b/lib/ace/edit_session/folding.js
@@ -439,21 +439,40 @@ function Folding() {
         if (location == null) {
             range = new Range(0, 0, this.getLength(), 0);
             if (expandInner == null) expandInner = true;
-        } else if (typeof location == "number")
+        } else if (typeof location == "number") {
             range = new Range(location, 0, location, this.getLine(location).length);
-        else if ("row" in location)
+        } else if ("row" in location) {
             range = Range.fromPoints(location, location);
-        else
+        } else if (Array.isArray(location)) {
+            folds = [];
+            location.forEach(function(range) {
+                folds = folds.concat(this.unfold(range));
+            }, this);
+            return folds;
+        } else {
             range = location;
+        }
         
         folds = this.getFoldsInRangeList(range);
+        var outermostFolds = folds;
+        // if range itself is in a fold, expand that fold instead of removing, 
+        // to not accidentally remove sibling folds
+        while (
+            folds.length == 1
+            && Range.comparePoints(folds[0].start, range.start) < 0 
+            && Range.comparePoints(folds[0].end, range.end) > 0
+        ) {
+            this.expandFolds(folds);
+            folds = this.getFoldsInRangeList(range);
+        }
+        
         if (expandInner != false) {
             this.removeFolds(folds);
         } else {
             this.expandFolds(folds);
         }
-        if (folds.length)
-            return folds;
+        if (outermostFolds.length)
+            return outermostFolds;
     };
 
     /*

--- a/lib/ace/edit_session_test.js
+++ b/lib/ace/edit_session_test.js
@@ -45,6 +45,8 @@ var Range = require("./range").Range;
 var assert = require("./test/assertions");
 var JavaScriptMode = require("./mode/javascript").Mode;
 
+require("./multi_select");
+
 function createFoldTestSession() {
     var lines = [
         "function foo(items) {",
@@ -525,6 +527,35 @@ module.exports = {
         assert.equal(session.$foldData[3].range.start.row, 12);
         editor.execCommand("unfoldall");
         assert.equal(session.$foldData.length, 0);
+    },
+
+    "test foldOther": function() {
+        var session = new EditSession("{\n\t1{\n\t\t\n\t\t1.1 {\n\t\t}\n\t}\n\t2 {\n\t\t2.1 {\n\t\t\t2.2 {\n\t\t\t}\n\t\t\t2.3 {\n\t\t\t}\n\t\t}\n\t}\n}\n\n{\n}");
+        var editor = new Editor(new MockRenderer(), session);
+        editor.setOption("mode", new JavaScriptMode());
+
+        editor.gotoLine(3, 2);
+        editor.execCommand("foldOther");
+        assert.equal(foldRows(), "3,6,16");
+
+        editor.find("2.2");
+        assert.equal(foldRows(), "3,8,10,16");
+
+        var removedFolds = session.unfold();
+        assert.equal(removedFolds.length, 4);
+        assert.equal(foldRows(), "");
+
+        editor.session.addFold("xxx", new Range(1, 0, 7, 0));
+        assert.equal(foldRows(), "1");
+        editor.session.foldAll();
+        assert.equal(foldRows(), "0,16");
+        removedFolds = editor.session.unfold(editor.selection.getAllRanges());
+        assert.equal(removedFolds.length, 1);
+        assert.equal(foldRows(), "1,8,10,16");
+
+        function foldRows() {
+            return session.$foldData.map(function(x) {return x.start.row;}).join(",");
+        }
     },
 
     "test fold getFoldDisplayLine": function() {


### PR DESCRIPTION
This fixes the bug when with the following code the foldOther command was not folding brackets after `2`
```js
{
    1{
         |<-cursor here
     }
     2{
     }
}
{
    3
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
