### PR TITLE
Add uint64_t, int64_t and size_t types to c_cpp highlight rules

### DIFF
--- a/lib/ace/mode/c_cpp_highlight_rules.js
+++ b/lib/ace/mode/c_cpp_highlight_rules.js
@@ -17,7 +17,7 @@ var c_cppHighlightRules = function() {
     
     var storageType = (
         "asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|" +
-        "_Imaginary|int|int8_t|int16_t|int32_t|int64_t|long|short|signed|struct|typedef|uint8_t|uint16_t|uint32_t|uint64_t|union|unsigned|void|" +
+        "_Imaginary|int|int8_t|int16_t|int32_t|int64_t|long|short|signed|size_t|struct|typedef|uint8_t|uint16_t|uint32_t|uint64_t|union|unsigned|void|" +
         "class|wchar_t|template|char16_t|char32_t"
     );
 

--- a/lib/ace/mode/c_cpp_highlight_rules.js
+++ b/lib/ace/mode/c_cpp_highlight_rules.js
@@ -17,7 +17,7 @@ var c_cppHighlightRules = function() {
     
     var storageType = (
         "asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|" +
-        "_Imaginary|int|int8_t|int16_t|int32_t|long|short|signed|struct|typedef|uint8_t|uint16_t|uint32_t|union|unsigned|void|" +
+        "_Imaginary|int|int8_t|int16_t|int32_t|int64_t|long|short|signed|struct|typedef|uint8_t|uint16_t|uint32_t|uint64_t|union|unsigned|void|" +
         "class|wchar_t|template|char16_t|char32_t"
     );
 


### PR DESCRIPTION
Add int64_t and uint64_t C stdint types to c_cpp highlight rules.
Add size_t to storage types in c_cpp highlight rules.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
