### PR TITLE
allow tokenizer rules to opt-in to using unicode regexes

### DIFF
--- a/lib/ace/tokenizer.js
+++ b/lib/ace/tokenizer.js
@@ -62,8 +62,10 @@ var Tokenizer = function(rules) {
             var rule = state[i];
             if (rule.defaultToken)
                 mapping.defaultToken = rule.defaultToken;
-            if (rule.caseInsensitive)
-                flag = "gi";
+            if (rule.caseInsensitive && flag.indexOf("i") === -1)
+                flag += "i";
+            if (rule.unicode && flag.indexOf("u") === -1)
+                flag += "u";
             if (rule.regex == null)
                 continue;
 


### PR DESCRIPTION
*Issue #, if available:* #4653

*Description of changes:*

Adds support for unicode regular expressions to the tokenizer. In particular, rules can now opt-in to using unicode regular expressions by setting `unicode: true` in their pattern definition.

With this change, users can make rules like:

```
{
    regex: "\p{L}*"
    unicode: true
}
```

which would match any number of unicode "letters", as described in https://unicode.org/reports/tr18/#General_Category_Property.

This could be useful for languages which seek to support unicode identifiers, as an example. (In that case, they might want to use the patterns / classes described in https://unicode.org/reports/tr31/, for ID_Start and ID_Continue)