### PR TITLE
Remove eval() from javascript_worker

### DIFF
--- a/lib/ace/mode/javascript_worker.js
+++ b/lib/ace/mode/javascript_worker.js
@@ -102,17 +102,6 @@ oop.inherits(JavaScriptWorker, Mirror);
         this.doc.getValue() && this.deferredUpdate.schedule(100);
     };
 
-    this.isValidJS = function(str) {
-        try {
-            // evaluated code can only create variables in this function
-            eval("throw 0;" + str);
-        } catch(e) {
-            if (e === 0)
-                return true;
-        }
-        return false;
-    };
-
     this.onUpdate = function() {
         var value = this.doc.getValue();
         value = value.replace(/^#!.*\n/, "\n");
@@ -120,9 +109,6 @@ oop.inherits(JavaScriptWorker, Mirror);
             return this.sender.emit("annotate", []);
 
         var errors = [];
-        // jshint reports many false errors
-        // report them as error only if code is actually invalid
-        var maxErrorLevel = this.isValidJS(value) ? "warning" : "error";
 
         // var start = new Date();
         lint(value, this.options, this.options.globals);
@@ -139,7 +125,7 @@ oop.inherits(JavaScriptWorker, Mirror);
             if (raw == "Missing semicolon.") {
                 var str = error.evidence.substr(error.character);
                 str = str.charAt(str.search(/\S/));
-                if (maxErrorLevel == "error" && str && /[\w\d{(['"]/.test(str)) {
+                if (str && /[\w\d{(['"]/.test(str)) {
                     error.reason = 'Missing ";" before statement';
                     type = "error";
                 } else {
@@ -154,7 +140,7 @@ oop.inherits(JavaScriptWorker, Mirror);
             }
             else if (errorsRe.test(raw)) {
                 errorAdded  = true;
-                type = maxErrorLevel;
+                type = "error";
             }
             else if (raw == "'{a}' is not defined.") {
                 type = "warning";


### PR DESCRIPTION
*Issue*
https://github.com/ajaxorg/ace/issues/4506

*Description of changes:*
eval() is forbidden in CSP compliant environments, where the "script-src: unsafe-eval" is not set.
It looks like `isValidJS` is no longer needed, as the newer versions of JSHint properly report errors and warnings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
