### PR TITLE
Add support for min(), max() and var() to css linter

### DIFF
--- a/lib/ace/mode/css/csslint.js
+++ b/lib/ace/mode/css/csslint.js
@@ -5914,7 +5914,7 @@ var Validation = module.exports = {
 
             // All properties accept some CSS-wide values.
             // https://drafts.csswg.org/css-values-3/#common-keywords
-            if (ValidationTypes.isAny(expression, "inherit | initial | unset")) {
+            if (ValidationTypes.isAny(expression, "inherit | initial | unset | var()")) {
                 if (expression.hasNext()) {
                     part = expression.next();
                     throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);

--- a/lib/ace/mode/css/csslint.js
+++ b/lib/ace/mode/css/csslint.js
@@ -6238,7 +6238,7 @@ copy(ValidationTypes, {
         },
 
         "<length>": function(part) {
-            if (part.type === "function" && /^(?:-(?:ms|moz|o|webkit)-)?calc/i.test(part)) {
+            if (part.type === "function" && /^(?:-(?:ms|moz|o|webkit)-)?(calc|min|max)\(/i.test(part)) {
                 return true;
             } else {
                 return part.type === "length" || part.type === "number" || part.type === "integer" || String(part) === "0";

--- a/lib/ace/mode/css/csslint.js
+++ b/lib/ace/mode/css/csslint.js
@@ -5914,7 +5914,7 @@ var Validation = module.exports = {
 
             // All properties accept some CSS-wide values.
             // https://drafts.csswg.org/css-values-3/#common-keywords
-            if (ValidationTypes.isAny(expression, "inherit | initial | unset | var()")) {
+            if (ValidationTypes.isAny(expression, "inherit | initial | unset")) {
                 if (expression.hasNext()) {
                     part = expression.next();
                     throw new ValidationError("Expected end of value but found '" + part + "'.", part.line, part.col);
@@ -5936,6 +5936,12 @@ var Validation = module.exports = {
             part;
 
         result = Matcher.parse(types).match(expression);
+
+        //HACK: This will just stop validating the property once a variable is found in a property
+        if (expression.hasNext() && ValidationTypes.isAny(expression, "var()"))
+        {
+            return;
+        }
 
         if (!result) {
             if (expression.hasNext() && !expression.isFirst()) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This makes 2 small changes to the css linter, which help it support two commonly used modern css constructs:

1. add support for min()/max() for css properties accepting a length. while I was modifying/testing the code I also noticed that currently it accepted stuff like "calcasdhkjas()" as valid because it starts with "calc", which is accepted, so I fixed that as well.
2.  allow var() as a value anywhere, to fully support css custom properties. definition of them was already supported, but using them still gave errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
