### PR TITLE
Ability to limit amount of undos/redos

### DIFF
--- a/src/undomanager.js
+++ b/src/undomanager.js
@@ -13,6 +13,7 @@
 var UndoManager = function() {
     this.$maxRev = 0;
     this.$fromUndo = false;
+    this.$undoDepth = Infinity;
     this.reset();
 };
 
@@ -36,6 +37,10 @@ var UndoManager = function() {
         if (!this.$keepRedoStack) this.$redoStack.length = 0;
         if (allowMerge === false || !this.lastDeltas) {
             this.lastDeltas = [];
+            var undoStackLength = this.$undoStack.length;
+            if (undoStackLength > this.$undoDepth - 1) {
+                this.$undoStack.splice(0, undoStackLength - this.$undoDepth + 1);
+            }
             this.$undoStack.push(this.lastDeltas);
             delta.id = this.$rev = ++this.$maxRev;
         }

--- a/src/undomanager_test.js
+++ b/src/undomanager_test.js
@@ -369,6 +369,27 @@ module.exports = {
         assert.equal(editor.getValue(), "");
         editor.redo();
         assert.equal(editor.getValue(), "\n\n\n\n");
+    },
+    "test: limit possible undos amount": function() {
+        editor.setValue("");
+        undoManager.startNewGroup();
+        editor.insert("a");
+        undoManager.startNewGroup();
+        editor.insert("b");
+        undoManager.startNewGroup();
+        editor.insert("c");
+        assert.equal(undoManager.$undoStack.length, 3);
+
+        undoManager.$undoDepth = 1;
+        editor.setValue("");
+        undoManager.startNewGroup();
+        editor.insert("a");
+        undoManager.startNewGroup();
+        editor.insert("b");
+        undoManager.startNewGroup();
+        editor.insert("c");
+        assert.equal(undoManager.$undoStack[0][0].lines[0], "c");
+        assert.equal(undoManager.$undoStack.length, undoManager.$undoDepth);
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:* #4864

*Description of changes:*
Limit number of undos/redos by setting `UndoManager.$undoDepth`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
