### PR TITLE
chore: Added workflows for closing stale issues and issue reprioritization

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,49 @@
+name: "Close Stale Issues"
+
+# Controls when the action will run.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */4 * * *"
+
+jobs:
+  cleanup:
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+      - uses: aws-actions/stale-issue-cleanup@v5
+        with:
+          issue-types: issues
+          # Setting messages to an empty string will cause the automation to skip
+          # that category
+          ancient-issue-message: This issue has not received any attention in 1 year. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+          stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+
+          # These labels are required
+          stale-issue-label: closing-soon
+          exempt-issue-label: no-autoclose
+          response-requested-label: response-requested
+
+          # Don't set closed-for-staleness label to skip closing very old issues
+          # regardless of label
+          closed-for-staleness-label: closed-for-staleness
+
+          # Issue timing
+          days-before-stale: 7
+          days-before-close: 7
+          days-before-ancient: 365
+
+          # If you don't want to mark a issue as being ancient based on a
+          # threshold of "upvotes", you can set this here. An "upvote" is
+          # the total number of +1, heart, hooray, and rocket reactions
+          # on an issue.
+          minimum-upvotes-to-exempt: 5
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          loglevel: DEBUG
+          # Set dry-run to true to not perform label or close actions.
+          dry-run: false

--- a/.github/workflows/issue-reprioritization.yml
+++ b/.github/workflows/issue-reprioritization.yml
@@ -1,0 +1,22 @@
+name: issue-reprioritization
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  issue-reprioritization:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kaizencc/issue-reprioritization-manager@main
+        id: reprioritization-manager
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          original-label: p2
+          new-label: p1
+          reprioritization-threshold: 5
+      - uses: kaizencc/pr-triage-manager@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          on-pulls: ${{ steps.reprioritization-manager.outputs.linked-pulls }}


### PR DESCRIPTION
*Description of changes:*

Added workflows for closing stale issues and issue reprioritization

Adds a Github Action that warns and then auto closes stale issues.
- Automatically adds a `closing-soon` label on issues that have had a `response-requested` label for 7 days and still have no response.
- Automatically adds a `closing-soon` label on issues that haven't had any attention in 1 year.  
- Automatically closes issues that have had a `closing-soon` label for 7 days.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
