### PR TITLE
Issue #5049

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -943,3 +943,7 @@ export const Range: {
   fromPoints(start: Ace.Point, end: Ace.Point): Ace.Range;
   comparePoints(p1: Ace.Point, p2: Ace.Point): number;
 };
+export interface TextInput {
+    resetSelection(): void;
+    setAriaOption(activeDescendant: string, role: string): void;
+}


### PR DESCRIPTION
Ace.d.ts: Autocomplete not working because of missing type declaration of TextInput.setAriaOptions

Added setAriaOptions() to Ace.d.ts : 

export interface TextInput {
    resetSelection(): void;
    setAriaOption(activeDescendant: string, role: string): void;
  }

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
