### PR TITLE
Add class to tooltip DOM element distinguish errors from warnings

### DIFF
--- a/lib/ace/mouse/default_gutter_handler.js
+++ b/lib/ace/mouse/default_gutter_handler.js
@@ -87,6 +87,7 @@ function GutterHandler(mouseHandler) {
         tooltipAnnotation = annotation.text.join("<br/>");
 
         tooltip.setHtml(tooltipAnnotation);
+        tooltip.setClassName(annotation.className.trim());
         tooltip.show();
         editor._signal("showGutterTooltip", tooltip);
         editor.on("mousewheel", hideTooltip);

--- a/lib/ace/tooltip.js
+++ b/lib/ace/tooltip.js
@@ -114,6 +114,7 @@ function Tooltip (parentNode) {
     this.hide = function() {
         if (this.isOpen) {
             this.getElement().style.display = "none";
+            this.getElement().className = "ace_tooltip";
             this.isOpen = false;
         }
     };


### PR DESCRIPTION
## Issue #4799 Styling Tooltip Base on Gutter Annotation Type

### Description of changes:
Adding required lines to add a CSS class to the tooltip element to distinguish errors from warnings.

Test by building ace from my branch, it's working like a charm:
<img width="296" alt="Screenshot 2022-05-31 at 20 45 56" src="https://user-images.githubusercontent.com/17025808/171262626-cc22be27-7c12-4a93-98c4-315d5e7a808d.png">

Not sure about if it the proper way to reset the `className` with an hardcoded value tho' 


