### PR TITLE
Build script: fix CSS extract with `options.compress`

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -460,7 +460,7 @@ function buildAce(options, callback) {
 }
 
 function extractCss(options, callback) {
-    var dir = BUILD_DIR + "/src" + (options.noconflict ? "-noconflict" : "");
+    var dir = BUILD_DIR + "/src" + (options.compress ? "-min" : "") + (options.noconflict ? "-noconflict" : "");
     var filenames = fs.readdirSync(dir);
     var css = "";
     var images = {};

--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -460,7 +460,7 @@ function buildAce(options, callback) {
 }
 
 function extractCss(options, callback) {
-    var dir = BUILD_DIR + "/src" + (options.compress ? "-min" : "") + (options.noconflict ? "-noconflict" : "");
+    var dir = getTargetDir(options);
     var filenames = fs.readdirSync(dir);
     var css = "";
     var images = {};


### PR DESCRIPTION
*Description of changes:*

During the build script, extract the CSS to the correct directory when `options.compress` is set to true. Otherwise, `readdirSync` on the next line will throw an error because the directory doesn't exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
