### PR TITLE
Fix for scrollAnimation overriding subsequent scrollTop changes

### DIFF
--- a/src/virtual_renderer.js
+++ b/src/virtual_renderer.js
@@ -1232,6 +1232,10 @@ var VirtualRenderer = function(container, theme) {
         
         var topMargin = $viewMargin && $viewMargin.top || 0;
         var bottomMargin = $viewMargin && $viewMargin.bottom || 0;
+
+        if (this.$scrollAnimation) {
+            this.$stopAnimation = true;
+        }
         
         var scrollTop = this.$scrollAnimation ? this.session.getScrollTop() : this.scrollTop;
         
@@ -1378,7 +1382,20 @@ var VirtualRenderer = function(container, theme) {
         _self.session.setScrollTop(steps.shift());
         // trick session to think it's already scrolled to not loose toValue
         _self.session.$scrollTop = toValue;
+        
+        function endAnimation() {
+            _self.$timer = clearInterval(_self.$timer);
+            _self.$scrollAnimation = null;
+            _self.$stopAnimation = false;
+            callback && callback();
+        }
+        
         this.$timer = setInterval(function() {
+            if (_self.$stopAnimation) {
+                endAnimation();
+                return;
+            }
+
             if (!_self.session) 
                 return clearInterval(_self.$timer);
             if (steps.length) {
@@ -1390,9 +1407,7 @@ var VirtualRenderer = function(container, theme) {
                 toValue = null;
             } else {
                 // do this on separate step to not get spurious scroll event from scrollbar
-                _self.$timer = clearInterval(_self.$timer);
-                _self.$scrollAnimation = null;
-                callback && callback();
+                endAnimation();
             }
         }, 10);
     };


### PR DESCRIPTION
#4992 

Fix for scrollAnimation overriding subsequent scrollTop changes.
Animation is now interrupted when `scrollCursorIntoView` is called.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
