### PR TITLE
fix cotextmenu cropped

### DIFF
--- a/lib/ace/css/editor.css
+++ b/lib/ace/css/editor.css
@@ -564,6 +564,7 @@ styles.join("\n")
     padding: 2px;
     cursor: pointer;
     overflow: hidden;
+    display: block;
 }
 .ace_mobile-button:hover {
     background-color: #eee;

--- a/lib/ace/mouse/touch_handler.js
+++ b/lib/ace/mouse/touch_handler.js
@@ -69,6 +69,17 @@ exports.addTouchListeners = function(el, editor) {
                 ] : ["span"]),
                 contextMenu.firstChild
             );
+            if(isOpen){
+                var rect = editor.container.getBoundingClientRect();
+                if(contextMenu.offsetTop + contextMenu.offsetHeight > rect.bottom) {
+                    contextMenu.style.top = contextMenu.offsetTop - (contextMenu.offsetHeight - contextMenu.lastChild?.offsetHeight || 0) + "px";
+                }
+            }else{
+                var cursor = editor.selection.cursor;
+                var pagePos = editor.renderer.textToScreenCoordinates(cursor.row, cursor.column);
+                var rect = editor.container.getBoundingClientRect();
+                contextMenu.style.top = pagePos.pageY - rect.top - 3 + "px";
+            }
         };
         var handleClick = function(e) {
             var action = e.target.getAttribute("action");


### PR DESCRIPTION
*Issue #4681, if available:*

*Description of changes:*
Problem to solve: ContextMenu gets cropped on small mobile screen sizes or with larger the font size. In addition, buttons needs more distance to distinguish separate ones. In the screenshot, it is hard to tell that "Select All" is one button and "Paste" is the next button. Screenshot can be reproduced on [demo page ](https://ace.c9.io/build/kitchen-sink.html) with font size 24.
<img width="363" alt="Screenshot 2022-04-27 at 15 19 35" src="https://user-images.githubusercontent.com/98534165/165548286-c4fbcdaf-575e-4a7e-9736-2bc51dde7755.png">



Solution: Buttons display block. 
Check if menu gets cropped at bottom. If so opens the menu up(by moving the menu up). When close menu by clicking the "more" button, move menu icon back to the cursor position. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
