### PR TITLE
chore: upgraded plist used in tools to 3.0.5

### DIFF
--- a/tool/package.json
+++ b/tool/package.json
@@ -10,6 +10,6 @@
     "css-stringify": "1.0.3",
     "deps-sort": "1.3.9",
     "derequire": "2.0.0",
-    "plist": "1.1.0"
+    "plist": "3.0.5"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/ajaxorg/ace/security/dependabot/2

*Description of changes:*
Upgraded plist used in tools to 3.0.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
