### PR TITLE
fix: Pass additional arguments for command.exec

### DIFF
--- a/lib/ace/commands/command_manager.js
+++ b/lib/ace/commands/command_manager.js
@@ -21,7 +21,10 @@ var CommandManager = function(platform, commands) {
     MultiHashHandler.call(this, commands, platform);
     this.byName = this.commands;
     this.setDefaultHandler("exec", function(e) {
-        return e.command.exec(e.editor, e.args || {});
+        if (!e.args) {
+            return e.command.exec(e.editor, {}, e.event, true);
+        }
+        return e.command.exec(e.editor, e.args, e.event, false);
     });
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Brought back from c9 branch

We pass 2 more new arguments:
```
event: Event, 
undefinedArguments: boolean
```

We have the flag `undefinedArguments` to know whether or not the arguments sent to the `exec` were initally undefined.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
