### PR TITLE
chore: remove usage of deprecated setCapture api

### DIFF
--- a/src/config_test.js
+++ b/src/config_test.js
@@ -4,14 +4,13 @@ if (typeof process !== "undefined") {
 
 "use strict";
 
-var dom = require("./config");
 var config = require("./config");
 var assert = require("./test/assertions");
 
 module.exports = {
 
     "test: path resolution" : function() {
-        config.set("packaged", "true");
+        config.set("packaged", true);
         var url = config.moduleUrl("kr_theme", "theme");
         assert.equal(url, "theme-kr_theme.js");
         
@@ -38,7 +37,8 @@ module.exports = {
         assert.equal(url, "_.js");
         
         url = config.moduleUrl("ace/ext/textarea");
-        assert.equal(url, "a/b/ext-textarea.js");        
+        assert.equal(url, "a/b/ext-textarea.js");
+        config.set("packaged", false);
     },
     "test: define options" : function() {
         var o = {};

--- a/src/css/editor.css.js
+++ b/src/css/editor.css.js
@@ -1,4 +1,4 @@
-module.exports = `/*
+/*
 styles = []
 for (var i = 1; i < 16; i++) {
     styles.push(".ace_br" + i + "{" + (
@@ -9,6 +9,7 @@ for (var i = 1; i < 16; i++) {
 }
 styles.join("\\n")
 */
+module.exports = `
 .ace_br1 {border-top-left-radius    : 3px;}
 .ace_br2 {border-top-right-radius   : 3px;}
 .ace_br3 {border-top-left-radius    : 3px; border-top-right-radius:    3px;}

--- a/src/mouse/default_handlers.js
+++ b/src/mouse/default_handlers.js
@@ -79,9 +79,6 @@ function DefaultHandlers(mouseHandler) {
             editor.selection.moveToPosition(pos);
         if (!waitForClickSelection)
             this.select();
-        if (editor.renderer.scroller.setCapture) {
-            editor.renderer.scroller.setCapture();
-        }
         editor.setStyle("ace_selecting");
         this.setState("select");
     };
@@ -143,9 +140,6 @@ function DefaultHandlers(mouseHandler) {
     this.selectByLinesEnd = function() {
         this.$clickSelection = null;
         this.editor.unsetStyle("ace_selecting");
-        if (this.editor.renderer.scroller.releaseCapture) {
-            this.editor.renderer.scroller.releaseCapture();
-        }
     };
 
     this.focusWait = function() {

--- a/src/virtual_renderer_test.js
+++ b/src/virtual_renderer_test.js
@@ -11,7 +11,6 @@ var EditSession = require("./edit_session").EditSession;
 var VirtualRenderer = require("./virtual_renderer").VirtualRenderer;
 var vim = require("./keyboard/vim");
 var assert = require("./test/assertions");
-require("./ext/error_marker");
 
 function setScreenPosition(node, rect) {
     node.style.left = rect[0] + "px";
@@ -23,6 +22,11 @@ function setScreenPosition(node, rect) {
 var editor = null;
 module.exports = {
     setUp: function() {
+        require("./config").setLoader(function(moduleName, cb) {
+            if (moduleName == "ace/ext/error_marker")
+                return cb(null, require("./ext/error_marker"));
+        });
+        
         if (editor)
             editor.destroy();
         var el = document.createElement("div");
@@ -255,7 +259,7 @@ module.exports = {
             }
         ]);
         renderer.$loop._flush();
-        var context = renderer.$scrollDecorator.canvas.getContext();
+        var context = renderer.$scrollDecorator.canvas.getContext("2d");
         var imageData = context.getImageData(0, 0, 50, 50);
         var scrollDecoratorColors = renderer.$scrollDecorator.colors.light;
         var values = [


### PR DESCRIPTION
fixes https://github.com/ajaxorg/ace/issues/5047

The intention of this code was to keep cursor as text cursor while selecting, when mouse was over a fold widget or outside of the editor. But this worked only on firefox.

If we want to keep this behavior, we can add 
```js
editor.renderer.scroller.onpointerdown = function(e) {
  editor.renderer.scroller.setPointerCapture(e.pointerId)
}
```
if it doesn't cause problems on mobile.