### PR TITLE
Proposal: Switch #ace irc channel from freenode.net to libera.chat

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,7 +103,7 @@ You can also find API documentation at [http://ace.c9.io/#nav=api](http://ace.c9
 
 Also check out the sample code for the kitchen sink [demo app](https://github.com/ajaxorg/ace/blob/master/demo/kitchen-sink/demo.js).
 
-If you still need help, feel free to drop a mail on the [ace mailing list](http://groups.google.com/group/ace-discuss), or at `irc.freenode.net#ace`.
+If you still need help, feel free to drop a mail on the [ace mailing list](http://groups.google.com/group/ace-discuss), or at `irc.libera.chat#ace`.
 
 Running Ace
 -----------

--- a/index.html
+++ b/index.html
@@ -1225,7 +1225,7 @@ if (match) {
                             <ul class="content-list">
                                 <li><a href="http://groups.google.com/group/ace-discuss">Ace Google Group</a></li>
                                 <li><a href="http://groups.google.com/group/ace-internals">Ace Core Google Group</a></li>
-                                <li><a href="irc://irc.freenode.net/%23ace">irc.freenode.net #ace</a></li>
+                                <li><a href="irc://irc.libera.chat/%23ace">libera.chat #ace</a> (<a href="https://web.libera.chat/?channel=#ace">Webchat</a> / <a href="https://app.element.io/#/room/#ace:libera.chat">Matrix: #ace:libera.chat</a>)</li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I just changed the links to the `#ace` IRC channel in the `Readme` and on the "Support" page, as Freenode no longer exists as an IRC network for open source projects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
