### PR TITLE
Add missing options to `EditorOptions`

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -217,6 +217,9 @@ export namespace Ace {
     behavioursEnabled: boolean;
     wrapBehavioursEnabled: boolean;
     enableAutoIndent: boolean;
+    enableBasicAutocompletion: boolean | Completer[],
+    enableLiveAutocompletion: boolean | Completer[],
+    enableSnippets: boolean,
     autoScrollEditorIntoView: boolean;
     keyboardHandler: string | null;
     placeholder: string;


### PR DESCRIPTION
While using ace in a small project, i realized that the options for ace/language_tool are missing in EditorOptions.

I tried to determine the types for the options in a best effort according to thier usage in
https://github.com/ajaxorg/ace/blob/v1.13.1/src/ext/language_tools.js#L152

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
