### PR TITLE
fix: Colors for variable, function and constant should be different

### DIFF
--- a/lib/ace/theme/chrome.css
+++ b/lib/ace/theme/chrome.css
@@ -80,9 +80,7 @@
   color: rgb(0, 0, 205);
 }
 
-.ace-chrome .ace_variable,
-.ace-chrome .ace_variable:not(.ace_parameter),
-.ace-chrome .ace_constant:not(.ace_numeric) {
+.ace-chrome .ace_variable {
   color: rgb(49, 132, 149);
 }
 

--- a/lib/ace/theme/merbivore.css
+++ b/lib/ace/theme/merbivore.css
@@ -63,9 +63,7 @@
 .ace-merbivore .ace_constant.ace_character,
 .ace-merbivore .ace_constant.ace_character.ace_escape,
 .ace-merbivore .ace_constant.ace_other,
-.ace-merbivore .ace_support.ace_type,
-.ace-merbivore .ace_variable:not(.ace_parameter),
-.ace-merbivore .ace_constant:not(.ace_numeric) {
+.ace-merbivore .ace_support.ace_type {
   color: #1EDAFB
 }
 

--- a/lib/ace/theme/merbivore_soft.css
+++ b/lib/ace/theme/merbivore_soft.css
@@ -62,9 +62,7 @@
 .ace-merbivore-soft .ace_constant.ace_character,
 .ace-merbivore-soft .ace_constant.ace_character.ace_escape,
 .ace-merbivore-soft .ace_constant.ace_other,
-.ace-merbivore-soft .ace_support.ace_type,
-.ace-merbivore-soft .ace_variable:not(.ace_parameter),
-.ace-merbivore-soft .ace_constant:not(.ace_numeric) {
+.ace-merbivore-soft .ace_support.ace_type {
   color: #68C1D8
 }
 

--- a/lib/ace/theme/tomorrow.css
+++ b/lib/ace/theme/tomorrow.css
@@ -92,9 +92,7 @@
 
 .ace-tomorrow .ace_entity.ace_name.ace_function,
 .ace-tomorrow .ace_support.ace_function,
-.ace-tomorrow .ace_variable,
-.ace-tomorrow .ace_variable:not(.ace_parameter),
-.ace-tomorrow .ace_constant:not(.ace_numeric) {
+.ace-tomorrow .ace_variable {
   color: #4271AE
 }
 

--- a/lib/ace/theme/tomorrow_night.css
+++ b/lib/ace/theme/tomorrow_night.css
@@ -92,9 +92,7 @@
 
 .ace-tomorrow-night .ace_entity.ace_name.ace_function,
 .ace-tomorrow-night .ace_support.ace_function,
-.ace-tomorrow-night .ace_variable,
-.ace-tomorrow-night .ace_variable:not(.ace_parameter),
-.ace-tomorrow-night .ace_constant:not(.ace_numeric) {
+.ace-tomorrow-night .ace_variable {
   color: #81A2BE
 }
 

--- a/lib/ace/theme/tomorrow_night_blue.css
+++ b/lib/ace/theme/tomorrow_night_blue.css
@@ -89,9 +89,7 @@
 
 .ace-tomorrow-night-blue .ace_entity.ace_name.ace_function,
 .ace-tomorrow-night-blue .ace_support.ace_function,
-.ace-tomorrow-night-blue .ace_variable,
-.ace-tomorrow-night-blue .ace_variable:not(.ace_parameter),
-.ace-tomorrow-night-blue .ace_constant:not(.ace_numeric) {
+.ace-tomorrow-night-blue .ace_variable {
   color: #BBDAFF
 }
 

--- a/lib/ace/theme/tomorrow_night_bright.css
+++ b/lib/ace/theme/tomorrow_night_bright.css
@@ -104,9 +104,7 @@
 
 .ace-tomorrow-night-bright .ace_entity.ace_name.ace_function,
 .ace-tomorrow-night-bright .ace_support.ace_function,
-.ace-tomorrow-night-bright .ace_variable,
-.ace-tomorrow-night-bright .ace_variable:not(.ace_parameter),
-.ace-tomorrow-night-bright .ace_constant:not(.ace_numeric) {
+.ace-tomorrow-night-bright .ace_variable {
   color: #7AA6DA
 }
 

--- a/lib/ace/theme/tomorrow_night_eighties.css
+++ b/lib/ace/theme/tomorrow_night_eighties.css
@@ -93,9 +93,7 @@
 
 .ace-tomorrow-night-eighties .ace_entity.ace_name.ace_function,
 .ace-tomorrow-night-eighties .ace_support.ace_function,
-.ace-tomorrow-night-eighties .ace_variable,
-.ace-tomorrow-night-eighties .ace_variable:not(.ace_parameter),
-.ace-tomorrow-night-eighties .ace_constant:not(.ace_numeric) {
+.ace-tomorrow-night-eighties .ace_variable {
   color: #6699CC
 }
 

--- a/lib/ace/theme/xcode.css
+++ b/lib/ace/theme/xcode.css
@@ -70,9 +70,7 @@
 
 .ace-xcode .ace_entity.ace_other.ace_attribute-name,
 .ace-xcode .ace_support.ace_constant,
-.ace-xcode .ace_support.ace_function, 
-.ace-xcode .ace_variable:not(.ace_parameter),
-.ace-xcode .ace_constant:not(.ace_numeric) {
+.ace-xcode .ace_support.ace_function {
   color: #450084
 }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/ajaxorg/ace/issues/4800

*Description of changes:*
Some changes for themes such as Tomorrow Night and etc have been introduced here: https://github.com/ajaxorg/ace/commit/87ad55daf243bdc619e15fbf220dc5ded235ed4c

But these changes are actually not so good to distinguish between variables, functions and constants. So reverting them back.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
