### PR TITLE
Change startLineNumber to firstLineNumber in static highlight demo

### DIFF
--- a/demo/static-highlighter.html
+++ b/demo/static-highlighter.html
@@ -69,7 +69,7 @@ require(["ace/ace", "ace/ext/static_highlight"], function(ace) {
         highlight(codeEl, {
             mode: codeEl.getAttribute("ace-mode"),
             theme: codeEl.getAttribute("ace-theme"),
-            startLineNumber: 1,
+            firstLineNumber: 1,
             showGutter: codeEl.getAttribute("ace-gutter"),
             trim: true
         }, function (highlighted) {


### PR DESCRIPTION
The static highlighter demo incorrectly used the option 'startLineNumber' instead of 'firstLineNumber' which is the name used in https://github.com/ajaxorg/ace/blob/563113e1900f691d0d669f64abe238d45796bcb0/lib/ace/ext/static_highlight.js#L124

Although this change has no affect on the behavior of the example, it does update it so that people looking at the example will see the correct option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
