### PR TITLE
Fix css EOF duplicate errors

### DIFF
--- a/lib/ace/mode/css/csslint.js
+++ b/lib/ace/mode/css/csslint.js
@@ -1879,9 +1879,8 @@ Parser.prototype = function() {
                     this._readWhitespace();
                 } else {
                     var tt = tokenStream.peek();
-                    if (tt === Tokens.EOF || tt === Tokens.RBRACE) {
-                        // Encountered when there are no more properties.
-                    } else {
+                    // If this isn't an right brace or the end of the file throw an SyntaxError.
+                    if (tt !== Tokens.EOF && tt !== Tokens.RBRACE) {
                         this._unexpectedToken(tokenStream.LT(1));
                     }
                 }

--- a/lib/ace/mode/css/csslint.js
+++ b/lib/ace/mode/css/csslint.js
@@ -1877,10 +1877,13 @@ Parser.prototype = function() {
 
                     value = new PropertyName(propertyName, hack, line || token.startLine, col || token.startCol);
                     this._readWhitespace();
-                } else if (tokenStream.peek() === Tokens.RBRACE) {
-                    // Encountered when there are no more properties.
                 } else {
-                    this._unexpectedToken(tokenStream.LT(1));
+                    var tt = tokenStream.peek();
+                    if (tt === Tokens.EOF || tt === Tokens.RBRACE) {
+                        // Encountered when there are no more properties.
+                    } else {
+                        this._unexpectedToken(tokenStream.LT(1));
+                    }
                 }
 
                 return value;
@@ -3129,7 +3132,7 @@ Parser.prototype = function() {
                         if (tt === Tokens.SEMICOLON) {
                             // if there's a semicolon, then there might be another declaration
                             this._readDeclarations(false, readMargins);
-                        } else if (tt !== Tokens.RBRACE) {
+                        } else if (tt !== Tokens.EOF && tt !== Tokens.RBRACE) {
                             // if there's a right brace, the rule is finished so don't do anything
                             // otherwise, rethrow the error because it wasn't handled properly
                             throw ex;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "amd-loader": "~0.0.4",
         "architect-build": "https://github.com/c9/architect-build/tarball/43a6fdeffe",
         "asyncjs": "~0.0.12",
-        "dryice": "^0.4.8",
+        "dryice": "0.4.11",
         "standard-version": "^9.3.2"
     },
     "mappings": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "amd-loader": "~0.0.4",
         "architect-build": "https://github.com/c9/architect-build/tarball/43a6fdeffe",
         "asyncjs": "~0.0.12",
-        "dryice": "0.4.11",
+        "dryice": "^0.4.8",
         "standard-version": "^9.3.2"
     },
     "mappings": {


### PR DESCRIPTION
Issue #4809 | Annotations: duplicate annotations in CSS mode

This Pull request fix a bug with the CSS Parser (file `csslint.js`), the bug is simple :
If a declaration is open `{` and after that the parser encounter the end of the file `EOF` it will throw twice a wrong error (`Unexpected token 'null' at line 3, col 1.`).

I imagine this edge case has never been considered, and therefore taken into account in the code.

### Before / After
Before:
<img width="396" alt="Before" src="https://user-images.githubusercontent.com/17025808/171702557-bc36becd-fddf-48b2-a0f3-7d0cb2cd1add.png">

After:
<img width="397" alt="After" src="https://user-images.githubusercontent.com/17025808/171702617-608285f0-414e-4294-a5b1-fc7a6b851b56.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
