### PR TITLE
fix: Some Python syntax highlight enhancements

### DIFF
--- a/lib/ace/mode/_test/tokens_python.json
+++ b/lib/ace/mode/_test/tokens_python.json
@@ -333,7 +333,7 @@
    "start",
   ["keyword","def"],
   ["text"," "],
-  ["identifier","to_lowercase"],
+  ["entity.name.function","to_lowercase"],
   ["paren.lparen","("],
   ["support.function","input"],
   ["paren.rparen",")"],

--- a/lib/ace/mode/python_highlight_rules.js
+++ b/lib/ace/mode/python_highlight_rules.js
@@ -170,6 +170,9 @@ var PythonHighlightRules = function() {
             token: "paren.rparen",
             regex: "[\\]\\)\\}]"
         }, {
+            token: ["keyword", "text", "entity.name.function"],
+            regex: "(def|class)(\\s+)(\\w+)"
+         }, {
             token: "text",
             regex: "\\s+"
         }, {


### PR DESCRIPTION
fix: Some Python syntax highlight enhancements:
 * brackets should be matched independently
 * functions should be matched as functions

For example, with dracula theme, before:

![image](https://user-images.githubusercontent.com/1298609/169684527-e155cd91-b923-4a92-87c4-30eede78e5b1.png)

After:

![image](https://user-images.githubusercontent.com/1298609/169684534-8d1f0fea-8d37-4eb6-83be-572443298605.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
