### PR TITLE
fix: Highlight unicode characters in Python function and class names

### DIFF
--- a/lib/ace/mode/python_highlight_rules.js
+++ b/lib/ace/mode/python_highlight_rules.js
@@ -171,7 +171,7 @@ var PythonHighlightRules = function() {
             regex: "[\\]\\)\\}]"
         }, {
             token: ["keyword", "text", "entity.name.function"],
-            regex: "(def|class)(\\s+)(\\w+)"
+            regex: "(def|class)(\\s+)([\\u00BF-\\u1FFF\\u2C00-\\uD7FF\\w]+)"
          }, {
             token: "text",
             regex: "\\s+"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/ajaxorg/ace/issues/4828

*Description of changes:*
Highlight unicode characters in Python function and class names

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
