### PR TITLE
Add all VHDL-2008 keywords (excluding PSL keywords)

### DIFF
--- a/lib/ace/mode/vhdl_highlight_rules.js
+++ b/lib/ace/mode/vhdl_highlight_rules.js
@@ -37,18 +37,21 @@ var VHDLHighlightRules = function() {
 
 
     
-    var keywords = "access|after|ailas|all|architecture|assert|attribute|"+
-                   "begin|block|buffer|bus|case|component|configuration|"+
-                   "disconnect|downto|else|elsif|end|entity|file|for|function|"+
-                   "generate|generic|guarded|if|impure|in|inertial|inout|is|"+
-                   "label|linkage|literal|loop|mapnew|next|of|on|open|others|"+
-                   "out|port|process|pure|range|record|reject|report|return|"+
-                   "select|severity|shared|signal|subtype|then|to|transport|"+
-                   "type|unaffected|united|until|wait|when|while|with";
+    var keywords = "access|after|alias|all|architecture|assert|attribute|"+
+                   "begin|block|body|buffer|bus|case|component|configuration|"+
+                   "context|disconnect|downto|else|elsif|end|entity|exit|"+
+                   "file|for|force|function|generate|generic|group|guarded|"+
+                   "if|impure|in|inertial|inout|is|label|library|linkage|"+
+                   "literal|loop|map|new|next|of|on|or|open|others|out|"+
+                   "package|parameter|port|postponed|procedure|process|"+
+                   "protected|pure|range|record|register|reject|release|"+
+                   "report|return|select|severity|shared|signal|subtype|then|"+
+                   "to|transport|type|unaffected|units|until|use|variable|"+
+                   "wait|when|while|with";
     
     var storageType = "bit|bit_vector|boolean|character|integer|line|natural|"+
                       "positive|real|register|signed|std_logic|"+
-                      "std_logic_vector|string||text|time|unsigned|variable";
+                      "std_logic_vector|string||text|time|unsigned";
     
     var storageModifiers = "array|constant";
     


### PR DESCRIPTION
I've updated the list of VHDL keywords to include all reserved words defined in the VHDL-2008 spec, with the exception of a handful of PSL keywords (which aren't part of VHDL, just reserved for when PSL is combined with VHDL).

I also changed `variable` to a keyword (like `signal`) rather than a type (`std_logic` and friends).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
