### PR TITLE
Indentation bug after closing html tag

### DIFF
--- a/lib/ace/ext/beautify.js
+++ b/lib/ace/ext/beautify.js
@@ -391,16 +391,18 @@ exports.beautify = function(session) {
                 }
 
                 // html indentation
-                if (is(token, "tag-open") && value === "</") {
-                    depth--;
-                // indent after opening tag
-                } else if (is(token, "tag-open") && value === "<" && singletonTags.indexOf(nextToken.value) === -1) {
-                    depth++;
-                // remove indent if unknown singleton
-                } else if (is(token, "tag-name")) {
+                if (nextToken && singletonTags.indexOf(nextToken.value) === -1) {
+                    if (is(token, "tag-open") && value === "</") {
+                        depth--;
+                    } else if (is(token, "tag-open") && value === "<") {
+                        depth++;
+                    } else if (is(token, "tag-close") && value === "/>"){
+                        depth--;
+                    }
+                }
+                
+                if (is(token, "tag-name")) {
                     tagName = value;
-                } else if (is(token, "tag-close") && value === "/>" && singletonTags.indexOf(tagName) === -1){
-                    depth--;
                 }
 
                 row = curRow;


### PR DESCRIPTION
This patch fixes a bug where indentation is broken after a closing html tag. e.g. in a PHP file.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
