### PR TITLE
Replace trimLine regex with String.trimEnd

### DIFF
--- a/lib/ace/ext/beautify.js
+++ b/lib/ace/ext/beautify.js
@@ -84,7 +84,7 @@ exports.beautify = function(session) {
     };
     
     var trimLine = function() {
-        code = code.replace(/ +$/, "");
+        code = code.trimEnd();
     };
 
     var trimCode = function() {


### PR DESCRIPTION
The builtin `String.prototype.trimEnd` is more performant than a regex. Note that this code already uses `String.prototype.trimRight` which is just an alias to `trimEnd`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
