### PR TITLE
fix: prevent race condition when creating css files in build

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -450,14 +450,21 @@ function buildAce(options, callback) {
         if (options.noconflict && !options.compress)
             buildTypes();
 
-        extractCss(options, function() {
-            if (callback) 
-                return callback();
+        // call extractCss only once during a build
+        if (cssUpdated) {
             console.log("Finished building " + getTargetDir(options));
-            
-        });
+            return;
+        } else {
+            cssUpdated = true;
+            extractCss(options, function() {
+                if (callback) 
+                    return callback();
+                console.log("Finished building " + getTargetDir(options));                
+            });
+        }
     }
 }
+var cssUpdated = false;
 
 function extractCss(options, callback) {
     var dir = getTargetDir(options);
@@ -548,6 +555,7 @@ function extractCss(options, callback) {
                 imageCounter++;
                 var imageName = name + "-" + imageCounter + ".png";
                 images[imageName] = buffer;
+                console.log("url(\"" + directory + "/" + imageName + "\")");
                 return "url(\"" + directory + "/" + imageName + "\")";
             }
         );


### PR DESCRIPTION
fixes https://github.com/ajaxorg/ace/issues/4850

the error was caused by extractCss being called 4 times, which called write on the same file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
