### PR TITLE
Append tooltip to body to ensure good positioning

### DIFF
--- a/src/mouse/default_gutter_handler.js
+++ b/src/mouse/default_gutter_handler.js
@@ -7,7 +7,7 @@ var Tooltip = require("../tooltip").Tooltip;
 function GutterHandler(mouseHandler) {
     var editor = mouseHandler.editor;
     var gutter = editor.renderer.$gutterLayer;
-    var tooltip = new GutterTooltip(editor.container);
+    var tooltip = new GutterTooltip();
 
     mouseHandler.editor.setDefaultHandler("guttermousedown", function(e) {
         if (!editor.isFocused() || e.getButton() != 0)
@@ -126,8 +126,8 @@ function GutterHandler(mouseHandler) {
     editor.on("changeSession", hideTooltip);
 }
 
-function GutterTooltip(parentNode) {
-    Tooltip.call(this, parentNode);
+function GutterTooltip() {
+    Tooltip.call(this, window.document.body);
 }
 
 oop.inherits(GutterTooltip, Tooltip);


### PR DESCRIPTION
Hi, Ace team! My team has been using a fork of Ace, and I'm hoping to merge some of our changes upstream so that we can return to using your official releases.

The engineer who originally accomplished this work has long since departed my team, so forgive me for this somewhat rote transcription of his working notes.

> Tooltip positioning was being messed up in our modal because of the position on the modal's container.  Skip the issue by appending the tooltip to the body instead of the editor container so that the mouse coords it uses to compute position are always correct.

This issue appears to be related to [ajaxorg/ace#2629](https://github.com/ajaxorg/ace/issues/2629) and [ajaxorg/ace#3262](https://github.com/ajaxorg/ace/issues/3262).