### PR TITLE
allow commands to be executed while searchbox is in focus

### DIFF
--- a/lib/ace/ext/searchbox.js
+++ b/lib/ace/ext/searchbox.js
@@ -126,9 +126,24 @@ var SearchBox = function(editor, range, showReplaceForm) {
         event.addCommandKeyListener(sb, function(e, hashId, keyCode) {
             var keyString = keyUtil.keyCodeToString(keyCode);
             var command = _this.$searchBarKb.findKeyCommand(hashId, keyString);
+            var toExecute = _this.editor.getKeyboardHandler().handleKeyboard(
+                _this.editor, hashId, keyString, keyCode, e
+                );
+            var success = false;
             if (command && command.exec) {
                 command.exec(_this);
                 event.stopEvent(e);
+            }else if (toExecute && toExecute.command) {
+                if (toExecute.command == "null") {
+                    success = true;
+                } else {
+                    success = _this.editor.commands.exec(toExecute.command, _this.editor, toExecute.args, e);
+                }
+                if (success && e && hashId != -1 &&
+                    toExecute.passEvent != true && toExecute.command.passEvent != true
+                ) {
+                    event.stopEvent(e);
+                }
             }
         });
 


### PR DESCRIPTION

*Issue #, if available:*
https://github.com/eXist-db/eXide/issues/113
*Description of changes:*
Allow keyboard commands to be executed even whilst the searchBox is in focus.
This can speed up the workflow a bit by avoiding the need for hitting `esc` then running the command,
the searchBox commands are the ones in priority and if the command doesn't belong to the searchBox it will fall to the editor handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This open source contribution to the [ace](https://github.com/ajaxorg/ace) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.
