### PR TITLE
Fix for '-' keybinding in Vim in Firefox

### DIFF
--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -108,6 +108,9 @@ var Keys = (function() {
         }
     };
 
+    // workaround for firefox bug
+    ret.PRINTABLE_KEYS[173] = '-';
+
     // A reverse map of FUNCTION_KEYS
     var name, i;
     for (i in ret.FUNCTION_KEYS) {
@@ -131,9 +134,6 @@ var Keys = (function() {
     ret.enter = ret["return"];
     ret.escape = ret.esc;
     ret.del = ret["delete"];
-
-    // workaround for firefox bug
-    ret[173] = '-';
     
     (function() {
         var mods = ["cmd", "ctrl", "alt", "shift"];


### PR DESCRIPTION
#4987

It's a fix for Firefox bug workaround.

This binding:
```js
ret[173] = '-';
```
needs to be replaced with this:
```js
ret.PRINTABLE_KEYS[173] = '-';
```
as `ret.PRINTABLE_KEYS` dict is used directly in `src/lib/event.js:229`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
