### PR TITLE
chore: fixed a typo in exempt label for autoclose workflow

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -25,7 +25,7 @@ jobs:
 
           # These labels are required
           stale-issue-label: closing-soon
-          exempt-issue-label: no-autoclose
+          exempt-issue-labels: no-autoclose
           response-requested-label: response-requested
 
           # Don't set closed-for-staleness label to skip closing very old issues


### PR DESCRIPTION
*Description of changes:*
Fixed a typo in exempt label for autoclose workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
