### PR TITLE
fix: Correct highlight of PHP heredoc strings with one word on line

### DIFF
--- a/demo/kitchen-sink/mini_require.js
+++ b/demo/kitchen-sink/mini_require.js
@@ -503,7 +503,7 @@
         if (!/^\w+:/.test(path)) path = host + path;
         var onLoad = function(e, val) {
             if (e) return processLoadQueue({id: id, path: path});
-            if (!/^(\s|\/\*([^*]|[*](?!\/))*\*\/|\/\/.*\n)*define\(function\(require/.test(val))
+            if (!/^(\s|\/\*([^*]|[*](?!\/))*\*\/|\/\/.*[\r]?\n)*define\(function\(require/.test(val))
                 val = "define(function(require, exports, module){" + val + "\n});"
             nextModule = {name: id};
             /* eslint no-eval:0 */

--- a/lib/ace/mode/_test/text_php.txt
+++ b/lib/ace/mode/_test/text_php.txt
@@ -1,4 +1,13 @@
 <?php
+$bar = <<<EOD
+highlightingWithNoSpaces
+doesn't break
+EOD;
+
+lorem('ipsum', <<<TEST
+foo bar
+TEST
+);
 
 function nfact($n) {
     if ($n == 0) {

--- a/lib/ace/mode/_test/tokens_php.json
+++ b/lib/ace/mode/_test/tokens_php.json
@@ -2,6 +2,43 @@
    "php-start",
   ["support.php_tag","<?php"]
 ],[
+   ["php-heredoc","EOD"],
+  ["variable","$bar"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["markup.list","<<<EOD"]
+],[
+   ["php-heredoc","EOD"],
+  ["string","highlightingWithNoSpaces"]
+],[
+   ["php-heredoc","EOD"],
+  ["string","doesn't break"]
+],[
+   "php-start",
+  ["markup.list","EOD"],
+  ["punctuation.operator",";"]
+],[
+   "php-start"
+],[
+   ["php-heredoc","TEST"],
+  ["identifier","lorem"],
+  ["paren.lparen","("],
+  ["string","'ipsum'"],
+  ["punctuation.operator",","],
+  ["text"," "],
+  ["markup.list","<<<TEST"]
+],[
+   ["php-heredoc","TEST"],
+  ["string","foo bar"]
+],[
+   "php-start",
+  ["markup.list","TEST"]
+],[
+   "php-start",
+  ["paren.rparen",")"],
+  ["punctuation.operator",";"]
+],[
    "php-start"
 ],[
    "php-start",

--- a/lib/ace/mode/php_highlight_rules.js
+++ b/lib/ace/mode/php_highlight_rules.js
@@ -1018,15 +1018,18 @@ sql_regcase'.split('|')
         ],
         "heredoc" : [
             {
-                onMatch : function(value, currentSate, stack) {
-                    if (stack[1] != value)
+                onMatch : function(value, currentState, stack) {
+                    if (stack[1] != value) {
+                        this.next = "";
                         return "string";
+                    }
                     stack.shift();
                     stack.shift();
+                    this.next = this.nextState;
                     return "markup.list";
                 },
                 regex : "^\\w+(?=;?$)",
-                next: "start"
+                nextState: "start"
             }, {
                 token: "string",
                 regex : ".*"


### PR DESCRIPTION
*Issue #, if available:* #3171

*Description of changes:*
1. [Fixing regexp in `mini_require` to support windows-style line breaks](https://github.com/ajaxorg/ace/commit/a1942533343741339aba35e0ecd0ea1906154aaa)
2. [Fixing highlight of PHP heredoc strings with one word on line](https://github.com/ajaxorg/ace/pull/4847/commits/ae4564c2961b006ca849625a0dee1093061eba5a)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
