### PR TITLE
Feat: Matching tags for highlighting/folding

### DIFF
--- a/src/edit_session/bracket_match.js
+++ b/src/edit_session/bracket_match.js
@@ -403,6 +403,6 @@ function BracketMatch() {
                 closeTagName: closeTagName
             };
         }
-    }
+    };
 }
 exports.BracketMatch = BracketMatch;

--- a/src/editor.js
+++ b/src/editor.js
@@ -555,7 +555,7 @@ Editor.$uid = 0;
             if (!session.$tagHighlight) session.$tagHighlight = [];
             
             var pos = self.getCursorPosition();
-            var iterator = new TokenIterator(self.session, pos.row, pos.column);
+            var iterator = new TokenIterator(session, pos.row, pos.column);
             var token = iterator.getCurrentToken();
 
             if (!token || !/\b(?:tag-open|tag-name)/.test(token.type)) {
@@ -566,16 +566,16 @@ Editor.$uid = 0;
                 return;
             }
 
-            var tagNames = self.getMatchingTags(pos);
+            var tagNamesRanges = session.getMatchingTags(pos);
 
-            if (!tagNames) {
+            if (!tagNamesRanges) {
                 for (let i in session.$tagHighlight) {
                     session.removeMarker(session.$tagHighlight[i]);
                 }
                 session.$tagHighlight = [];
                 return;
             }
-            var ranges = [tagNames.openTagName, tagNames.closeTagName];
+            var ranges = [tagNamesRanges.openTagName, tagNamesRanges.closeTagName];
 
             //remove range if different
             var clean = false;
@@ -594,179 +594,6 @@ Editor.$uid = 0;
             }
         }, 50);
     };
