### PR TITLE
Fix editor shadow appearing under the selected line background when horizontal scroll is active

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,7 +152,7 @@ npm run test
 
 You can also run the tests in your browser by serving:
 
-    http://localhost:8888/lib/ace/test/tests.html
+    http://localhost:8888/src/test/tests.html
 
 This makes debugging failing tests way more easier.
 

--- a/src/css/editor.css.js
+++ b/src/css/editor.css.js
@@ -93,8 +93,15 @@ styles.join("\\n")
     right: 0;
 }
 
-.ace_scroller.ace_scroll-left {
+.ace_scroller.ace_scroll-left:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     box-shadow: 17px 0 16px -16px rgba(0, 0, 0, 0.4) inset;
+    pointer-events: none;
 }
 
 .ace_gutter-cell {


### PR DESCRIPTION
### Issue description

Now, when horizontal scroll is active (triggered by line length exceeding editor width), editor displays shadow on the left side of it. It is an `inset` shadow, which means it is displayed below the content (see [box-shadow docs](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#values) for details). This shadow is overlapped by active line background colour. On the default theme it's not visible, because it has background colour, which is almost transparent (with 0.07 alpha channel value). If you try it on a theme with rgb background color without alpha channel like `Clouds`, issue becomes visible (see screenshots below).

### Fix description

The issue is fixed by moving the shadow to the `:after` pseudo-element, which comes as a last child of the container. It is rendered above all other children, which leads to shadow appearing correctly above the active line.

### Before
<img width="158" alt="Screenshot 2023-01-12 at 18 04 01" src="https://user-images.githubusercontent.com/1381598/212135357-41c50669-fd23-4ee7-b78e-afb2129a9055.png">

### After
<img width="156" alt="Screenshot 2023-01-12 at 18 03 44" src="https://user-images.githubusercontent.com/1381598/212135380-596eacdc-7a76-42b3-855d-a1e8c0eeff1d.png">

This PR also updates README with a path to correct `tests.html` location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
