### PR TITLE
fix: Dracula theme constants should be pink, not purple

### DIFF
--- a/lib/ace/theme/dracula.css
+++ b/lib/ace/theme/dracula.css
@@ -68,7 +68,7 @@
 }
 
 .ace-dracula .ace_constant.ace_language {
-  color: #bd93f9
+  color: #ff79c6
 }
 
 .ace-dracula .ace_constant.ace_numeric {


### PR DESCRIPTION
In dracula theme, constants should be pink, not purple. See one example in IDLE :

![image](https://user-images.githubusercontent.com/1298609/169683688-0e903683-425a-4482-a853-fb7cc94cca00.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
