### PR TITLE
Rename the "Pallete" button to "Palette"

### DIFF
--- a/src/commands/default_commands.js
+++ b/src/commands/default_commands.js
@@ -851,7 +851,7 @@ exports.commands = [{
     scrollIntoView: "cursor"
 }, {
     name: "openCommandPallete",
-    description: "Open command pallete",
+    description: "Open command palette",
     bindKey: bindKey("F1", "F1"),
     exec: function(editor) {
         editor.prompt({ $type: "commands" });

--- a/src/mouse/touch_handler.js
+++ b/src/mouse/touch_handler.js
@@ -34,7 +34,7 @@ exports.addTouchListeners = function(el, editor) {
                     clipboard && ["span", { class: "ace_mobile-button", action: "paste" }, "Paste"],
                     hasUndo && ["span", { class: "ace_mobile-button", action: "undo" }, "Undo"],
                     ["span", { class: "ace_mobile-button", action: "find" }, "Find"],
-                    ["span", { class: "ace_mobile-button", action: "openCommandPallete" }, "Pallete"]
+                    ["span", { class: "ace_mobile-button", action: "openCommandPallete" }, "Palette"]
                 ] : ["span"]),
                 contextMenu.firstChild
             );


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* On mobile, the "Pallete" button brings up a whole list of editor actions. However, in English, this word is spelled [palette](https://www.merriam-webster.com/dictionary/palette).
I changed only the button label and the accompanying action description, not the name of the action in the code. This in order to maintain compatibility with existing code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
