### PR TITLE
add highlighting support for Single-Assignment C

### DIFF
--- a/demo/kitchen-sink/docs/sac.sac
+++ b/demo/kitchen-sink/docs/sac.sac
@@ -1,0 +1,75 @@
+/*****************************************************************************
+ *
+ *   SAC demo program
+ *
+ *   This SAC demo program implements 2-dimensional relaxation on double
+ *   precision floating point numbers applying a 4-point stencil and fixed
+ *   boundary conditions.
+ *
+ *   The vertical (SIZE1) and the horizontal (SIZE2) array size as well as
+ *   the number of iterations to be performed (LOOP) may be set at compile
+ *   time.
+ *
+ *****************************************************************************/
+
+#ifndef LOOP
+#define LOOP 100
+#endif
+
+#ifndef SIZE1
+#define SIZE1 1000
+#endif
+
+#ifndef SIZE2
+#define SIZE2 1000
+#endif
+
+use Array: all;
+use StdIO: all;
+
+inline
+double[+] onestep(double[+] B)
+{
+  A = with {
+        ( . < x < . ) : 0.25*(B[x+[1,0]]
+                              + B[x-[1,0]]
+                              + B[x+[0,1]]
+                              + B[x-[0,1]]);
+      } : modarray( B );
+
+  return(A);
+}
+
+inline
+double[+] relax(double[+] A, int steps)
+{
+  for (k=0; k<steps; k++) {
+    A = onestep(A);
+  }
+
+  return(A);
+}
+
+int main ()
+{
+  A = with {
+        ( . <= x <= . ) : 0.0d;
+      } : genarray( [SIZE1,SIZE2] );
+
+  A = modarray(A, [0,1], 500.0d);
+  A = relax( A, LOOP);
+
+  z = with {
+        ( 0*shape(A) <= x < shape(A) ) : A[x];
+      } : fold( +, 0d );
+
+#if 0
+  printf("%.10g\n", z);
+  return(0);
+#else
+  print( z);
+  return( 0);
+#endif
+}
+
+

