### PR TITLE
Add/Fix ability to use HTML fragments

### DIFF
--- a/lib/ace/mode/html/saxparser.js
+++ b/lib/ace/mode/html/saxparser.js
@@ -4950,6 +4950,8 @@ TreeBuilder.prototype.startTokenization = function(tokenizer) {
 	this.activeFormattingElements = [];
 	this.start();
 	if (this.context) {
+		// This means user want to setup an HTML fragment
+
 		switch(this.context) {
 		case 'title':
 		case 'textarea':
@@ -4974,6 +4976,15 @@ TreeBuilder.prototype.startTokenization = function(tokenizer) {
 			break;
 		}
 		this.insertHtmlElement();
+
+		if (this.context === 'head') {
+			// In case it's an 'head' fragment, we insert a head DOM element
+			this.insertHeadElement();
+		} else {
+			// Else a body DOM element
+			this.insertBodyElement();
+		}
+
 		this.resetInsertionMode();
 		// todo form pointer
 	} else {
@@ -5320,13 +5331,14 @@ TreeBuilder.prototype.parseError = function(code, args) {
  * Resets the insertion mode (http://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html#reset-the-insertion-mode-appropriately)
  */
 TreeBuilder.prototype.resetInsertionMode = function() {
-	var last = false;
+	var fragmentAssigned = false;
 	var node = null;
 	for (var i = this.openElements.length - 1; i >= 0; i--) {
 		node = this.openElements.item(i);
 		if (i === 0) {
+			// Normally we enter here if a fragment context has been set
 			assert.ok(this.context);
-			last = true;
+			fragmentAssigned = true;
 			node = new StackItem("http://www.w3.org/1999/xhtml", this.context, [], null);
 		}
 
@@ -5347,7 +5359,7 @@ TreeBuilder.prototype.resetInsertionMode = function() {
 				return this.setInsertionMode('inColumnGroup');
 			if (node.localName === 'table')
 				return this.setInsertionMode('inTable');
-			if (node.localName === 'head' && !last)
+			if (node.localName === 'head')
 				return this.setInsertionMode('inHead');
 			if (node.localName === 'body')
 				return this.setInsertionMode('inBody');
@@ -5360,7 +5372,7 @@ TreeBuilder.prototype.resetInsertionMode = function() {
 					return this.setInsertionMode('afterHead');
 		}
 
-		if (last)
+		if (fragmentAssigned)
 			return this.setInsertionMode('inBody');
 	}
 };
@@ -5823,7 +5835,10 @@ function SAXParser() {
 	this._scriptingEnabled = false;
 }
 
-SAXParser.prototype.parse = function(source) {
+SAXParser.prototype.parse = function(source, context) {
+	if (context) {
+		this._treeBuilder.setFragmentContext(context);
+	}
 	this._tokenizer.tokenize(source);
 	var document = this._treeBuilder.document;
 	if (document) {

--- a/lib/ace/mode/html_worker.js
+++ b/lib/ace/mode/html_worker.js
@@ -45,6 +45,11 @@ var errorTypes = {
 var Worker = exports.Worker = function(sender) {
     Mirror.call(this, sender);
     this.setTimeout(400);
+
+    // The context is currently only used for Fragment
+    // It's format is an object: {fragmentContext: "body"}
+    // %Value% need to be a string of a DOM Element type:
+    // "head" | "body" | "footer" | ...
     this.context = null;
 };
 
@@ -80,10 +85,9 @@ oop.inherits(Worker, Mirror);
                 });
             }
         };
-        if (this.context)
-            parser.parseFragment(value, this.context);
-        else
-            parser.parse(value);
+
+        parser.parse(value, this.context);
+
         this.sender.emit("error", errors);
     };
 


### PR DESCRIPTION
## Issue #4811 Add/Fix ability to use HTML fragments

### Description of changes:
I fixed the existing code handling the HTML fragment feature, I haven't remove the obsolete `DocumentFragment` class but this class either was never really finished or pieces were lost over time.

I decided to use the exact same route as for non-fragment document, and do the required work to reconnect with the existing features.

I test it by compiling with  `node ./Makefile.dryice.js` on a clean new web server and it's works.  

### Risks
Since the feature didn't work for at least the last 4/5 years I don't think new bugs will be introduced with these changes.
Few have tried to use fragment (see issue #3518), but was face to the incomplete `DocumentFragment` class.

### How to use Fragment
You need to pass to the HTML mode an object with a property called `fragmentContext` and the value need to be the name of a valid DOM Element tag name (`head`, `body`, `div`, `footer`, ...) ensure it in lowercase without extra space(s).

After a discussion with @andrewnester , my setup is:
```javascript
let containerId = 'my-awesome-ace';

let editor = ace.edit(containerId);

let HtmlMode = require("ace/mode/html").Mode;
editor.session.setMode(new HtmlMode({fragmentContext: "body"});
```

If for a reason I ignore you have an error telling you `require("ace/mode/html")` return `undefined`

Do something like:
```javascript
let config = require("ace/config");
let net = require("ace/lib/net");

function _initialize() {
    let containerId = 'my-awesome-ace';

    let editor = ace.edit(containerId);

    let HtmlMode = require("ace/mode/html").Mode;
    editor.session.setMode(new HtmlMode({fragmentContext: "body"});
}

net.loadScript(config.moduleUrl("ace/mode/html", "mode"), _initialize);
```

If you use the no-conflic version of ace, please prefix the require with `ace.`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

