### PR TITLE
Make sure completions aren't null or undefined

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -179,6 +179,8 @@ var Autocomplete = function() {
             data.completer.insertMatch(this.editor, data);
         } else {
             // TODO add support for options.deleteSuffix
+            if (!completions)
+                return false;
             if (completions.filterText) {
                 var ranges = this.editor.selection.getAllRanges();
                 for (var i = 0, range; range = ranges[i]; i++) {


### PR DESCRIPTION
I was experiencing some undefined errors with completions while adding an onScroll listener to hide the autocomplete window when the user was scrolling.

While the error is most likely due to my horrible code in this situation (there is no other easy way to do it), I still suggest adding this check to avoid such errors in the future.

I manually patched this file in node modules, and it helped fix the error.