### PR TITLE
Always wrap Ace output in a class

### DIFF
--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -26,16 +26,16 @@ module.exports = {
         editor.renderer.$themeId = "./theme/textmate";
         
         editor.execCommand("insertstring", "a");
-        checkInnerHTML('<d "ace_line ace_selected"><s "ace_completion-highlight">a</s><s "ace_">rraysort</s><s "ace_completion-meta">local</s></d><d "ace_line"><s "ace_completion-highlight">a</s><s "ace_">looooooooooooooooooooooooooooong_word</s><s "ace_completion-meta">local</s></d>', function() {
+        checkInnerHTML('<d "ace_line ace_selected"><s "ace_token ace_completion-highlight">a</s><s "ace_token ace_">rraysort</s><s "ace_token ace_completion-meta">local</s></d><d "ace_line"><s "ace_token ace_completion-highlight">a</s><s "ace_token ace_">looooooooooooooooooooooooooooong_word</s><s "ace_token ace_completion-meta">local</s></d>', function() {
             editor.execCommand("insertstring", "rr");
-            checkInnerHTML('<d "ace_line ace_selected"><s "ace_completion-highlight">arr</s><s "ace_">aysort</s><s "ace_completion-meta">local</s></d>', function() {
+            checkInnerHTML('<d "ace_line ace_selected"><s "ace_token ace_completion-highlight">arr</s><s "ace_token ace_">aysort</s><s "ace_token ace_completion-meta">local</s></d>', function() {
                 editor.execCommand("insertstring", "r");
-                checkInnerHTML('<d "ace_line ace_selected"><s "ace_completion-highlight">arr</s><s "ace_">ayso</s><s "ace_completion-highlight">r</s><s "ace_">t</s><s "ace_completion-meta">local</s></d>', function() {
+                checkInnerHTML('<d "ace_line ace_selected"><s "ace_token ace_completion-highlight">arr</s><s "ace_token ace_">ayso</s><s "ace_token ace_completion-highlight">r</s><s "ace_token ace_">t</s><s "ace_token ace_completion-meta">local</s></d>', function() {
                     
                     editor.onCommandKey(null, 0, 13);
                     assert.equal(editor.getValue(), "arraysort\narraysort alooooooooooooooooooooooooooooong_word");
                     editor.execCommand("insertstring", " looooooooooooooooooooooooooooong_");
-                    checkInnerHTML('<d "ace_line ace_selected"><s "ace_">a</s><s "ace_completion-highlight">looooooooooooooooooooooooooooong_</s><s "ace_">word</s><s "ace_completion-meta">local</s></d>', function() {
+                    checkInnerHTML('<d "ace_line ace_selected"><s "ace_token ace_">a</s><s "ace_token ace_completion-highlight">looooooooooooooooooooooooooooong_</s><s "ace_token ace_">word</s><s "ace_token ace_completion-meta">local</s></d>', function() {
                         editor.onCommandKey(null, 0, 13);
                         editor.destroy();
                         editor.container.remove();

--- a/src/ext/static_highlight_test.js
+++ b/src/ext/static_highlight_test.js
@@ -39,17 +39,16 @@ module.exports = {
         ].join("\n");
         var mode = new JavaScriptMode();
         var result = highlighter.render(snippet, mode, theme);
-        assert.equal(result.html, "<div class='ace-tomorrow'><div class='ace_static_highlight ace_show_gutter' style='counter-reset:ace_line 0'>" 
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_comment ace_doc'>/** this is a function</span>\n</div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_comment ace_doc'>*</span>\n</div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_comment ace_doc'>*/</span>\n</div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span>\n</div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_storage ace_type'>function</span> <span class='ace_entity ace_name ace_function'>hello</span> <span class='ace_paren ace_lparen'>(</span><span class='ace_variable ace_parameter'>a</span><span class='ace_punctuation ace_operator'>, </span><span class='ace_variable ace_parameter'>b</span><span class='ace_punctuation ace_operator'>, </span><span class='ace_variable ace_parameter'>c</span><span class='ace_paren ace_rparen'>)</span> <span class='ace_paren ace_lparen'>{</span>\n</div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span>    <span class='ace_storage ace_type'>console</span><span class='ace_punctuation ace_operator'>.</span><span class='ace_support ace_function ace_firebug'>log</span><span class='ace_paren ace_lparen'>(</span><span class='ace_identifier'>a</span> <span class='ace_keyword ace_operator'>*</span> <span class='ace_identifier'>b</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_identifier'>c</span> <span class='ace_keyword ace_operator'>+</span> <span class='ace_string'>&#39;sup$&#39;</span><span class='ace_paren ace_rparen'>)</span><span class='ace_punctuation ace_operator'>;</span>\n</div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_indent-guide'>    </span><span class='ace_indent-guide'>    </span>   <span class='ace_comment'>//</span>\n</div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_indent-guide'>    </span><span class='ace_indent-guide'>    </span>    <span class='ace_comment'>//</span>\n</div>"
-            + "<div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_paren ace_rparen'>}</span>\n</div>"
-            + "</div></div>");
+        assert.equal(result.html, "<div class='ace-tomorrow'><div class='ace_static_highlight ace_show_gutter' style='counter-reset:ace_line 0'><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_token ace_comment ace_doc'>/** this is a function</span>\n" +
+            "</div><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_token ace_comment ace_doc'>*</span>\n" +
+            "</div><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_token ace_comment ace_doc'>*/</span>\n" +
+            "</div><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span>\n" +
+            "</div><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_token ace_storage ace_type'>function</span><span class='ace_token'> </span><span class='ace_token ace_entity ace_name ace_function'>hello</span><span class='ace_token'> </span><span class='ace_token ace_paren ace_lparen'>(</span><span class='ace_token ace_variable ace_parameter'>a</span><span class='ace_token ace_punctuation ace_operator'>, </span><span class='ace_token ace_variable ace_parameter'>b</span><span class='ace_token ace_punctuation ace_operator'>, </span><span class='ace_token ace_variable ace_parameter'>c</span><span class='ace_token ace_paren ace_rparen'>)</span><span class='ace_token'> </span><span class='ace_token ace_paren ace_lparen'>{</span>\n" +
+            "</div><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_token'>    </span><span class='ace_token ace_storage ace_type'>console</span><span class='ace_token ace_punctuation ace_operator'>.</span><span class='ace_token ace_support ace_function ace_firebug'>log</span><span class='ace_token ace_paren ace_lparen'>(</span><span class='ace_token ace_identifier'>a</span><span class='ace_token'> </span><span class='ace_token ace_keyword ace_operator'>*</span><span class='ace_token'> </span><span class='ace_token ace_identifier'>b</span><span class='ace_token'> </span><span class='ace_token ace_keyword ace_operator'>+</span><span class='ace_token'> </span><span class='ace_token ace_identifier'>c</span><span class='ace_token'> </span><span class='ace_token ace_keyword ace_operator'>+</span><span class='ace_token'> </span><span class='ace_token ace_string'>&#39;sup$&#39;</span><span class='ace_token ace_paren ace_rparen'>)</span><span class='ace_token ace_punctuation ace_operator'>;</span>\n" +
+            "</div><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_indent-guide'>    </span><span class='ace_indent-guide'>    </span><span class='ace_token'>   </span><span class='ace_token ace_comment'>//</span>\n" +
+            "</div><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_indent-guide'>    </span><span class='ace_indent-guide'>    </span><span class='ace_token'>    </span><span class='ace_token ace_comment'>//</span>\n" +
+            "</div><div class='ace_line'><span class='ace_gutter ace_gutter-cell'></span><span class='ace_token ace_paren ace_rparen'>}</span>\n" +
+            "</div></div></div>");
         assert.ok(!!result.css);
         next();
     },
@@ -97,7 +96,7 @@ module.exports = {
         var mode = new TextMode();
 
         var result = highlighter.render(snippet, mode, theme);
-        assert.ok(result.html.indexOf("</span>$&#39;$1$2$$$&#38;\n</div>") != -1);
+        assert.ok(result.html.indexOf("</span><span class='ace_token'>$&#39;$1$2$$$&#38;</span>\n</div>") != -1);
 
         next();
     },
@@ -108,11 +107,11 @@ module.exports = {
         var mode = new TextMode();
 
         var result = highlighter.render(snippet, mode, theme);
-        assert.ok(result.html.indexOf("</span>&#38;&#60;>&#39;&#34;\n</div>") != -1);
+        assert.ok(result.html.indexOf("</span><span class='ace_token'>&#38;&#60;>&#39;&#34;</span>\n</div>") != -1);
         
         var mode = new JavaScriptMode();
         var result = highlighter.render("/*" + snippet, mode, theme);
-        assert.ok(result.html.indexOf("<span class='ace_comment'>/*&#38;&#60;>&#39;&#34;</span>") != -1);
+        assert.ok(result.html.indexOf("<span class='ace_token ace_comment'>/*&#38;&#60;>&#39;&#34;</span>") != -1);
         
         next();
     },
@@ -125,7 +124,7 @@ module.exports = {
             theme: "./theme/tomorrow",
             mode: "./mode/javascript"
         }, function() {
-            assert.ok(/class="ace_storage ace_type">var/.test(el.innerHTML));
+            assert.ok(/class="ace_token ace_storage ace_type">var/.test(el.innerHTML));
             next();
         });
     }

--- a/src/layer/text.js
+++ b/src/layer/text.js
@@ -386,7 +386,7 @@ var Text = function(parentEl) {
         valueFragment.appendChild(this.dom.createTextNode(i ? value.slice(i) : value, this.element));
 
         if (!this.$textToken[token.type]) {
-            var classes = "ace_" + token.type.replace(/\./g, " ace_");
+            var classes = "ace_token ace_" + token.type.replace(/\./g, " ace_");
             var span = this.dom.createElement("span");
             if (token.type == "fold")
                 span.style.width = (token.value.length * this.config.characterWidth) + "px";
@@ -397,7 +397,10 @@ var Text = function(parentEl) {
             parent.appendChild(span);
         }
         else {
-            parent.appendChild(valueFragment);
+            var span = this.dom.createElement("span");
+            span.className = "ace_token";
+            span.appendCHild(valueFragment);
+            parent.appendChild(span);
         }
 
         return screenColumn + value.length;

--- a/src/layer/text_test.js
+++ b/src/layer/text_test.js
@@ -44,13 +44,13 @@ module.exports = {
         
         var parent = dom.createElement("div");
         this.textLayer.$renderLine(parent, 0);
-        assert.domNode(parent, ["div", {}, ["span", {class: "ace_cjk", style: "width: 20px;"}, "\u3000"]]);
+        assert.domNode(parent, ["div", {}, ["span", {class: "ace_token"}, {class: "ace_cjk", style: "width: 20px;"}, "\u3000"]]);
 
         this.textLayer.setShowInvisibles(true);
         var parent = dom.createElement("div");
         this.textLayer.$renderLine(parent, 0);
         assert.domNode(parent, ["div", {},
-            ["span", {class: "ace_cjk ace_invisible ace_invisible_space", style: "width: 20px;"}, this.textLayer.SPACE_CHAR],
+            ["span", {class: "ace_token"}, [{class: "ace_cjk ace_invisible ace_invisible_space", style: "width: 20px;"}, this.textLayer.SPACE_CHAR]],
             ["span", {class: "ace_invisible ace_invisible_eol"}, "\xB6"]
         ]);
     },
@@ -72,21 +72,21 @@ module.exports = {
         
         this.session.setValue("      \n\t\tf\n   ");
         testRender([
-            "<span class=\"ace_indent-guide\">" + SPACE(4) + "</span>" + SPACE(2),
-            "<span class=\"ace_indent-guide\">" + SPACE(4) + "</span>" + SPACE(4) + "<span class=\"ace_identifier\">f</span>",
-            SPACE(3)
+            "<span class=\"ace_indent-guide\">" + SPACE(4) + "</span><span class=\"ace_token\">" + SPACE(2) + "</span>",
+            "<span class=\"ace_indent-guide\">" + SPACE(4) + "</span><span class=\"ace_token\">" + SPACE(4) + "</span><span class=\"ace_token ace_identifier\">f</span>",
+            "<span class=\"ace_token\">" + SPACE(3) + "</span>"
         ]);
         
         this.textLayer.setShowInvisibles(true);
         testRender([
-            "<span class=\"ace_indent-guide ace_invisible ace_invisible_space\">" + DOT(4) + "</span><span class=\"ace_invisible ace_invisible_space\">" + DOT(2) + "</span>" + EOL,
-            "<span class=\"ace_indent-guide ace_invisible ace_invisible_tab\">" + TAB(4) + "</span><span class=\"ace_invisible ace_invisible_tab\">" + TAB(4) + "</span><span class=\"ace_identifier\">f</span>" + EOL
+            "<span class=\"ace_indent-guide ace_invisible ace_invisible_space\">" + DOT(4) + "</span><span class=\"ace_token\"><span class=\"ace_invisible ace_invisible_space\">" + DOT(2) + "</span></span>" + EOL,
+            "<span class=\"ace_indent-guide ace_invisible ace_invisible_tab\">" + TAB(4) + "</span><span class=\"ace_token\"><span class=\"ace_invisible ace_invisible_tab\">" + TAB(4) + "</span></span><span class=\"ace_token ace_identifier\">f</span>" + EOL
         ]);
         
         this.textLayer.setDisplayIndentGuides(false);
         testRender([
-            "<span class=\"ace_invisible ace_invisible_space\">" + DOT(6) + "</span>" + EOL,
-            "<span class=\"ace_invisible ace_invisible_tab\">" + TAB(4) + "</span><span class=\"ace_invisible ace_invisible_tab\">" + TAB(4) + "</span><span class=\"ace_identifier\">f</span>" + EOL
+            "<span class=\"ace_token\"><span class=\"ace_invisible ace_invisible_space\">" + DOT(6) + "</span></span>" + EOL,
+            "<span class=\"ace_token\"><span class=\"ace_invisible ace_invisible_tab\">" + TAB(4) + "</span><span class=\"ace_invisible ace_invisible_tab\">" + TAB(4) + "</span></span><span class=\"ace_token ace_identifier\">f</span>" + EOL
         ]);
     }
 };


### PR DESCRIPTION
Hi, Ace team! My team has been using a fork of Ace, and I'm hoping to merge some of our changes upstream so that we can return to using your official releases.

The engineer who originally accomplished this work has long since departed my team, so please forgive this somewhat rote transcription of his working notes.

```
We have styling needs that Ace's default classes make impossible, so
we ensure all Ace-generated tokens are wrapped in the `ace_token` class
so we can target them.

Risk: Ace has quite a few tests relying on the structure of the output
html, which may indicate that these new spans could cause some problems
at some point.
```