### PR TITLE
feat: Added ability to configure certain format options for beautify extension

### DIFF
--- a/lib/ace/ext/beautify.js
+++ b/lib/ace/ext/beautify.js
@@ -44,12 +44,17 @@ exports.singletonTags = ["area", "base", "br", "col", "command", "embed", "hr", 
 // insert a line break after block level tags
 exports.blockTags = ["article", "aside", "blockquote", "body", "div", "dl", "fieldset", "footer", "form", "head", "header", "html", "nav", "ol", "p", "script", "section", "style", "table", "tbody", "tfoot", "thead", "ul"];
 
+exports.formatOptions = {
+    lineBreaksAfterCommasInCurlyBlock: true
+};
+
 exports.beautify = function(session) {
     var iterator = new TokenIterator(session, 0, 0);
     var token = iterator.getCurrentToken();
     var tabString = session.getTabString();
     var singletonTags = exports.singletonTags;
     var blockTags = exports.blockTags;
+    var formatOptions = exports.formatOptions || {};
     var nextToken;
     var breakBefore = false;
     var spaceBefore = false;
@@ -269,7 +274,7 @@ exports.beautify = function(session) {
                     trimNext();
 
                     // line break after commas in curly block
-                    if (value.match(/^(,)$/) && curlyDepth>0 && roundDepth===0) {
+                    if (value.match(/^(,)$/) && curlyDepth>0 && roundDepth===0 && formatOptions.lineBreaksAfterCommasInCurlyBlock) {
                         rowsToAdd++;
                     } else {
                         spaceAfter = true;

--- a/lib/ace/ext/beautify_test.js
+++ b/lib/ace/ext/beautify_test.js
@@ -383,6 +383,40 @@ module.exports = {
             + "\t\t\"b\": \"2\"\n"
             + "\t}\n"
             + "</script>");
+    },
+
+    "test beautify php default behaviour with line breaks after comma": function() {
+        var s = new EditSession([
+            "<?php\n",
+            "class Test {",
+            "public int $id, $num;",
+            "}"
+        ], new PHPMode());
+        s.setUseSoftTabs(false);
+
+        beautify.beautify(s);
+        assert.equal(s.getValue(), "<?php\n"
+            + "class Test {\n"
+            + "\tpublic int $id,\n" 
+            + "\t$num;\n"
+            + "}");
+    },
+
+    "test beautify php with no line breaks after comma": function() {
+        var s = new EditSession([
+            "<?php\n",
+            "class Test {",
+            "public int $id, $num;",
+            "}"
+        ], new PHPMode());
+        s.setUseSoftTabs(false);
+
+        beautify.formatOptions.lineBreaksAfterCommasInCurlyBlock = false;
+        beautify.beautify(s);
+        assert.equal(s.getValue(), "<?php\n"
+            + "class Test {\n"
+            + "\tpublic int $id, $num;\n"
+            + "}");
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/ajaxorg/ace/issues/4670

*Description of changes:*

Added `formatOptions` exported by `beautify` extension which allows to configure certain formatting options. 
Right now only 1 option is available:
- `lineBreaksAfterCommasInCurlyBlock` - defines if new line break should be inserted after commas within curly block. default: `true` 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
