### PR TITLE
fix: Uncaught TypeError: Cannot read properties of undefined in worker code

### DIFF
--- a/lib/ace/worker/v2/worker_client.js
+++ b/lib/ace/worker/v2/worker_client.js
@@ -190,7 +190,7 @@ define(function (require, exports, module) {
 
       this.$doc = doc;
       this.call("setValue", [doc.getValue()]);
-      doc.on("change", this.changeListener);
+      doc.on("change", this.changeListener, true);
     };
 
     this.changeListener = function (delta) {

--- a/lib/ace/worker/worker_client.js
+++ b/lib/ace/worker/worker_client.js
@@ -184,7 +184,7 @@ var WorkerClient = function(worker) {
 
         this.$doc = doc;
         this.call("setValue", [doc.getValue()]);
-        doc.on("change", this.changeListener);
+        doc.on("change", this.changeListener, true);
     };
 
     this.changeListener = function(delta) {


### PR DESCRIPTION
*Issue #, if available:* #4583

*Description of changes:*

The issue was caused by the fact that `changeListener` used to collect deltas was not the first listener for `change` event on the document. Because of this, any listener for `change` event which modified editor content and attached earlier then `changeListener` caused deltas being stored for sending in wrong order.

For example, assume that we have such handler set somewhere in the code which embeds Ace

```
editor.session.on("change", (e) => {
  if (e.lines && e.lines[0].indexOf("smth") !== 0) {
    editor.setValue("smth");
  }
})
```

When user makes a change in Ace, for example, pressing Enter to insert new line, the following will happen

1.  [onTextInput event is triggered](https://github.com/ajaxorg/ace/blob/94422a4a892495564c56089af85019a8f8f24673/lib/ace/keyboard/keybinding.js#L145)
2. [insertMergedLines](https://github.com/ajaxorg/ace/blob/94422a4a892495564c56089af85019a8f8f24673/lib/ace/document.js#L403) is called which calls `applyDelta` function (with `delta1`)

3. Delta to insert a new line is applied to document and [change event is sent](https://github.com/ajaxorg/ace/blob/94422a4a892495564c56089af85019a8f8f24673/lib/ace/document.js#L583). Now document stored in Ace memory contains a new line

4. Handlers for `change` event is being [called one by one] with `delta1` change (https://github.com/ajaxorg/ace/blob/master/lib/ace/lib/event_emitter.js#L75-L76)

5. The first handler to be called is our custom one which calls `editor.setValue("smth");`

6. Another `change` event is triggered with new `delta2` change and handlers for `change` event are called again in loop even though previous processing was not yet finished.

7. First handler called but don't do any action, and then `changeListener` called with `delta2`

8. And only after finishing processing even with `delta2` change, `changeListener` handler with `delta1` change is called which makes the delta being stored out of order.

Note: This behaviour of EventEmitter is inline with default behaviour in Node.

The fix is always to call `changeListener` first so the deltas stored in the same order.

Another potential fix would be to change EventEmitter to be synchronous and store events in the queue while processing previous ones but this change is much more complex.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
