### PR TITLE
Fix undefined error thrown when using soft wraps and RTL font

### DIFF
--- a/lib/ace/bidihandler.js
+++ b/lib/ace/bidihandler.js
@@ -160,9 +160,11 @@ var BidiHandler = function(session) {
                 } else {
                     this.line = this.line.substring(0, splits[splitIndex]);
                 }
+
+                if (splitIndex == splits.length) {
+                    this.line += (this.showInvisibles) ? endOfLine : bidiUtil.DOT;
+                }
             }
-            if (splitIndex == splits.length)
-                this.line += (this.showInvisibles) ? endOfLine : bidiUtil.DOT;
         } else {
             this.line += this.showInvisibles ? endOfLine : bidiUtil.DOT;
         }


### PR DESCRIPTION
*Issue #:*
N/A

*Description of changes:*
Our organization ran into an issue where we see an undefined error being thrown when users attempt to use RTL fonts in an editor with soft wraps enabled.

I found the offending line of code in the bidihandler.js file where there is a conditional that checks for truthiness of the `splits` variable but then directly below/outside that block, the code attempts to access `splits.length` without first checking for truthiness.

Side note: I've found the RTL functionality in Ace to be rather buggy with some weird indentations that appear when writing multiple lines using RTL mode + RTL font. Is there an issue that outlines the current state of support for RTL languages?