### PR TITLE
Update setFontSize typing to accept number

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -756,7 +756,7 @@ export namespace Ace {
     setStyle(style: string): void;
     unsetStyle(style: string): void;
     getFontSize(): string;
-    setFontSize(size: string): void;
+    setFontSize(size: number): void;
     focus(): void;
     isFocused(): boolean;
     blur(): void;


### PR DESCRIPTION
*Description of changes:*

Per the [API Docs](https://ace.c9.io/#nav=api&api=editor), the parameter `setFontSize` should be typed as a `number` instead of as a `string`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
