### PR TITLE
fix: Incorrect YAML syntax highlighting for version numbers with multiple periods

### DIFF
--- a/demo/kitchen-sink/docs/yaml.yaml
+++ b/demo/kitchen-sink/docs/yaml.yaml
@@ -18,6 +18,7 @@ items:
       size:      8
       price:     100.27
       quantity:  1
+      version:   1.2.3.4
 
 bill-to:  &id001
     street: |

--- a/lib/ace/mode/_test/text_yaml.txt
+++ b/lib/ace/mode/_test/text_yaml.txt
@@ -18,6 +18,7 @@ items:
       size:      8
       price:     100.27
       quantity:  1
+      version:   1.2.3.4
 
 bill-to:  &id001
     street: |

--- a/lib/ace/mode/_test/tokens_yaml.json
+++ b/lib/ace/mode/_test/tokens_yaml.json
@@ -98,6 +98,11 @@
   ["text","  "],
   ["constant.numeric","1"]
 ],[
+   "start",
+  ["meta.tag","      version"],
+  ["keyword",":"],
+  ["text","   1.2.3.4"]
+],[
    "start"
 ],[
    "start",
@@ -124,7 +129,7 @@
   ["indent","    "],
   ["meta.tag","ref-id"],
   ["keyword",":"],
-  ["text","   id123"]
+  ["text"," id123  "]
 ],[
    "start",
   ["meta.tag","    city"],

--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -100,7 +100,7 @@ var YamlHighlightRules = function() {
                 regex : "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"
             }, {
                 token : "constant.numeric", // float
-                regex : /(\b|[+\-\.])[\d_]+(?:(?:\.[\d_]*)?(?:[eE][+\-]?[\d_]+)?)(?=[^\d-\w]|$)/
+                regex : /(\b|[+\-])[\d_]+(?:(?:\.[\d_]*)?(?:[eE][+\-]?[\d_]+)?)(?=[^\d-\w]|$)$/
             }, {
                 token : "constant.numeric", // other number
                 regex : /[+\-]?\.inf\b|NaN\b|0x[\dA-Fa-f_]+|0b[10_]+/

--- a/lib/ace/mode/yaml_highlight_rules.js
+++ b/lib/ace/mode/yaml_highlight_rules.js
@@ -100,7 +100,7 @@ var YamlHighlightRules = function() {
                 regex : "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"
             }, {
                 token : "constant.numeric", // float
-                regex : /(\b|[+\-])[\d_]+(?:(?:\.[\d_]*)?(?:[eE][+\-]?[\d_]+)?)(?=[^\d-\w]|$)$/
+                regex : /(\b|[+\-\.])[\d_]+(?:(?:\.[\d_]*)?(?:[eE][+\-]?[\d_]+)?)(?=[^\d-\w]|$)$/
             }, {
                 token : "constant.numeric", // other number
                 regex : /[+\-]?\.inf\b|NaN\b|0x[\dA-Fa-f_]+|0b[10_]+/


### PR DESCRIPTION
*Issue #, if available:* https://github.com/ajaxorg/ace/issues/4468

*Description of changes:*
Fixed incorrect YAML syntax highlighting for version numbers with multiple periods


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
