### PR TITLE
Option to determine specific prefixes for quote insertion

### DIFF
--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -821,13 +821,18 @@ EditSession.$uid = 0;
     this.$modes = config.$modes;
 
     /**
-     * Sets a new text mode for the `EditSession`. This method also emits the `'changeMode'` event. If a [[BackgroundTokenizer `BackgroundTokenizer`]] is set, the `'tokenizerUpdate'` event is also emitted.
-     * @param {TextMode} mode Set a new text mode
-     * @param {cb} optional callback
-     *
-     **/
+     * 
+     * @type {TextMode|null}
+     */
     this.$mode = null;
     this.$modeId = null;
+    
+    /**
+     * Sets a new text mode for the `EditSession`. This method also emits the `'changeMode'` event. If a [[BackgroundTokenizer `BackgroundTokenizer`]] is set, the `'tokenizerUpdate'` event is also emitted.
+     * @param {TextMode} mode Set a new text mode
+     * @param {Function} cb optional callback
+     *
+     **/
     this.setMode = function(mode, cb) {
         if (mode && typeof mode === "object") {
             if (mode.getTokenizer)

--- a/src/mode/behaviour/behaviour_test.js
+++ b/src/mode/behaviour/behaviour_test.js
@@ -18,6 +18,7 @@ var XMLMode = require("../xml").Mode;
 var HTMLMode = require("../html").Mode;
 var CSSMode = require("../css").Mode;
 var MarkdownMode = require("../markdown").Mode;
+var PythonMode = require("../python").Mode;
 var editor;
 var exec = function(name, times, args) {
     do {
@@ -52,25 +53,25 @@ module.exports = {
         exec("addCursorBelow", 2);
 
         exec("insertstring", 1, "if ");
-        
-        // pairing ( 
+
+        // pairing (
         exec("insertstring", 1, "(");
         testValue("if ()");
         testSelection(0, 4);
         exec("insertstring", 1, ")");
         testValue("if ()");
         testSelection(0, 5);
-        
-        // pairing [ 
+
+        // pairing [
         exec("gotoleft", 1);
         exec("insertstring", 1, "[");
         testValue("if ([])");
         testSelection(0, 5);
-        
+
         exec("insertstring", 1, "]");
         testValue("if ([])");
         testSelection(0, 6);
-        
+
         // test deletion
         exec("gotoleft", 1);
         exec("backspace", 1);
@@ -81,22 +82,22 @@ module.exports = {
         exec("insertstring", 1, "{");
         testValue("if (){}");
         testSelection(0, 6);
-        
+
         exec("insertstring", 1, "}");
         testValue("if (){}");
         testSelection(0, 7);
-        
+
         exec("gotolinestart", 1);
         exec("insertstring", 1, "(");
         testValue("(if (){}");
         exec("backspace", 1);
-        
+
         editor.setValue("");
         exec("insertstring", 1, "{");
         assert.equal(editor.getValue(), "{");
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "{\n    \n}");
-        
+
         editor.setValue("");
         exec("insertstring", 1, "(");
         exec("insertstring", 1, '"');
@@ -105,7 +106,7 @@ module.exports = {
         exec("backspace", 1);
         exec("insertstring", 1, '"');
         assert.equal(editor.getValue(), '("")');
-        
+
         editor.setValue("('foo')", 1);
         exec("gotoleft", 1);
         exec("selectleft", 1);
@@ -118,7 +119,7 @@ module.exports = {
         exec("selectleft", 1);
         exec("insertstring", 1, '"');
         assert.equal(editor.getValue(), '("foo")');
-        
+
         editor.setValue("", 1);
         exec("selectleft", 1);
         exec("insertstring", 1, '"');
@@ -127,8 +128,8 @@ module.exports = {
         exec("insertstring", 1, 'n');
         exec("insertstring", 1, '"');
         assert.equal(editor.getValue(), '"\\n"');
-        
-        editor.setValue("");        
+
+        editor.setValue("");
         exec("insertstring", 1, '`');
         assert.equal(editor.getValue(), '``');
         exec("insertstring", 1, 'n');
@@ -153,13 +154,13 @@ module.exports = {
         assert.equal(editor.session.getLine(2), "    ");
         editor.session.setValue(["<OuterTag",
             "    <xyzrt"
-        ].join("\n"));        
+        ].join("\n"));
         exec("golinedown", 1);
         exec("gotolineend", 1);
         exec("selectleft", 3);
         exec("insertstring", 1, '>');
         assert.equal(editor.session.getLine(1), "    <xy></xy>");
-        
+
         editor.setValue(["<a x='11'",
             "<b a='",
             "   ",
@@ -179,7 +180,7 @@ module.exports = {
             " >  ",
             "'>     >"
         ].join("\n"));
-        
+
         editor.setValue("");
         "<div x='1'>".split("").forEach(function(ch) {
             exec("insertstring", 1, ch);
@@ -187,16 +188,16 @@ module.exports = {
         assert.equal(editor.getValue(), "<div x='1'></div>");
         exec("insertstring", 1, ">");
         assert.equal(editor.getValue(), "<div x='1'>></div>");
-        
+
         editor.setValue("<div '", 1);
         exec("selectleft", 1);
         exec("insertstring", 1, '"');
         assert.equal(editor.getValue(), "<div \"");
-        
+
         exec("selectleft", 1);
         exec("insertstring", 1, "'");
         assert.equal(editor.getValue(), "<div '");
-        
+
         exec("selectleft", 1);
         exec("insertstring", 1, "a");
         exec("selectleft", 1);
@@ -210,13 +211,13 @@ module.exports = {
         exec("selectleft", 1);
         exec("insertstring", 1, "'");
         assert.equal(editor.getValue(), "<div '");
-        
+
         editor.setWrapBehavioursEnabled(true);
         editor.setValue("<div a", 1);
         exec("selectleft", 1);
         exec("insertstring", 1, "'");
         assert.equal(editor.getValue(), "<div 'a'");
-        
+
         editor.setValue("<div a=></div>", 1);
         exec("gotoleft", 7);
         exec("insertstring", 1, '"');
@@ -225,7 +226,7 @@ module.exports = {
         exec("gotoright", 1);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "<div a=\"\">\n    \n</div>");
-        
+
         exec("undo", 1);
         assert.equal(editor.getValue(), "<div a=\"\"></div>");
         exec("gotoleft", 1);
@@ -237,26 +238,26 @@ module.exports = {
         assert.equal(editor.getValue(), "<div a=></div>");
         exec("backspace", 1);
         assert.equal(editor.getValue(), "<div a></div>");
-        
+
         editor.setValue("    <div><div>", 1);
         editor.selection.moveTo(0, 9);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "    <div>\n        <div>");
-        
+
         editor.setValue("  <div></div>", 1);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "  <div></div>\n  ");
-        
+
         editor.setValue("    <br><br>", 1);
         editor.selection.moveTo(0, 8);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "    <br>\n    <br>");
-        
+
         editor.setValue("<div a='x", 1);
         exec("gotoleft", 1);
         exec("insertstring", 1, ">");
         assert.equal(editor.getValue(), "<div a='>x");
-        
+
         editor.setValue("");
         "<!DOCTYPE html></div><link><a>".split("").forEach(function(ch) {
             exec("insertstring", 1, ch);
@@ -273,7 +274,7 @@ module.exports = {
         exec("backspace", 2);
         exec("insertstring", 1, "'");
         assert.equal(editor.getValue(), "'");
-        
+
         editor.session.setMode(new JavaScriptMode);
         editor.setValue("");
         exec("insertstring", 1, '"');
@@ -393,6 +394,17 @@ module.exports = {
         exec("insertstring", 1, "`");
         exec("insertstring", 1, "`");
         assert.equal(editor.getValue(), "``-``");
+    },
+    "test: python": function() {
+        editor.session.setMode(new PythonMode());
+        editor.setValue("f", 1);
+        exec("insertstring", 1, '"');
+        assert.equal(editor.getValue(), 'f""');
+
+        // there is no such prefix for python
+        editor.setValue("p", 1);
+        exec("insertstring", 1, '"');
+        assert.equal(editor.getValue(), 'p"');
     }
 };
 

--- a/src/mode/behaviour/behaviour_test.js
+++ b/src/mode/behaviour/behaviour_test.js
@@ -53,25 +53,25 @@ module.exports = {
         exec("addCursorBelow", 2);
 
         exec("insertstring", 1, "if ");
-
-        // pairing (
+        
+        // pairing ( 
         exec("insertstring", 1, "(");
         testValue("if ()");
         testSelection(0, 4);
         exec("insertstring", 1, ")");
         testValue("if ()");
         testSelection(0, 5);
-
-        // pairing [
+        
+        // pairing [ 
         exec("gotoleft", 1);
         exec("insertstring", 1, "[");
         testValue("if ([])");
         testSelection(0, 5);
-
+        
         exec("insertstring", 1, "]");
         testValue("if ([])");
         testSelection(0, 6);
-
+        
         // test deletion
         exec("gotoleft", 1);
         exec("backspace", 1);
@@ -82,22 +82,22 @@ module.exports = {
         exec("insertstring", 1, "{");
         testValue("if (){}");
         testSelection(0, 6);
-
+        
         exec("insertstring", 1, "}");
         testValue("if (){}");
         testSelection(0, 7);
-
+        
         exec("gotolinestart", 1);
         exec("insertstring", 1, "(");
         testValue("(if (){}");
         exec("backspace", 1);
-
+        
         editor.setValue("");
         exec("insertstring", 1, "{");
         assert.equal(editor.getValue(), "{");
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "{\n    \n}");
-
+        
         editor.setValue("");
         exec("insertstring", 1, "(");
         exec("insertstring", 1, '"');
@@ -106,7 +106,7 @@ module.exports = {
         exec("backspace", 1);
         exec("insertstring", 1, '"');
         assert.equal(editor.getValue(), '("")');
-
+        
         editor.setValue("('foo')", 1);
         exec("gotoleft", 1);
         exec("selectleft", 1);
@@ -119,7 +119,7 @@ module.exports = {
         exec("selectleft", 1);
         exec("insertstring", 1, '"');
         assert.equal(editor.getValue(), '("foo")');
-
+        
         editor.setValue("", 1);
         exec("selectleft", 1);
         exec("insertstring", 1, '"');
@@ -128,8 +128,8 @@ module.exports = {
         exec("insertstring", 1, 'n');
         exec("insertstring", 1, '"');
         assert.equal(editor.getValue(), '"\\n"');
-
-        editor.setValue("");
+        
+        editor.setValue("");        
         exec("insertstring", 1, '`');
         assert.equal(editor.getValue(), '``');
         exec("insertstring", 1, 'n');
@@ -154,13 +154,13 @@ module.exports = {
         assert.equal(editor.session.getLine(2), "    ");
         editor.session.setValue(["<OuterTag",
             "    <xyzrt"
-        ].join("\n"));
+        ].join("\n"));        
         exec("golinedown", 1);
         exec("gotolineend", 1);
         exec("selectleft", 3);
         exec("insertstring", 1, '>');
         assert.equal(editor.session.getLine(1), "    <xy></xy>");
-
+        
         editor.setValue(["<a x='11'",
             "<b a='",
             "   ",
@@ -180,7 +180,7 @@ module.exports = {
             " >  ",
             "'>     >"
         ].join("\n"));
-
+        
         editor.setValue("");
         "<div x='1'>".split("").forEach(function(ch) {
             exec("insertstring", 1, ch);
@@ -188,16 +188,16 @@ module.exports = {
         assert.equal(editor.getValue(), "<div x='1'></div>");
         exec("insertstring", 1, ">");
         assert.equal(editor.getValue(), "<div x='1'>></div>");
-
+        
         editor.setValue("<div '", 1);
         exec("selectleft", 1);
         exec("insertstring", 1, '"');
         assert.equal(editor.getValue(), "<div \"");
-
+        
         exec("selectleft", 1);
         exec("insertstring", 1, "'");
         assert.equal(editor.getValue(), "<div '");
-
+        
         exec("selectleft", 1);
         exec("insertstring", 1, "a");
         exec("selectleft", 1);
@@ -211,13 +211,13 @@ module.exports = {
         exec("selectleft", 1);
         exec("insertstring", 1, "'");
         assert.equal(editor.getValue(), "<div '");
-
+        
         editor.setWrapBehavioursEnabled(true);
         editor.setValue("<div a", 1);
         exec("selectleft", 1);
         exec("insertstring", 1, "'");
         assert.equal(editor.getValue(), "<div 'a'");
-
+        
         editor.setValue("<div a=></div>", 1);
         exec("gotoleft", 7);
         exec("insertstring", 1, '"');
@@ -226,7 +226,7 @@ module.exports = {
         exec("gotoright", 1);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "<div a=\"\">\n    \n</div>");
-
+        
         exec("undo", 1);
         assert.equal(editor.getValue(), "<div a=\"\"></div>");
         exec("gotoleft", 1);
@@ -238,26 +238,26 @@ module.exports = {
         assert.equal(editor.getValue(), "<div a=></div>");
         exec("backspace", 1);
         assert.equal(editor.getValue(), "<div a></div>");
-
+        
         editor.setValue("    <div><div>", 1);
         editor.selection.moveTo(0, 9);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "    <div>\n        <div>");
-
+        
         editor.setValue("  <div></div>", 1);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "  <div></div>\n  ");
-
+        
         editor.setValue("    <br><br>", 1);
         editor.selection.moveTo(0, 8);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "    <br>\n    <br>");
-
+        
         editor.setValue("<div a='x", 1);
         exec("gotoleft", 1);
         exec("insertstring", 1, ">");
         assert.equal(editor.getValue(), "<div a='>x");
-
+        
         editor.setValue("");
         "<!DOCTYPE html></div><link><a>".split("").forEach(function(ch) {
             exec("insertstring", 1, ch);
@@ -274,7 +274,7 @@ module.exports = {
         exec("backspace", 2);
         exec("insertstring", 1, "'");
         assert.equal(editor.getValue(), "'");
-
+        
         editor.session.setMode(new JavaScriptMode);
         editor.setValue("");
         exec("insertstring", 1, '"');
@@ -287,6 +287,16 @@ module.exports = {
         exec("insertstring", 1, '`');
         exec("insertstring", 1, 'b');
         assert.equal(editor.getValue(), "`b`");
+
+        editor.setValue("");
+        exec("insertstring", 1, 'a');
+        exec("insertstring", 1, "'");
+        assert.equal(editor.getValue(), "a'");
+
+        editor.setValue("");
+        exec("insertstring", 1, 'b');
+        exec("insertstring", 1, "`");
+        assert.equal(editor.getValue(), "b``");
     },
     "test: css": function() {
         editor.session.setMode(new CSSMode());

--- a/src/mode/behaviour/cstyle.js
+++ b/src/mode/behaviour/cstyle.js
@@ -49,9 +49,8 @@ var getWrapped = function(selection, selected, opening, closing) {
 /**
  * Creates a new Cstyle behaviour object with the specified options.
  * @constructor
- * @param {Object} options - The options for the Cstyle behaviour object.
- * @param {boolean} options.braces - Whether to force braces auto-pairing.
- * @param {{[quote: string]: RegExp}} options.pairQuotesAfter - An object containing conditions to determine whether to apply matching quote or not.
+ * @param {Object} [options] - The options for the Cstyle behaviour object.
+ * @param {boolean} [options.braces] - Whether to force braces auto-pairing.
  */
 var CstyleBehaviour = function(options) {
     this.add("braces", "insertion", function(state, action, editor, session, text) {
@@ -267,10 +266,11 @@ var CstyleBehaviour = function(options) {
                     var isWordBefore = wordRe.test(leftChar);
                     wordRe.lastIndex = 0;
                     var isWordAfter = wordRe.test(rightChar);
-                    var pairQuotesAfter = options && options.pairQuotesAfter && options.pairQuotesAfter[quotes[text]]
-                        && options.pairQuotesAfter[quotes[text]].test(leftChar);
+
+                    var pairQuotesAfter = session.$mode.$pairQuotesAfter;
+                    var shouldPairQuotes = pairQuotesAfter && pairQuotesAfter[quote] && pairQuotesAfter[quote].test(leftChar);
                     
-                    if ((!pairQuotesAfter && isWordBefore) || isWordAfter)
+                    if ((!shouldPairQuotes && isWordBefore) || isWordAfter)
                         return null; // before or after alphanumeric
                     if (rightChar && !/[\s;,.})\]\\]/.test(rightChar))
                         return null; // there is rightChar and it isn't closing

--- a/src/mode/behaviour/cstyle.js
+++ b/src/mode/behaviour/cstyle.js
@@ -51,9 +51,7 @@ var getWrapped = function(selection, selected, opening, closing) {
  * @constructor
  * @param {Object} options - The options for the Cstyle behaviour object.
  * @param {boolean} options.braces - Whether to force braces auto-pairing.
- * @param {Object[]} options.quotesPrefixes - An array of objects containing information about quotes prefixes.
- * @param {RegExp} options.quotesPrefixes[].quotes - The regular expression used to determine which quote type the prefix applies to.
- * @param {RegExp} options.quotesPrefixes[].condition - The regular expression used to determine if the character on the left of the quote is suitable.
+ * @param {{[quote: string]: RegExp}} options.pairQuotesAfter - An object containing conditions to determine whether to apply matching quote or not.
  */
 var CstyleBehaviour = function(options) {
     this.add("braces", "insertion", function(state, action, editor, session, text) {
@@ -269,18 +267,10 @@ var CstyleBehaviour = function(options) {
                     var isWordBefore = wordRe.test(leftChar);
                     wordRe.lastIndex = 0;
                     var isWordAfter = wordRe.test(rightChar);
-                    var hasStringPrefixes = false;
-                    if (options && options.quotesPrefixes && Array.isArray(options.quotesPrefixes)) {
-                        for (var prefix of options.quotesPrefixes) {
-                            if (prefix.quotes && prefix.condition && prefix.quotes instanceof RegExp
-                                && prefix.quotes.test(quotes[text]) && prefix.condition instanceof RegExp
-                                && prefix.condition.test(leftChar)) {
-                                hasStringPrefixes = true;
-                                break;
-                            }
-                        }
-                    }
-                    if ((!hasStringPrefixes && isWordBefore) || isWordAfter)
+                    var pairQuotesAfter = options && options.pairQuotesAfter && options.pairQuotesAfter[quotes[text]]
+                        && options.pairQuotesAfter[quotes[text]].test(leftChar);
+                    
+                    if ((!pairQuotesAfter && isWordBefore) || isWordAfter)
                         return null; // before or after alphanumeric
                     if (rightChar && !/[\s;,.})\]\\]/.test(rightChar))
                         return null; // there is rightChar and it isn't closing

--- a/src/mode/behaviour/cstyle.js
+++ b/src/mode/behaviour/cstyle.js
@@ -223,7 +223,7 @@ var CstyleBehaviour = function(options) {
     this.add("string_dquotes", "insertion", function(state, action, editor, session, text) {
         var quotes = session.$mode.$quotes || defaultQuotes;
         if (text.length == 1 && quotes[text]) {
-            if (this.lineCommentStart && this.lineCommentStart.indexOf(text) != -1) 
+            if (this.lineCommentStart && this.lineCommentStart.indexOf(text) != -1)
                 return;
             initContext(editor);
             var quote = text;
@@ -236,16 +236,16 @@ var CstyleBehaviour = function(options) {
                 var line = session.doc.getLine(cursor.row);
                 var leftChar = line.substring(cursor.column-1, cursor.column);
                 var rightChar = line.substring(cursor.column, cursor.column + 1);
-                
+
                 var token = session.getTokenAt(cursor.row, cursor.column);
                 var rightToken = session.getTokenAt(cursor.row, cursor.column + 1);
                 // We're escaped.
                 if (leftChar == "\\" && token && /escape/.test(token.type))
                     return null;
-                
+
                 var stringBefore = token && /string|escape/.test(token.type);
                 var stringAfter = !rightToken || /string|escape/.test(rightToken.type);
-                
+
                 var pair;
                 if (rightChar == quote) {
                     pair = stringBefore !== stringAfter;
@@ -260,8 +260,11 @@ var CstyleBehaviour = function(options) {
                     wordRe.lastIndex = 0;
                     var isWordBefore = wordRe.test(leftChar);
                     wordRe.lastIndex = 0;
-                    var isWordAfter = wordRe.test(leftChar);
-                    if (isWordBefore || isWordAfter)
+                    var isWordAfter = wordRe.test(rightChar);
+                    let hasStringPrefixes = (options && options.quotePrefixes &&
+                        Array.isArray(options.quotePrefixes)) ? options.quotePrefixes.includes(leftChar) : null;
+
+                    if ((!hasStringPrefixes && isWordBefore) || isWordAfter)
                         return null; // before or after alphanumeric
                     if (rightChar && !/[\s;,.})\]\\]/.test(rightChar))
                         return null; // there is rightChar and it isn't closing
@@ -295,11 +298,11 @@ var CstyleBehaviour = function(options) {
 
 };
 
-    
+
 CstyleBehaviour.isSaneInsertion = function(editor, session) {
     var cursor = editor.getCursorPosition();
     var iterator = new TokenIterator(session, cursor.row, cursor.column);
-    
+
     // Don't insert in the middle of a keyword/identifier/lexical
     if (!this.$matchTokenType(iterator.getCurrentToken() || "text", SAFE_INSERT_IN_TOKENS)) {
         if (/[)}\]]/.test(editor.session.getLine(cursor.row)[cursor.column]))
@@ -309,7 +312,7 @@ CstyleBehaviour.isSaneInsertion = function(editor, session) {
         if (!this.$matchTokenType(iterator2.getCurrentToken() || "text", SAFE_INSERT_IN_TOKENS))
             return false;
     }
-    
+
     // Only insert in front of whitespace/comments
     iterator.stepForward();
     return iterator.getCurrentTokenRow() !== cursor.row ||

--- a/src/mode/javascript.js
+++ b/src/mode/javascript.js
@@ -10,9 +10,16 @@ var CStyleFoldMode = require("./folding/cstyle").FoldMode;
 
 var Mode = function() {
     this.HighlightRules = JavaScriptHighlightRules;
-    
+
     this.$outdent = new MatchingBraceOutdent();
-    this.$behaviour = new CstyleBehaviour();
+    this.$behaviour = new CstyleBehaviour({
+        quotesPrefixes: [
+            {
+                quotes: new RegExp("`"),
+                condition: new RegExp("\\w")
+            }
+        ]
+    });
     this.foldingRules = new CStyleFoldMode();
 };
 oop.inherits(Mode, TextMode);

--- a/src/mode/javascript.js
+++ b/src/mode/javascript.js
@@ -13,12 +13,9 @@ var Mode = function() {
 
     this.$outdent = new MatchingBraceOutdent();
     this.$behaviour = new CstyleBehaviour({
-        quotesPrefixes: [
-            {
-                quotes: new RegExp("`"),
-                condition: new RegExp("\\w")
-            }
-        ]
+        pairQuotesAfter: {
+            "`": /\w/
+        }
     });
     this.foldingRules = new CStyleFoldMode();
 };

--- a/src/mode/javascript.js
+++ b/src/mode/javascript.js
@@ -12,11 +12,7 @@ var Mode = function() {
     this.HighlightRules = JavaScriptHighlightRules;
 
     this.$outdent = new MatchingBraceOutdent();
-    this.$behaviour = new CstyleBehaviour({
-        pairQuotesAfter: {
-            "`": /\w/
-        }
-    });
+    this.$behaviour = new CstyleBehaviour();
     this.foldingRules = new CStyleFoldMode();
 };
 oop.inherits(Mode, TextMode);
@@ -26,6 +22,9 @@ oop.inherits(Mode, TextMode);
     this.lineCommentStart = "//";
     this.blockComment = {start: "/*", end: "*/"};
     this.$quotes = {'"': '"', "'": "'", "`": "`"};
+    this.$pairQuotesAfter = {
+        "`": /\w/
+    };
 
     this.getNextLineIndent = function(state, line, tab) {
         var indent = this.$getIndent(line);

--- a/src/mode/python.js
+++ b/src/mode/python.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var oop = require("../lib/oop");
+var CstyleBehaviour = require("./behaviour/cstyle").CstyleBehaviour;
 var TextMode = require("./text").Mode;
 var PythonHighlightRules = require("./python_highlight_rules").PythonHighlightRules;
 var PythonFoldMode = require("./folding/pythonic").FoldMode;
@@ -9,7 +10,7 @@ var Range = require("../range").Range;
 var Mode = function() {
     this.HighlightRules = PythonHighlightRules;
     this.foldingRules = new PythonFoldMode("\\:");
-    this.$behaviour = this.$defaultBehaviour;
+    this.$behaviour = new CstyleBehaviour({quotePrefixes: ["f", "F", "u", "U", "r", "R"]});
 };
 oop.inherits(Mode, TextMode);
 
@@ -44,31 +45,31 @@ oop.inherits(Mode, TextMode);
         "break": 1,
         "continue": 1
     };
-    
+
     this.checkOutdent = function(state, line, input) {
         if (input !== "\r\n" && input !== "\r" && input !== "\n")
             return false;
 
         var tokens = this.getTokenizer().getLineTokens(line.trim(), state).tokens;
-        
+
         if (!tokens)
             return false;
-        
+
         // ignore trailing comments
         do {
             var last = tokens.pop();
         } while (last && (last.type == "comment" || (last.type == "text" && last.value.match(/^\s+$/))));
-        
+
         if (!last)
             return false;
-        
+
         return (last.type == "keyword" && outdents[last.value]);
     };
 
     this.autoOutdent = function(state, doc, row) {
         // outdenting in python is slightly different because it always applies
         // to the next line and only of a new line is inserted
-        
+
         row += 1;
         var indent = this.$getIndent(doc.getLine(row));
         var tab = doc.getTabString();

--- a/src/mode/python.js
+++ b/src/mode/python.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var oop = require("../lib/oop");
-var CstyleBehaviour = require("./behaviour/cstyle").CstyleBehaviour;
 var TextMode = require("./text").Mode;
 var PythonHighlightRules = require("./python_highlight_rules").PythonHighlightRules;
 var PythonFoldMode = require("./folding/pythonic").FoldMode;
@@ -10,18 +9,17 @@ var Range = require("../range").Range;
 var Mode = function() {
     this.HighlightRules = PythonHighlightRules;
     this.foldingRules = new PythonFoldMode("\\:");
-    this.$behaviour = new CstyleBehaviour({
-        pairQuotesAfter: {
-            "'": /[ruf]/i,
-            '"': /[ruf]/i
-        }
-    });
+    this.$behaviour = this.$defaultBehaviour;
 };
 oop.inherits(Mode, TextMode);
 
 (function() {
 
     this.lineCommentStart = "#";
+    this.$pairQuotesAfter = {
+        "'": /[ruf]/i,
+        '"': /[ruf]/i
+    };
 
     this.getNextLineIndent = function(state, line, tab) {
         var indent = this.$getIndent(line);

--- a/src/mode/python.js
+++ b/src/mode/python.js
@@ -10,7 +10,14 @@ var Range = require("../range").Range;
 var Mode = function() {
     this.HighlightRules = PythonHighlightRules;
     this.foldingRules = new PythonFoldMode("\\:");
-    this.$behaviour = new CstyleBehaviour({quotePrefixes: ["f", "F", "u", "U", "r", "R"]});
+    this.$behaviour = new CstyleBehaviour({
+        quotesPrefixes: [
+            {
+                quotes: new RegExp("['\"]"),
+                condition: new RegExp("[ruf]", "i")
+            }
+        ]
+    });
 };
 oop.inherits(Mode, TextMode);
 
@@ -45,31 +52,31 @@ oop.inherits(Mode, TextMode);
         "break": 1,
         "continue": 1
     };
-
+    
     this.checkOutdent = function(state, line, input) {
         if (input !== "\r\n" && input !== "\r" && input !== "\n")
             return false;
 
         var tokens = this.getTokenizer().getLineTokens(line.trim(), state).tokens;
-
+        
         if (!tokens)
             return false;
-
+        
         // ignore trailing comments
         do {
             var last = tokens.pop();
         } while (last && (last.type == "comment" || (last.type == "text" && last.value.match(/^\s+$/))));
-
+        
         if (!last)
             return false;
-
+        
         return (last.type == "keyword" && outdents[last.value]);
     };
 
     this.autoOutdent = function(state, doc, row) {
         // outdenting in python is slightly different because it always applies
         // to the next line and only of a new line is inserted
-
+        
         row += 1;
         var indent = this.$getIndent(doc.getLine(row));
         var tab = doc.getTabString();

--- a/src/mode/python.js
+++ b/src/mode/python.js
@@ -11,12 +11,10 @@ var Mode = function() {
     this.HighlightRules = PythonHighlightRules;
     this.foldingRules = new PythonFoldMode("\\:");
     this.$behaviour = new CstyleBehaviour({
-        quotesPrefixes: [
-            {
-                quotes: new RegExp("['\"]"),
-                condition: new RegExp("[ruf]", "i")
-            }
-        ]
+        pairQuotesAfter: {
+            "'": /[ruf]/i,
+            '"': /[ruf]/i
+        }
     });
 };
 oop.inherits(Mode, TextMode);

--- a/src/mode/text.js
+++ b/src/mode/text.js
@@ -9,6 +9,20 @@ var lang = require("../lib/lang");
 var TokenIterator = require("../token_iterator").TokenIterator;
 var Range = require("../range").Range;
 
+/**
+ *
+ * @constructor
+ * @alias TextMode
+ * @property {{[quote: string]: string}} [$quotes] - quotes used by language mode
+ * @property {string} lineCommentStart - characters that indicate the start of a line comment
+ * @property {{start: string, end: string}} [blockComment] - characters that indicate the start and end of a block comment
+ * @property {TextHighlightRules} HighlightRules - language specific highlighters
+ * @property {FoldMode} foldingRules - language specific folding rules
+ * @property {MatchingBraceOutdent} $outdent
+ * @property {RegExp} tokenRe
+ * @property {RegExp} nonTokenRe
+ * @property {{[quote: string]: RegExp}} [$pairQuotesAfter] - An object containing conditions to determine whether to apply matching quote or not.
+ */
 var Mode = function() {
     this.HighlightRules = TextHighlightRules;
 };


### PR DESCRIPTION
*Issue #, if available:* #5063

*Description of changes:*
- add option for modes quote prefixes (separate conditions for each quote, if it's necessary)
- fix small bug with checking `leftChar` for `isWordAfter` instead of `rightChar`
- Add backtick auto insertion after `word` for Javascript mode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
