### PR TITLE
add undocumented Target command

### DIFF
--- a/lib/ace/mode/nsis_highlight_rules.js
+++ b/lib/ace/mode/nsis_highlight_rules.js
@@ -80,7 +80,7 @@ var NSISHighlightRules = function() {
             regex: /\b(?:false|off)\b/
         }, {
             token: "constant.language.option.nsis",
-            regex: /(?:\b|^\s*)(?:(?:un\.)?components|(?:un\.)?custom|(?:un\.)?directory|(?:un\.)?instfiles|(?:un\.)?license|uninstConfirm|admin|all|auto|both|bottom|bzip2|current|force|hide|highest|ifdiff|ifnewer|lastused|leave|left|listonly|lzma|nevershow|none|normal|notset|right|show|silent|silentlog|textonly|top|try|user|Win10|Win7|Win8|WinVista|zlib)\b/,
+            regex: /(?:\b|^\s*)(?:(?:un\.)?components|(?:un\.)?custom|(?:un\.)?directory|(?:un\.)?instfiles|(?:un\.)?license|uninstConfirm|admin|all|amd64-unicode|auto|both|bottom|bzip2|current|force|hide|highest|ifdiff|ifnewer|lastused|leave|left|listonly|lzma|nevershow|none|normal|notset|right|show|silent|silentlog|textonly|top|try|user|Win10|Win7|Win8|WinVista|x86-(ansi|unicode)zlib)\b/,
             caseInsensitive: true
         }, {
             token: "constant.language.slash-option.nsis",

--- a/lib/ace/mode/nsis_highlight_rules.js
+++ b/lib/ace/mode/nsis_highlight_rules.js
@@ -80,7 +80,7 @@ var NSISHighlightRules = function() {
             regex: /\b(?:false|off)\b/
         }, {
             token: "constant.language.option.nsis",
-            regex: /(?:\b|^\s*)(?:(?:un\.)?components|(?:un\.)?custom|(?:un\.)?directory|(?:un\.)?instfiles|(?:un\.)?license|uninstConfirm|admin|all|amd64-unicode|auto|both|bottom|bzip2|current|force|hide|highest|ifdiff|ifnewer|lastused|leave|left|listonly|lzma|nevershow|none|normal|notset|right|show|silent|silentlog|textonly|top|try|user|Win10|Win7|Win8|WinVista|x86-(ansi|unicode)zlib)\b/,
+            regex: /(?:\b|^\s*)(?:(?:un\.)?components|(?:un\.)?custom|(?:un\.)?directory|(?:un\.)?instfiles|(?:un\.)?license|uninstConfirm|admin|all|amd64-unicode|auto|both|bottom|bzip2|current|force|hide|highest|ifdiff|ifnewer|lastused|leave|left|listonly|lzma|nevershow|none|normal|notset|right|show|silent|silentlog|textonly|top|try|user|Win10|Win7|Win8|WinVista|x86-(ansi|unicode)|zlib)\b/,
             caseInsensitive: true
         }, {
             token: "constant.language.slash-option.nsis",


### PR DESCRIPTION
Adds undocumented `Target` command and its parameters. See [ticket](https://sourceforge.net/p/nsis/feature-requests/549/#e073) for details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
