### PR TITLE
Fix syntax error in the custom scroll CSS

### DIFF
--- a/src/scrollbar_custom.js
+++ b/src/scrollbar_custom.js
@@ -17,7 +17,8 @@ dom.importCssString(`.ace_editor>.ace_sb-v div, .ace_editor>.ace_sb-h div{
 .ace_editor>.ace_sb-v, .ace_editor>.ace_sb-h {
   position: absolute;
   z-index: 6;
-  background: none;' + '  overflow: hidden!important;
+  background: none;
+  overflow: hidden!important;
 }
 .ace_editor>.ace_sb-v {
   z-index: 6;


### PR DESCRIPTION
*Description of changes:*

Fix syntax error in CSS inside the `src/scrollbar_custom.js` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
