### PR TITLE
Allow user feedback for empty autocompletes

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -141,6 +141,10 @@ var Autocomplete = function() {
             data = this.popup.getData(this.popup.getRow());
         if (!data)
             return false;
+	if (data.value === "") {
+            // explicitly given nothing to insert, so do exactly that.    
+            return this.detach();
+	}
 
         var completions = this.completions;
         this.editor.startOperation({command: {name: "insertMatch"}});

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -278,6 +278,7 @@ var Autocomplete = function() {
         var detachIfFinished = function(results) {
             if (!results.finished) return;
             if (!this.emptyMessage) return this.detach();
+            var prefix = results.prefix;
             // pop up the empty completions message
             var completionsForEmpty = [{
                 caption: this.emptyMessage(prefix),


### PR DESCRIPTION
Hi, Ace team! My team has been using a fork of Ace, and I'm hoping to merge some of our changes upstream so that we can return to using your official releases.

The engineer who originally accomplished this work has long since departed my team, so please forgive this somewhat rote transcription of his working notes.

Commit 1 of 2: "Allow completions with empty values"

```
Previously, completions with an empty string for `value` would display
correctly as a suggestion in the popup, but would error trying to
`Document.$detectNewLine` on the completion object if the user tried to
insert that suggestion.

Autocomplete now respects empty string as a value, doing an insert of
nothing on select that suggestion (rather than erroring).  This is handy
to properly support since it enables use cases like popping up a hint
in place of completions in cases where no suggestions are possible.
```

Commit 2 of 2: "Allow user feedback for empty autocompletes"

```
Add support for setting a completer.emptyMessage function which
generates a message to display in the completions popup when there
are no completions.

This enables configuring the editor to always give the user feedback
when they ask for suggestions, even if it is just to note that there
are none.
```