### PR TITLE
fix: Move session.onChange and placeholder.onChange handlers to be first in the change event handler queue

### DIFF
--- a/lib/ace/edit_session.js
+++ b/lib/ace/edit_session.js
@@ -197,7 +197,7 @@ EditSession.$uid = 0;
             this.doc.off("change", this.$onChange);
 
         this.doc = doc;
-        doc.on("change", this.$onChange);
+        doc.on("change", this.$onChange, true);
 
         this.bgTokenizer.setDocument(this.getDocument());
 

--- a/lib/ace/placeholder.js
+++ b/lib/ace/placeholder.js
@@ -58,7 +58,7 @@ var PlaceHolder = function(session, length, pos, others, mainClass, othersClass)
     this.mainClass = mainClass;
     this.othersClass = othersClass;
     this.$onUpdate = this.onUpdate.bind(this);
-    this.doc.on("change", this.$onUpdate);
+    this.doc.on("change", this.$onUpdate, true);
     this.$others = others;
     
     this.$onCursorChange = function() {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/ajaxorg/ace/issues/4732

*Description of changes:* 
It seems to be the cause of the issue is similar to this one https://github.com/ajaxorg/ace/pull/4831, so applying similar fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