--- a/lib/ace/ext/modelist.js
+++ b/lib/ace/ext/modelist.js
@@ -171,6 +171,7 @@ var supportedModes = {
     RST:         ["rst"],
     Ruby:        ["rb|ru|gemspec|rake|^Guardfile|^Rakefile|^Gemfile"],
     Rust:        ["rs"],
+    SaC:         ["sac"],
     SASS:        ["sass"],
     SCAD:        ["scad"],
     Scala:       ["scala|sbt"],

--- a/lib/ace/mode/sac.js
+++ b/lib/ace/mode/sac.js
@@ -1,0 +1,23 @@
+define(function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var SaCHighlightRules = require("./sac_highlight_rules").sacHighlightRules;
+var FoldMode = require("./folding/cstyle").FoldMode;
+
+var Mode = function() {
+  this.HighlightRules = SaCHighlightRules;
+  this.foldingRules = new FoldMode();
+  this.$behaviour = this.$defaultBehaviour;
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+  this.lineCommentStart = "//";
+  this.blockComment = {start: "/*", end: "*/"};
+  this.$id = "ace/mode/sac";
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+});

--- a/lib/ace/mode/sac_highlight_rules.js
+++ b/lib/ace/mode/sac_highlight_rules.js
@@ -1,0 +1,193 @@
+define(function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var DocCommentHighlightRules = require("./doc_comment_highlight_rules").DocCommentHighlightRules;
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var sacHighlightRules = function() {
+
+    var keywordControls = (
+        "break|continue|do|else|for|if|" +
+        "return|with|while|use|class|all|void"
+    );
+
+    var storageType = (
+        "bool|char|complex|double|float|" +
+        "byte|int|short|long|longlong|" +
+        "ubyte|uint|ushort|ulong|ulonglong|" +
+        "struct|typedef"
+    );
+
+    var storageModifiers = (
+        "inline|external|specialize"
+    );
+
+    var keywordOperators = (
+        "step|width"
+    );
+
+    var builtinConstants = (
+        "true|false"
+    );
+
+    var keywordMapper = this.$keywords = this.createKeywordMapper({
+        "keyword.control" : keywordControls,
+        "storage.type" : storageType,
+        "storage.modifier" : storageModifiers,
+        "keyword.operator" : keywordOperators,
+        "constant.language": builtinConstants
+    }, "identifier");
+
+    var identifierRe = "[a-zA-Z\\$_\u00a1-\uffff][a-zA-Z\\d\\$_\u00a1-\uffff]*\\b";
+    var escapeRe = /\\(?:['"?\\abfnrtv]|[0-7]{1,3}|x[a-fA-F\d]{2}|u[a-fA-F\d]{4}U[a-fA-F\d]{8}|.)/.source;
+    var formatRe = "%"
+          + /(\d+\$)?/.source // field (argument #)
+          + /[#0\- +']*/.source // flags
+          + /[,;:_]?/.source // separator character (AltiVec)
+          + /((-?\d+)|\*(-?\d+\$)?)?/.source // minimum field width
+          + /(\.((-?\d+)|\*(-?\d+\$)?)?)?/.source // precision
+          + /(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)?/.source // length modifier
+          + /(\[[^"\]]+\]|[diouxXDOUeEfFgGaACcSspn%])/.source; // conversion type
+
+    // regexp must not have capturing parentheses. Use (?:) instead.
+    // regexps are ordered -> the first match is used
+
+    this.$rules = {
+        "start" : [
+            {
+                token : "comment",
+                regex : "//$",
+                next : "start"
+            }, {
+                token : "comment",
+                regex : "//",
+                next : "singleLineComment"
+            },
+            DocCommentHighlightRules.getStartRule("doc-start"),
+            {
+                token : "comment", // multi line comment
+                regex : "\\/\\*",
+                next : "comment"
+            }, {
+                token : "string", // character
+                regex : "'(?:" + escapeRe + "|.)?'"
+            }, {
+                token : "string.start",
+                regex : '"',
+                stateName: "qqstring",
+                next: [
+                    { token: "string", regex: /\\\s*$/, next: "qqstring" },
+                    { token: "constant.language.escape", regex: escapeRe },
+                    { token: "constant.language.escape", regex: formatRe },
+                    { token: "string.end", regex: '"|$', next: "start" },
+                    { defaultToken: "string"}
+                ]
+            }, {
+                token : "string.start",
+                regex : 'R"\\(',
+                stateName: "rawString",
+                next: [
+                    { token: "string.end", regex: '\\)"', next: "start" },
+                    { defaultToken: "string"}
+                ]
+            }, {
+                token : "constant.numeric", // hex
+                regex : "0[xX][0-9a-fA-F]+(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
+            }, {
+                token : "constant.numeric", // float
+                regex : "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
+            }, {
+                token : "keyword", // pre-compiler directives
+                regex : "#\\s*(?:include|import|pragma|line|define|undef)\\b",
+                next  : "directive"
+            }, {
+                token : "keyword", // special case pre-compiler directive
+                regex : "#\\s*(?:endif|if|ifdef|else|elif|ifndef)\\b"
+            }, {
+                token : "support.function",
+                regex : "fold|foldfix|genarray|modarray|propagate"
+            }, {
+                token : keywordMapper,
+                regex : "[a-zA-Z_$][a-zA-Z0-9_$]*"
+            }, {
+                token : "keyword.operator",
+                regex : /--|\+\+|<<=|>>=|>>>=|<>|&&|\|\||\?:|[*%\/+\-&\^|~!<>=]=?/
+            }, {
+              token : "punctuation.operator",
+              regex : "\\?|\\:|\\,|\\;|\\."
+            }, {
+                token : "paren.lparen",
+                regex : "[[({]"
+            }, {
+                token : "paren.rparen",
+                regex : "[\\])}]"
+            }, {
+                token : "text",
+                regex : "\\s+"
+            }
+        ],
+        "comment" : [
+            {
+                token : "comment", // closing comment
+                regex : "\\*\\/",
+                next : "start"
+            }, {
+                defaultToken : "comment"
+            }
+        ],
+        "singleLineComment" : [
+            {
+                token : "comment",
+                regex : /\\$/,
+                next : "singleLineComment"
+            }, {
+                token : "comment",
+                regex : /$/,
+                next : "start"
+            }, {
+                defaultToken: "comment"
+            }
+        ],
+        "directive" : [
+            {
+                token : "constant.other.multiline",
+                regex : /\\/
+            },
+            {
+                token : "constant.other.multiline",
+                regex : /.*\\/
+            },
+            {
+                token : "constant.other",
+                regex : "\\s*<.+?>",
+                next : "start"
+            },
+            {
+                token : "constant.other", // single line
+                regex : '\\s*["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]',
+                next : "start"
+            },
+            {
+                token : "constant.other", // single line
+                regex : "\\s*['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']",
+                next : "start"
+            },
+            // "\" implies multiline, while "/" implies comment
+            {
+                token : "constant.other",
+                regex : /[^\\\/]+/,
+                next : "start"
+            }
+        ]
+    };
+
+    this.embedRules(DocCommentHighlightRules, "doc-",
+        [ DocCommentHighlightRules.getEndRule("start") ]);
+    this.normalizeRules();
+};
+
+oop.inherits(sacHighlightRules, TextHighlightRules);
+
+exports.sacHighlightRules = sacHighlightRules;
+});


### PR DESCRIPTION
*Description of changes:*

With this PR I'd like to include support to syntax highlight Single-Assignment C code, which is a functional array programming language (see https://sac-home.org for more info) with a very similar syntax to C/C++.

The mode rules are based off of the ace C/C++ mode file, but SaC is a subset of C so I've omitted a lot from it (it didn't make sense to extend it).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
