### PR TITLE
chore: Add test to fix flaky coverage report

### DIFF
--- a/lib/ace/editor_commands_test.js
+++ b/lib/ace/editor_commands_test.js
@@ -54,7 +54,25 @@ var exec = function(name, times, args) {
 
 
 module.exports = {
-
+    "test highlightmatching": function(done) {
+        editor = new Editor(new MockRenderer());
+        editor.session.setMode(new HTMLMode);
+        editor.setValue("<html><head></head> abcd</html>", 1);
+        exec("gotostart", 1);
+        exec("gotoright", 3);
+        assert.equal(editor.$highlightTagPending, true);
+        setTimeout(function() {
+            assert.equal(editor.$highlightTagPending, false);
+            assert.ok(editor.session.$tagHighlight);
+            exec("gotoend", 1);
+            exec("gotoleft", 3);
+            assert.equal(editor.$highlightTagPending, true);
+            setTimeout(function() {
+                assert.equal(editor.$highlightTagPending, false);
+                done();
+            }, 51);
+        }, 51);
+    },    
     "test modifyNumber": function() {
         editor = new Editor(new MockRenderer());
         editor.setValue("999");

--- a/lib/ace/test/all_browser.js
+++ b/lib/ace/test/all_browser.js
@@ -24,6 +24,7 @@ var testNames = [
     "ace/editor_highlight_selected_word_test",
     "ace/editor_navigation_test",
     "ace/editor_text_edit_test",
+    "ace/editor_commands_test",
     "ace/ext/hardwrap_test",
     "ace/ext/static_highlight_test",
     "ace/ext/whitespace_test",

--- a/lib/ace/undomanager_test.js
+++ b/lib/ace/undomanager_test.js
@@ -58,6 +58,36 @@ module.exports = {
         editor.setSession(session);
     },
 
+    "test: merging": function(done) {
+        editor.session.setValue("-");
+        editor.execCommand("insertstring", "a");
+        editor.execCommand("insertstring", "b");
+        editor.execCommand("insertstring", "c");
+        editor.execCommand("gotolinestart");
+        // TODO remove setTimeout when timeout from informUndoManager is removed 
+        setTimeout(function() {
+            editor.execCommand("insertstring", "x");
+            editor.execCommand("insertstring", "y");
+            editor.execCommand("insertstring", "z");
+            editor.execCommand("undo");
+            assert.equal(editor.getValue(), "abc-");
+            editor.execCommand("redo");
+            assert.equal(editor.getValue(), "xyzabc-");
+            editor.execCommand("gotolineend");
+
+            editor.execCommand("insertstring", "k");
+            editor.execCommand("insertstring", "l");
+            setTimeout(function() {
+                editor.sequenceStartTime = Date.now() - 3000;
+                editor.execCommand("insertstring", "m");
+                editor.execCommand("insertstring", "n");
+                assert.equal(editor.getValue(), "xyzabc-klmn");
+                editor.execCommand("undo");
+                assert.equal(editor.getValue(), "xyzabc-kl");
+                done();
+            });
+        });
+    },
     "test: reabsing": function() {
         session.setValue("012345-012345-012345");
         session.insert({row: 0, column: 0}, "xx");


### PR DESCRIPTION
some code in highlightTags and undoManager was called by tests only when test runner was slow, causing flaky code coverage reports. This pull request adds tests to prevent that. 