### PR TITLE
[WIP] replace importCssString with importCssStylesheet

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -376,6 +376,18 @@ function buildAce(options, callback) {
     var snippetFiles = jsFileList("lib/ace/snippets");
     var modeNames = modeList();
 
+    copy("lib/ace/", getTargetDir(options) + "/", {
+        exclude: function (name) {
+            // skip folders
+            if (/^[^.]*$/.test(name)) {
+                return false;
+            }
+
+            return /^(?!.*css$).*$/.test(name)
+        },
+        include: /\.css$/
+    });
+
     buildCore(options, {outputFile: "ace.js"}, addCb());
     // modes
     modeNames.forEach(function(name) {
@@ -435,11 +447,12 @@ function buildAce(options, callback) {
             order: -1000
         }]
     }, "worker-base", addCb());
-    // 
+
     function addCb() {
         addCb.count = (addCb.count || 0) + 1; 
         return done;
     }
+
     function done() {
         if (--addCb.count > 0)
             return;

--- a/lib/ace/lib/dom.js
+++ b/lib/ace/lib/dom.js
@@ -31,7 +31,7 @@
 define(function(require, exports, module) {
 "use strict";
 
-var useragent = require("./useragent"); 
+var useragent = require("./useragent");
 var XHTML_NS = "http://www.w3.org/1999/xhtml";
 
 exports.buildDom = function buildDom(arr, parent, refs) {
@@ -206,9 +206,17 @@ exports.importCssString = function importCssString(cssText, id, target) {
     container.insertBefore(style, container.firstChild);
 };
 
-exports.importCssStylsheet = function(uri, doc) {
-    exports.buildDom(["link", {rel: "stylesheet", href: uri}], exports.getDocumentHead(doc));
+exports.importCssStylesheet = function(uri, doc) {
+    var doc = exports.getDocumentHead(doc);
+
+     // If style is already imported return immediately.
+    if (uri && doc.querySelector("link[href='" + uri +"'")) {
+        return;
+    }
+
+    exports.buildDom(["link", {rel: "stylesheet", href: uri}], doc);
 };
+
 exports.scrollbarWidth = function(document) {
     var inner = exports.createElement("ace_inner");
     inner.style.width = "100%";

--- a/lib/ace/lib/url.js
+++ b/lib/ace/lib/url.js
@@ -27,16 +27,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * ***** END LICENSE BLOCK ***** */
-
+ 
 define(function(require, exports, module) {
-"use strict";
-var url = require("../lib/url");
+    "use strict";
 
-exports.isDark = false;
-exports.cssClass = "ace-tm";
-exports.cssUrl = "./theme/textmate.css";
-exports.$id = "ace/theme/textmate";
-
-var dom = require("../lib/dom");
-dom.importCssStylesheet(url.resolve(exports.cssUrl));
+    var config = require("../config");
+    
+    exports.resolve = function (url) {
+        var basePath = config.get("basePath");
+        return basePath ? basePath + "/" + url : "lib/ace/" + url;
+    };
 });

--- a/lib/ace/theme/ambiance.js
+++ b/lib/ace/theme/ambiance.js
@@ -22,12 +22,13 @@
  * ***** END LICENSE BLOCK ***** */
 
 define(function(require, exports, module) {
+"use strict";
+var url = require("../lib/url");
 
 exports.isDark = true;
 exports.cssClass = "ace-ambiance";
-exports.cssText = require("../requirejs/text!./ambiance.css");
+exports.cssUrl = "./theme/ambiance.css";
 
 var dom = require("../lib/dom");
-dom.importCssString(exports.cssText, exports.cssClass);
-
+dom.importCssStylesheet(url.resolve(exports.cssUrl));
 });

--- a/lib/ace/virtual_renderer.js
+++ b/lib/ace/virtual_renderer.js
@@ -43,12 +43,11 @@ var VScrollBar = require("./scrollbar").VScrollBar;
 var RenderLoop = require("./renderloop").RenderLoop;
 var FontMetrics = require("./layer/font_metrics").FontMetrics;
 var EventEmitter = require("./lib/event_emitter").EventEmitter;
-var editorCss = require("./requirejs/text!./css/editor.css");
-
 var useragent = require("./lib/useragent");
+var url = require("./lib/url");
 var HIDE_TEXTAREA = useragent.isIE;
 
-dom.importCssString(editorCss, "ace_editor.css");
+dom.importCssStylesheet(url.resolve("css/editor.css"));
 
 /**
  * The class that is responsible for drawing everything you see on the screen!
@@ -1647,11 +1646,7 @@ var VirtualRenderer = function(container, theme) {
                 throw new Error("couldn't load module " + theme + " or it didn't call define");
             if (module.$id)
                 _self.$themeId = module.$id;
-            dom.importCssString(
-                module.cssText,
-                module.cssClass,
-                _self.container
-            );
+            dom.importCssStylesheet(url.resolve(module.cssUrl));
 
             if (_self.theme)
                 dom.removeCssClass(_self.container, _self.theme.cssClass);
@@ -1722,7 +1717,7 @@ var VirtualRenderer = function(container, theme) {
     };
     
     this.attachToShadowRoot = function() {
-        dom.importCssString(editorCss, "ace_editor.css", this.container);
+        dom.importCssStylesheet(url.resolve("css/editor.css"), this.container);
     };
 
     /**


### PR DESCRIPTION
*Issue:* #3260

*Description of changes:*
Instead of creating `style` element and embedding it in the `head`, now CSS files are preserved during build and then are imported as external styles.

**Important**
Current change affects only themes **ambiance** and **textmate**. If the approach is approved, I can continue with the rest of the themes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
