### PR TITLE
replace escaped newline with actual newline when in regex mode

### DIFF
--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -250,7 +250,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
         }
     };
 
-    this.getInput = function getInput(el) {
+    this.getInputValue = function getInputValue(el) {
         if (this.$search.$options.re) {
             return el.value.replace('\\n', '\n');
         }
@@ -276,7 +276,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
         this.editor.renderer.updateBackMarkers();
     };
     this.find = function(skipCurrent, backwards, preventScroll) {
-        var range = this.editor.find(this.getInput(this.searchInput), {
+        var range = this.editor.find(this.getInputValue(this.searchInput), {
             skipCurrent: skipCurrent,
             backwards: backwards,
             wrap: true,
@@ -331,7 +331,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
         this.find(true, true);
     };
     this.findAll = function(){
-        var range = this.editor.findAll(this.getInput(this.searchInput), {            
+        var range = this.editor.findAll(this.getInputValue(this.searchInput), {            
             regExp: this.regExpOption.checked,
             caseSensitive: this.caseSensitiveOption.checked,
             wholeWord: this.wholeWordOption.checked
@@ -344,17 +344,17 @@ var SearchBox = function(editor, range, showReplaceForm) {
     };
     this.replace = function() {
         if (!this.editor.getReadOnly())
-            this.editor.replace(this.getInput(this.replaceInput));
+            this.editor.replace(this.getInputValue(this.replaceInput));
     };    
     this.replaceAndFindNext = function() {
         if (!this.editor.getReadOnly()) {
-            this.editor.replace(this.getInput(this.replaceInput));
+            this.editor.replace(this.getInputValue(this.replaceInput));
             this.findNext();
         }
     };
     this.replaceAll = function() {
         if (!this.editor.getReadOnly())
-            this.editor.replaceAll(this.getInput(this.replaceInput));
+            this.editor.replaceAll(this.getInputValue(this.replaceInput));
     };
 
     this.hide = function() {

--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -251,7 +251,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
     };
 
     this.getInputValue = function getInputValue(el) {
-        if (this.$search.$options.re) {
+        if (this.$search && this.$search.$options && this.$search.$options.re) {
             return el.value.replace('\\n', '\n');
         }
         

--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -250,6 +250,14 @@ var SearchBox = function(editor, range, showReplaceForm) {
         }
     };
 
+    this.getInput = function getInput(el) {
+        if (this.$search.$options.re) {
+            return el.value.replace('\\n', '\n');
+        }
+        
+        return el.value;
+    };
+
     this.$syncOptions = function(preventScroll) {
         dom.setCssClass(this.replaceOption, "checked", this.searchRange);
         dom.setCssClass(this.searchOption, "checked", this.searchOption.checked);
@@ -268,7 +276,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
         this.editor.renderer.updateBackMarkers();
     };
     this.find = function(skipCurrent, backwards, preventScroll) {
-        var range = this.editor.find(this.searchInput.value, {
+        var range = this.editor.find(this.getInput(this.searchInput), {
             skipCurrent: skipCurrent,
             backwards: backwards,
             wrap: true,
@@ -323,7 +331,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
         this.find(true, true);
     };
     this.findAll = function(){
-        var range = this.editor.findAll(this.searchInput.value, {            
+        var range = this.editor.findAll(this.getInput(this.searchInput), {            
             regExp: this.regExpOption.checked,
             caseSensitive: this.caseSensitiveOption.checked,
             wholeWord: this.wholeWordOption.checked
@@ -336,17 +344,17 @@ var SearchBox = function(editor, range, showReplaceForm) {
     };
     this.replace = function() {
         if (!this.editor.getReadOnly())
-            this.editor.replace(this.replaceInput.value);
+            this.editor.replace(this.getInput(this.replaceInput));
     };    
     this.replaceAndFindNext = function() {
         if (!this.editor.getReadOnly()) {
-            this.editor.replace(this.replaceInput.value);
+            this.editor.replace(this.getInput(this.replaceInput));
             this.findNext();
         }
     };
     this.replaceAll = function() {
         if (!this.editor.getReadOnly())
-            this.editor.replaceAll(this.replaceInput.value);
+            this.editor.replaceAll(this.getInput(this.replaceInput));
     };
 
     this.hide = function() {

--- a/lib/ace/search.js
+++ b/lib/ace/search.js
@@ -239,6 +239,10 @@ var Search = function() {
     };
 
     this.$assembleRegExp = function(options, $disableFakeMultiline) {
+        if (options.regExp && typeof options.needle === 'string') {
+            options.needle = options.needle.replace('\\n', '\n');
+        }
+
         if (options.needle instanceof RegExp)
             return options.re = options.needle;
 

--- a/lib/ace/search.js
+++ b/lib/ace/search.js
@@ -239,10 +239,6 @@ var Search = function() {
     };
 
     this.$assembleRegExp = function(options, $disableFakeMultiline) {
-        if (options.regExp && typeof options.needle === 'string') {
-            options.needle = options.needle.replace('\\n', '\n');
-        }
-
         if (options.needle instanceof RegExp)
             return options.re = options.needle;
 


### PR DESCRIPTION
*Issue #, if available:* #2869

*Description of changes:* Right now, replacing a newline doesn't work in the ace editor. This allows replacing newlines when in regex replace mode.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
