### PR TITLE
fix: Do not render selected word markers for the same range multiple times

### DIFF
--- a/lib/ace/search_highlight.js
+++ b/lib/ace/search_highlight.js
@@ -56,7 +56,7 @@ var SearchHighlight = function(regExp, clazz, type) {
         if (!this.regExp)
             return;
         var start = config.firstRow, end = config.lastRow;
-        var renderedMarkerRanges = new Set();
+        var renderedMarkerRanges = {};
 
         for (var i = start; i <= end; i++) {
             var ranges = this.cache[i];
@@ -73,9 +73,9 @@ var SearchHighlight = function(regExp, clazz, type) {
             for (var j = ranges.length; j --; ) {
                 var rangeToAddMarkerTo = ranges[j].toScreenRange(session);
                 var rangeAsString = rangeToAddMarkerTo.toString();
-                if (renderedMarkerRanges.has(rangeAsString)) continue;
+                if (renderedMarkerRanges[rangeAsString]) continue;
 
-                renderedMarkerRanges.add(rangeAsString);
+                renderedMarkerRanges[rangeAsString] = true;
                 markerLayer.drawSingleLineMarker(
                     html, rangeToAddMarkerTo, this.clazz, config);
             }

--- a/lib/ace/search_highlight.js
+++ b/lib/ace/search_highlight.js
@@ -56,6 +56,7 @@ var SearchHighlight = function(regExp, clazz, type) {
         if (!this.regExp)
             return;
         var start = config.firstRow, end = config.lastRow;
+        var renderedMarkerRanges = new Set();
 
         for (var i = start; i <= end; i++) {
             var ranges = this.cache[i];
@@ -70,8 +71,13 @@ var SearchHighlight = function(regExp, clazz, type) {
             }
 
             for (var j = ranges.length; j --; ) {
+                var rangeToAddMarkerTo = ranges[j].toScreenRange(session);
+                var rangeAsString = rangeToAddMarkerTo.toString();
+                if (renderedMarkerRanges.has(rangeAsString)) continue;
+
+                renderedMarkerRanges.add(rangeAsString);
                 markerLayer.drawSingleLineMarker(
-                    html, ranges[j].toScreenRange(session), this.clazz, config);
+                    html, rangeToAddMarkerTo, this.clazz, config);
             }
         }
     };


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/ajaxorg/ace/issues/4687

*Description of changes:*
Avoid rendering multiple markers at the same range to avoid browser freeze when a lot of search values found in folded code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
