### PR TITLE
Update ace.d.ts typings for navigate

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -883,10 +883,10 @@ export namespace Ace {
     jumpToMatching(select: boolean, expand: boolean): void;
     gotoLine(lineNumber: number, column: number, animate: boolean): void;
     navigateTo(row: number, column: number): void;
-    navigateUp(times: number): void;
-    navigateDown(times: number): void;
-    navigateLeft(times: number): void;
-    navigateRight(times: number): void;
+    navigateUp(times?: number): void;
+    navigateDown(times?: number): void;
+    navigateLeft(times?: number): void;
+    navigateRight(times?: number): void;
     navigateLineStart(): void;
     navigateLineEnd(): void;
     navigateFileEnd(): void;

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -883,10 +883,10 @@ export namespace Ace {
     jumpToMatching(select: boolean, expand: boolean): void;
     gotoLine(lineNumber: number, column: number, animate: boolean): void;
     navigateTo(row: number, column: number): void;
-    navigateUp(): void;
-    navigateDown(): void;
-    navigateLeft(): void;
-    navigateRight(): void;
+    navigateUp(times: number): void;
+    navigateDown(times: number): void;
+    navigateLeft(times: number): void;
+    navigateRight(times: number): void;
     navigateLineStart(): void;
     navigateLineEnd(): void;
     navigateFileEnd(): void;


### PR DESCRIPTION
*Description of changes:*

The typings navigateUp/Down/LeftRight are missing the times parameter. This just adds them to match the function definition.

This will show errors in an IDE:
`editor.navigateUp(3)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
