### PR TITLE
Replace regex with trimRight()

### DIFF
--- a/lib/ace/ext/beautify.js
+++ b/lib/ace/ext/beautify.js
@@ -84,7 +84,7 @@ exports.beautify = function(session) {
     };
     
     var trimLine = function() {
-        code = code.replace(/ +$/, "");
+        code = code.trimRight();
     };
 
     var trimCode = function() {


### PR DESCRIPTION
*Description of changes:*

The builtin `String.prototype.trimRight()` is more performant than the regex.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
