### PR TITLE
Was failing with toLowerCase() unknown function when called with a do…

### DIFF
--- a/demo/kitchen-sink/doclist.js
+++ b/demo/kitchen-sink/doclist.js
@@ -170,7 +170,10 @@ function loadDoc(name, callback) {
 }
 
 function saveDoc(name, callback) {
-    var doc = fileCache[name.toLowerCase()] || name;
+    var doc = name;
+    if (typeof(name) === 'string') {
+        doc = fileCache[name.toLowerCase()];
+    }
     if (!doc || !doc.session)
         return callback("Unknown document: " + name);
 


### PR DESCRIPTION
… object.  If saveDoc is called with a string in the name parameter, look it up in the fileCache.  Otherwise, use what was passed as a doc object.

*Issue #, if available:*

*Description of changes:*

When editing a mode with:
http://192.168.1.163:8888/tool/mode_creator.html
the Save function was failing with toLowerCase() unknown function.  Changed to check if the name parameter is a string, if so use it as a filename and look up in fileCache.  Otherwise use it as a doc object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
