### PR TITLE
Fix determination of anonymous code blocks in Postgres Mode

### DIFF
--- a/demo/kitchen-sink/docs/pgsql.pgsql
+++ b/demo/kitchen-sink/docs/pgsql.pgsql
@@ -116,3 +116,14 @@ lines - use dollar quotes
 $$;
 
 END;
+
+-- Anonymous code block
+DO LANGUAGE plpgsql $$
+BEGIN
+    -- code block
+END $$;
+
+DO $$
+BEGIN
+    -- code block
+END; $$;

--- a/lib/ace/mode/_test/tokens_pgsql.json
+++ b/lib/ace/mode/_test/tokens_pgsql.json
@@ -886,4 +886,52 @@
   ["statementEnd",";"]
 ],[
    "start"
+],[
+   "start",
+  ["comment","-- Anonymous code block"]
+],[
+   "dollarSql",
+  ["keyword.statementBegin","DO"],
+  ["text"," "],
+  ["keyword","LANGUAGE"],
+  ["text"," "],
+  ["identifier","plpgsql"],
+  ["text"," "],
+  ["string","$$"]
+],[
+   "dollarSql",
+  ["keyword","BEGIN"]
+],[
+   "dollarSql",
+  ["text","    "],
+  ["comment","-- code block"]
+],[
+   "start",
+  ["keyword","END"],
+  ["text"," "],
+  ["string","$$"],
+  ["statementEnd",";"]
+],[
+   "start"
+],[
+   "dollarSql",
+  ["keyword.statementBegin","DO"],
+  ["text"," "],
+  ["string","$$"]
+],[
+   "dollarSql",
+  ["keyword","BEGIN"]
+],[
+   "dollarSql",
+  ["text","    "],
+  ["comment","-- code block"]
+],[
+   "start",
+  ["keyword","END"],
+  ["statementEnd",";"],
+  ["text"," "],
+  ["string","$$"],
+  ["statementEnd",";"]
+],[
+   "start"
 ]]

--- a/lib/ace/mode/pgsql_highlight_rules.js
+++ b/lib/ace/mode/pgsql_highlight_rules.js
@@ -527,7 +527,7 @@ var PgsqlHighlightRules = function() {
                 next : "javascript-start"
             }, {
                 token : "string",
-                regex : "\\$[\\w_0-9]*\\$$", // dollar quote at the end of a line
+                regex : "\\$\\$$",
                 next : "dollarSql"
             }, {
                 token : "string",
@@ -544,8 +544,8 @@ var PgsqlHighlightRules = function() {
                 regex : "\\/\\*",
                 next : "commentDollarSql"
             }, {
-                token : "string", // end quoting with dollar at the start of a line
-                regex : "^\\$[\\w_0-9]*\\$",
+                token : ["keyword", "statementEnd", "text", "string"], // end quoting with dollar at the start of a line
+                regex : "(^|END)(;)?(\\s*)(\\$\\$)",
                 next : "statement"
             }, {
                 token : "string",


### PR DESCRIPTION
*Issue #, if available:* #4790

*Description of changes:*
Highlight of anonymous code block now wouldn't break highlight of other tokens

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
