### PR TITLE
fix: Correctly tokenize YAML meta tags with non alphabetical characters after multiline string

### DIFF
--- a/lib/ace/mode/_test/text_yaml.txt
+++ b/lib/ace/mode/_test/text_yaml.txt
@@ -23,6 +23,7 @@ bill-to:  &id001
     street: |
             123 Tornado Alley
             Suite 16
+    ref-id: id123  
     city:   East Centerville
     state:  KS
 

--- a/lib/ace/mode/_test/tokens_yaml.json
+++ b/lib/ace/mode/_test/tokens_yaml.json
@@ -122,7 +122,12 @@
 ],[
    "start",
   ["indent","    "],
-  ["meta.tag","city"],
+  ["meta.tag","ref-id"],
+  ["keyword",":"],
+  ["text","   id123"]
+],[
+   "start",
+  ["meta.tag","    city"],
   ["keyword",":"],
   ["text","   East Centerville"]
 ],[

--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -57,10 +57,10 @@ var YamlHighlightRules = function() {
                 regex: "[&\\*][a-zA-Z0-9-_]+"
             }, {
                 token: ["meta.tag", "keyword"],
-                regex: /^(\s*\w.*?)(:(?=\s|$))/
+                regex: /^(\s*\w[^\s:]*?)(:(?=\s|$))/
             },{
                 token: ["meta.tag", "keyword"],
-                regex: /(\w.*?)(\s*:(?=\s|$))/
+                regex: /(\w[^\s:]*?)(\s*:(?=\s|$))/
             }, {
                 token : "keyword.operator",
                 regex : "<<\\w*:\\w*"

--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -60,7 +60,7 @@ var YamlHighlightRules = function() {
                 regex: /^(\s*\w.*?)(:(?=\s|$))/
             },{
                 token: ["meta.tag", "keyword"],
-                regex: /(\w+?)(\s*:(?=\s|$))/
+                regex: /(\w.*?)(\s*:(?=\s|$))/
             }, {
                 token : "keyword.operator",
                 regex : "<<\\w*:\\w*"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/ajaxorg/ace/issues/4694

*Description of changes:*
Correctly tokenize YAML meta tags with non alphabetical characters after multiline string

Previously match regex did not include non alphabetical characters in such meta tag keywords. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