-
-    /**
-     * Returns [[Range]]'s for matching tags and tag names, if there are any
-     * @param {Position} pos
-     * @returns {{closeTag: Range, closeTagName: Range, openTag: Range, openTagName: Range} | undefined}
-     */
-    this.getMatchingTags = function (pos) {
-        var iterator = new TokenIterator(this.session, pos.row, pos.column);
-        var token = iterator.getCurrentToken();
-        var found = false;
-        var backward = false;
-        if (token.type.indexOf('tag-name') === -1) {
-            do {
-                if (!backward) token = iterator.stepForward(); else token = iterator.stepBackward();
-                if (token) {
-                    if (token.value === "<") backward = true;
-                    if (token.type.indexOf('tag-name') !== -1) {
-                        found = true;
-                    }
-                }
-            } while (token && !found);
-        }
-        if (!token) return;
-
-        var tag = token.value;
-        var currentTag = token.value;
-        var depth = 0;
-        var prevToken = iterator.stepBackward();
-
-        if (prevToken.value === '<') {
-            //find closing tag
-            var openTagStart = new Range(iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn(),
-                iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn() + 1
-            );
-            token = iterator.stepForward();
-            var openTagName = new Range(iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn(),
-                iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn() + token.value.length
-            );
-            iterator.stepBackward();
-            var foundOpenTagEnd = false;
-            do {
-                prevToken = token;
-                token = iterator.stepForward();
-                if (token) {
-                    if (token.value === '>' && !foundOpenTagEnd) {
-                        var openTagEnd = new Range(iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn(),
-                            iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn() + 1
-                        );
-                        foundOpenTagEnd = true;
-                    }
-                    if (token.type.indexOf('tag-name') !== -1) {
-                        currentTag = token.value;
-                        if (tag === currentTag) {
-                            if (prevToken.value === '<') {
-                                depth++;
-                            }
-                            else if (prevToken.value === '</') {
-                                depth--;
-                                if (depth < 0) {
-                                    iterator.stepBackward();
-                                    var closeTagStart = new Range(iterator.getCurrentTokenRow(),
-                                        iterator.getCurrentTokenColumn(), iterator.getCurrentTokenRow(),
-                                        iterator.getCurrentTokenColumn() + 2
-                                    );
-                                    token = iterator.stepForward();
-                                    var closeTagName = new Range(iterator.getCurrentTokenRow(),
-                                        iterator.getCurrentTokenColumn(), iterator.getCurrentTokenRow(),
-                                        iterator.getCurrentTokenColumn() + token.value.length
-                                    );
-                                    token = iterator.stepForward();
-                                    if (token && token.value === '>') {
-                                        var closeTagEnd = new Range(iterator.getCurrentTokenRow(),
-                                            iterator.getCurrentTokenColumn(), iterator.getCurrentTokenRow(),
-                                            iterator.getCurrentTokenColumn() + 1
-                                        );
-                                    }
-                                    else {
-                                        return;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    else if (tag === currentTag && token.value === '/>') { // self closing tag
-                        depth--;
-                    }
-                }
-            } while (token && depth >= 0);
-        }
-        else {
-            //find opening tag
-            var startRow = iterator.getCurrentTokenRow();
-            var startColumn = iterator.getCurrentTokenColumn();
-            var endColumn = startColumn + 1;
-            var closeTagStart = new Range(startRow, startColumn, startRow, endColumn);
-            iterator.stepForward();
-            var closeTagName = new Range(iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn(),
-                iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn() + token.value.length
-            );
-            token = iterator.stepForward();
-            if (!token || token.value !== ">") return;
-            var closeTagEnd = new Range(iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn(),
-                iterator.getCurrentTokenRow(), iterator.getCurrentTokenColumn() + 1
-            );
-            iterator.stepBackward();
-            iterator.stepBackward();
-            do {
-                token = prevToken;
-                startRow = iterator.getCurrentTokenRow();
-                startColumn = iterator.getCurrentTokenColumn();
-                endColumn = startColumn + token.value.length;
-
-                prevToken = iterator.stepBackward();
-
-                if (token) {
-                    if (token.type.indexOf('tag-name') !== -1) {
-                        if (tag === token.value) {
-                            if (prevToken.value === '<') {
-                                depth++;
-                                if (depth > 0) {
-                                    var openTagName = new Range(startRow, startColumn, startRow, endColumn);
-                                    var openTagStart = new Range(iterator.getCurrentTokenRow(),
-                                        iterator.getCurrentTokenColumn(), iterator.getCurrentTokenRow(),
-                                        iterator.getCurrentTokenColumn() + 1
-                                    );
-                                    do {
-                                        token = iterator.stepForward();
-                                    } while (token && token.value !== '>');
-                                    var openTagEnd = new Range(iterator.getCurrentTokenRow(),
-                                        iterator.getCurrentTokenColumn(), iterator.getCurrentTokenRow(),
-                                        iterator.getCurrentTokenColumn() + 1
-                                    );
-                                }
-                            }
-                            else if (prevToken.value === '</') {
-                                depth--;
-                            }
-                        }
-                    }
-                    else if (token.value === '/>') { // self closing tag
-                        var stepCount = 0;
-                        var tmpToken = prevToken;
-                        while (tmpToken) {
-                            if (tmpToken.type.indexOf('tag-name') !== -1 && tmpToken.value === tag) {
-                                depth--;
-                                break;
-                            }
-                            else if (tmpToken.value === '<') {
-                                break;
-                            }
-                            tmpToken = iterator.stepBackward();
-                            stepCount++;
-                        }
-                        for (var i = 0; i < stepCount; i++) {
-                            iterator.stepForward();
-                        }
-                    }
-                }
-            } while (prevToken && depth <= 0);
-        }
-        if (openTagStart && openTagEnd && closeTagStart && closeTagEnd && openTagName && closeTagName) {
-            return {
-                openTag: new Range(openTagStart.start.row, openTagStart.start.column, openTagEnd.end.row,
-                    openTagEnd.end.column
-                ),
-                closeTag: new Range(closeTagStart.start.row, closeTagStart.start.column, closeTagEnd.end.row,
-                    closeTagEnd.end.column
-                ),
-                openTagName: openTagName,
-                closeTagName: closeTagName
-            };
-        }
-    }
 
     /**
      *
@@ -2447,7 +2274,7 @@ Editor.$uid = 0;
 
             //find matching tag
             if (range.compare(cursor.row, cursor.column) === 0) {
-                var tagsRanges = this.getMatchingTags(cursor);
+                var tagsRanges = this.session.getMatchingTags(cursor);
                 if (tagsRanges) {
                     if (tagsRanges.openTag.contains(cursor.row, cursor.column)) {
                         range = tagsRanges.closeTag;

--- a/src/editor_commands_test.js
+++ b/src/editor_commands_test.js
@@ -230,14 +230,14 @@ module.exports = {
         exec("gotoright", 15);
         editor.execCommand(editor.commands.byName.selecttomatching);
         editor.execCommand(editor.commands.byName.selecttomatching);
-        assert.range(editor.selection.getRange(), 0, 6, 0, 15);
+        assert.range(editor.selection.getRange(), 0, 10, 0, 15);
 
         editor.setValue("<html>abcd</div></div></html>", 1);
         exec("gotostart", 1);
         exec("gotoright", 21);
         editor.execCommand(editor.commands.byName.selecttomatching);
         editor.execCommand(editor.commands.byName.selecttomatching);
-        assert.range(editor.selection.getRange(), 0, 6, 0, 21);
+        assert.range(editor.selection.getRange(), 0, 16, 0, 21);
 
         editor.setValue("", 1);
         exec("gotostart", 1);

--- a/src/editor_commands_test.js
+++ b/src/editor_commands_test.js
@@ -29,15 +29,15 @@ module.exports = {
         editor.setValue("<html><head></head> abcd</html>", 1);
         exec("gotostart", 1);
         exec("gotoright", 3);
-        assert.equal(editor.$highlightTagPending, true);
+        assert.equal(editor.$highlightPending, true);
         setTimeout(function() {
-            assert.equal(editor.$highlightTagPending, false);
-            assert.ok(editor.session.$tagHighlight);
+            assert.equal(editor.$highlightPending, false);
+            assert.ok(editor.session.$bracketHighlight);
             exec("gotoend", 1);
             exec("gotoleft", 3);
-            assert.equal(editor.$highlightTagPending, true);
+            assert.equal(editor.$highlightPending, true);
             setTimeout(function() {
-                assert.equal(editor.$highlightTagPending, false);
+                assert.equal(editor.$highlightPending, false);
                 done();
             }, 51);
         }, 51);

--- a/src/keyboard/vim.js
+++ b/src/keyboard/vim.js
@@ -136,8 +136,12 @@
   };
 
 
-  CodeMirror.findMatchingTag = function(cm, head) {
-    
+  CodeMirror.findMatchingTag = function (cm, head) {
+    return cm.findMatchingTag(head);
+  }
+
+  CodeMirror.findEnclosingTag = function (cm, head) {
+
   };
 
   CodeMirror.signal = function(o, name, e) { return o._signal(name, e) };
@@ -612,6 +616,20 @@
   this.findMatchingBracket = function(pos) {
     var m = this.ace.session.findMatchingBracket(toAcePos(pos));
     return {to: m && toCmPos(m)};
+  };
+  this.findMatchingTag = function (pos) {
+    var m = this.ace.session.getMatchingTags(toAcePos(pos));
+    if (!m) return;
+    return {
+      open: {
+        from: toCmPos(m.openTag.start),
+        to: toCmPos(m.openTag.end)
+      },
+      close: {
+        from: toCmPos(m.closeTag.start),
+        to: toCmPos(m.closeTag.end)
+      }
+    };
   };
   this.indentLine = function(line, method) {
     if (method === true)

--- a/src/keyboard/vim_test.js
+++ b/src/keyboard/vim_test.js
@@ -1665,25 +1665,27 @@ testEdit('di>_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'di>', 'a\t<>b');
 testEdit('da<_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'da<', 'a\tb');
 testEdit('da>_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'da>', 'a\tb');
 
-// deleting tag objects
-isAce || testEdit('dat_noop', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer><inner>hello</inner></outer>');
-isAce || testEdit('dat_open_tag', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer></outer>', {
+//TODO: mode changing is not implemented for vim
+isAce || testEdit('dat_noop', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer><inner>hello</inner></outer>',{
+    mode: 'text'
+});
+testEdit('dat_open_tag', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer></outer>', {
   mode: 'xml'
 });
-isAce || testEdit('dat_inside_tag', '<outer><inner>hello</inner></outer>', /l/, 'dat', '<outer></outer>', {
+testEdit('dat_inside_tag', '<outer><inner>hello</inner></outer>', /l/, 'dat', '<outer></outer>', {
   mode: 'xml'
 });
-isAce || testEdit('dat_close_tag', '<outer><inner>hello</inner></outer>', /\//, 'dat', '<outer></outer>', {
+testEdit('dat_close_tag', '<outer><inner>hello</inner></outer>', /\//, 'dat', '<outer></outer>', {
   mode: 'xml'
 });
 
-isAce || testEdit('dit_open_tag', '<outer><inner>hello</inner></outer>', /n/, 'dit', '<outer><inner></inner></outer>', {
+testEdit('dit_open_tag', '<outer><inner>hello</inner></outer>', /n/, 'dit', '<outer><inner></inner></outer>', {
   mode: 'xml'
 });
-isAce || testEdit('dit_inside_tag', '<outer><inner>hello</inner></outer>', /l/, 'dit', '<outer><inner></inner></outer>', {
+testEdit('dit_inside_tag', '<outer><inner>hello</inner></outer>', /l/, 'dit', '<outer><inner></inner></outer>', {
   mode: 'xml'
 });
-isAce || testEdit('dit_close_tag', '<outer><inner>hello</inner></outer>', /\//, 'dit', '<outer><inner></inner></outer>', {
+testEdit('dit_close_tag', '<outer><inner>hello</inner></outer>', /\//, 'dit', '<outer><inner></inner></outer>', {
   mode: 'xml'
 });
 

--- a/src/keyboard/vim_test.js
+++ b/src/keyboard/vim_test.js
@@ -9,6 +9,8 @@ var Editor = require("./../editor").Editor;
 var UndoManager = require("./../undomanager").UndoManager;
 var MockRenderer = require("./../test/mockrenderer").MockRenderer;
 var JavaScriptMode = require("./../mode/javascript").Mode;
+var CSSMode = require("./../mode/css").Mode;
+var XMLMode = require("./../mode/xml").Mode;
 var VirtualRenderer = require("./../virtual_renderer").VirtualRenderer;
 var assert = require("./../test/assertions");
 var keys = require("./../lib/keys");
@@ -28,10 +30,14 @@ var phantom = window.name == "nodejs";
 var renderer = new VirtualRenderer(el);
 var editor = window.editor = new Editor(renderer);
 editor.session.setUndoManager(new UndoManager());
+var modes = {
+    js: new JavaScriptMode(),
+    css: new CSSMode(),
+    xml: new XMLMode()
+};
 editor.setOptions({
     useWorker: false,
     behavioursEnabled: false,
-    mode: new JavaScriptMode(),
 });
 function CodeMirror(place, opts) {
     var cm = editor.state && editor.state.cm;
@@ -48,6 +54,7 @@ function CodeMirror(place, opts) {
     editor.setOption("indentedSoftWrap", false);
     editor.setOption("wrap", opts.lineWrapping);
     editor.setOption("useSoftTabs", !opts.indentWithTabs);
+    editor.setOption("mode", opts.mode ? modes[opts.mode] : modes.js);
     cm.setOption("tabSize", opts.tabSize || 4);
     cm.setOption("indentUnit", opts.indentUnit || 2);
 
@@ -1665,9 +1672,8 @@ testEdit('di>_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'di>', 'a\t<>b');
 testEdit('da<_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'da<', 'a\tb');
 testEdit('da>_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'da>', 'a\tb');
 
-//TODO: mode changing is not implemented for vim
-isAce || testEdit('dat_noop', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer><inner>hello</inner></outer>',{
-    mode: 'text'
+testEdit('dat_noop', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer><inner>hello</inner></outer>',{
+    mode: 'css'
 });
 testEdit('dat_open_tag', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer></outer>', {
   mode: 'xml'

--- a/src/layer/text.js
+++ b/src/layer/text.js
@@ -500,8 +500,10 @@ var Text = function(parentEl) {
         var line = this.session.doc.getLine(cell.row);
         if (line !== "") {
             var childNodes = cell.element.childNodes;
-            if (childNodes && childNodes[indentLevel - 1] && childNodes[indentLevel - 1].classList) {
-                childNodes[indentLevel - 1].classList.add("ace_indent-guide-active");
+            if (childNodes) {
+                let node = childNodes[indentLevel - 1];
+                if (node && node.classList && node.classList.contains("ace_indent-guide")) node.classList.add(
+                    "ace_indent-guide-active");
             }
         }
     };

--- a/src/mode/folding/xml.js
+++ b/src/mode/folding/xml.js
@@ -1,10 +1,8 @@
 "use strict";
 
 var oop = require("../../lib/oop");
-var lang = require("../../lib/lang");
 var Range = require("../../range").Range;
 var BaseFoldMode = require("./fold_mode").FoldMode;
-var TokenIterator = require("../../token_iterator").TokenIterator;
 
 var FoldMode = exports.FoldMode = function(voidElements, optionalEndTags) {
     BaseFoldMode.call(this);
@@ -37,7 +35,7 @@ function is(token, type) {
             return this.getCommentFoldWidget(session, row);
 
         if (tag.closing || (!tag.tagName && tag.selfClosing))
-            return foldStyle == "markbeginend" ? "end" : "";
+            return foldStyle === "markbeginend" ? "end" : "";
 
         if (!tag.tagName || tag.selfClosing || this.voidElements.hasOwnProperty(tag.tagName.toLowerCase()))
             return "";
@@ -107,147 +105,15 @@ function is(token, type) {
         return false;
     };
 
-    /*
-     * reads a full tag and places the iterator after the tag
-     */
-    this._readTagForward = function(iterator) {
-        var token = iterator.getCurrentToken();
-        if (!token)
-            return null;
-
-        var tag = new Tag();
-        do {
-            if (is(token, "tag-open")) {
-                tag.closing = is(token, "end-tag-open");
-                tag.start.row = iterator.getCurrentTokenRow();
-                tag.start.column = iterator.getCurrentTokenColumn();
-            } else if (is(token, "tag-name")) {
-                tag.tagName = token.value;
-            } else if (is(token, "tag-close")) {
-                tag.selfClosing = token.value == "/>";
-                tag.end.row = iterator.getCurrentTokenRow();
-                tag.end.column = iterator.getCurrentTokenColumn() + token.value.length;
-                iterator.stepForward();
-                return tag;
-            }
-        } while(token = iterator.stepForward());
-
-        return null;
-    };
-    
-    this._readTagBackward = function(iterator) {
-        var token = iterator.getCurrentToken();
-        if (!token)
-            return null;
-
-        var tag = new Tag();
-        do {
-            if (is(token, "tag-open")) {
-                tag.closing = is(token, "end-tag-open");
-                tag.start.row = iterator.getCurrentTokenRow();
-                tag.start.column = iterator.getCurrentTokenColumn();
-                iterator.stepBackward();
-                return tag;
-            } else if (is(token, "tag-name")) {
-                tag.tagName = token.value;
-            } else if (is(token, "tag-close")) {
-                tag.selfClosing = token.value == "/>";
-                tag.end.row = iterator.getCurrentTokenRow();
-                tag.end.column = iterator.getCurrentTokenColumn() + token.value.length;
-            }
-        } while(token = iterator.stepBackward());
-
-        return null;
-    };
-    
-    this._pop = function(stack, tag) {
-        while (stack.length) {
-            
-            var top = stack[stack.length-1];
-            if (!tag || top.tagName == tag.tagName) {
-                return stack.pop();
-            }
-            else if (this.optionalEndTags.hasOwnProperty(top.tagName)) {
-                stack.pop();
-                continue;
-            } else {
-                return null;
-            }
-        }
-    };
-    
     this.getFoldWidgetRange = function(session, foldStyle, row) {
-        var firstTag = this._getFirstTagInLine(session, row);
-        
-        if (!firstTag) {
+        var tags = session.getMatchingTags({row: row, column: 0});
+        if (tags) {
+            return new Range(
+                tags.openTag.end.row, tags.openTag.end.column, tags.closeTag.start.row, tags.closeTag.start.column);
+        } else {
             return this.getCommentFoldWidget(session, row)
                 && session.getCommentFoldRange(row, session.getLine(row).length);
         }
-        
-        var isBackward = firstTag.closing || firstTag.selfClosing;
-        var stack = [];
-        var tag;
-        
-        if (!isBackward) {
-            var iterator = new TokenIterator(session, row, firstTag.start.column);
-            var start = {
-                row: row,
-                column: firstTag.start.column + firstTag.tagName.length + 2
-            };
-            if (firstTag.start.row == firstTag.end.row)
-                start.column = firstTag.end.column;
-            while (tag = this._readTagForward(iterator)) {
-                if (tag.selfClosing) {
-                    if (!stack.length) {
-                        tag.start.column += tag.tagName.length + 2;
-                        tag.end.column -= 2;
-                        return Range.fromPoints(tag.start, tag.end);
-                    } else
-                        continue;
-                }
-                
-                if (tag.closing) {
-                    this._pop(stack, tag);
-                    if (stack.length == 0)
-                        return Range.fromPoints(start, tag.start);
-                }
-                else {
-                    stack.push(tag);
-                }
-            }
-        }
-        else {
-            var iterator = new TokenIterator(session, row, firstTag.end.column);
-            var end = {
-                row: row,
-                column: firstTag.start.column
-            };
-            
-            while (tag = this._readTagBackward(iterator)) {
-                if (tag.selfClosing) {
-                    if (!stack.length) {
-                        tag.start.column += tag.tagName.length + 2;
-                        tag.end.column -= 2;
-                        return Range.fromPoints(tag.start, tag.end);
-                    } else
-                        continue;
-                }
-                
-                if (!tag.closing) {
-                    this._pop(stack, tag);
-                    if (stack.length == 0) {
-                        tag.start.column += tag.tagName.length + 2;
-                        if (tag.start.row == tag.end.row && tag.start.column < tag.end.column)
-                            tag.start.column = tag.end.column;
-                        return Range.fromPoints(tag.start, end);
-                    }
-                }
-                else {
-                    stack.push(tag);
-                }
-            }
-        }
-        
     };
 
 }).call(FoldMode.prototype);

--- a/src/test/mockdom.js
+++ b/src/test/mockdom.js
@@ -41,10 +41,10 @@ function ClassList(node) {
        dom.removeCssClass(this.el, str);
     };
     this.toggle = function(str) {
-       dom.toggleCssClass(this.el, str);
+       return dom.toggleCssClass(this.el, str);
     };
     this.contains = function(str) {
-       dom.hasCssClass(this.el, str);
+       return dom.hasCssClass(this.el, str);
     };
 }).call(ClassList.prototype);
 


### PR DESCRIPTION
*Issue #, if available:* #4282 #2424

*Description of changes:*
- `getMatchingTags` method returns both open and close tag Ranges
- Unifies three different implementations of matching tag from `jumptomatching`, `xml folding` and `$highlightTags`
- `findMatchingTags` implementation for vim
- `jumpToMatching` better behaviour, when cursor is on closing tag
- Combines `$highlightTags` and `$highlightBrackets`
- Highlights both tag names
- Highlights indent guide, when cursor is on tag name 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
