### PR TITLE
fix: Namespace-relative names for PHP

### DIFF
--- a/lib/ace/mode/php/php.js
+++ b/lib/ace/mode/php/php.js
@@ -462,10 +462,6 @@ define(function (require, exports, module) {
 						re: /^match\b/i
 					},
 					{
-						value: PHP.Constants.T_NAMESPACE,
-						re: /^namespace\b/i
-					},
-					{
 						value: PHP.Constants.T_NEW,
 						re: /^new\b/i
 					},
@@ -781,6 +777,10 @@ define(function (require, exports, module) {
 					{
 						value: PHP.Constants.T_NAME_RELATIVE,
 						re: /^namespace\\\w+(?:\\\w+)*/
+					},
+					{
+						value: PHP.Constants.T_NAMESPACE,
+						re: /^namespace\b/i
 					},
 					{
 						value: PHP.Constants.T_ATTRIBUTE,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed regexp's order to determine `namespace\NamespaceName` as `T_NAME_RELATIVE` and not `T_NAMESPACE` + `T_NAME_FULLY_QUALIFIED` (according to new [RFC](https://wiki.php.net/rfc/namespaced_names_as_token))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
