### PR TITLE
Fix typo in naming openCommandPalette action

### DIFF
--- a/src/commands/default_commands.js
+++ b/src/commands/default_commands.js
@@ -854,7 +854,7 @@ exports.commands = [{
     multiSelectAction: "forEach",
     scrollIntoView: "cursor"
 }, {
-    name: "openCommandPallete",
+    name: "openCommandPalette",
     description: "Open command palette",
     bindKey: bindKey("F1", "F1"),
     exec: function(editor) {

--- a/src/keyboard/vscode.js
+++ b/src/keyboard/vscode.js
@@ -128,7 +128,7 @@ exports.handler.addCommands([{
     name: "goToNextError"
 }, {
     bindKey: {mac: "Command-Shift-P|F1", win: "Ctrl-Shift-P|F1"},
-    name: "openCommandPallete"
+    name: "openCommandPalette"
 }, {
     bindKey: {mac: "Shift-Option-Up", win: "Alt-Shift-Up"},
     name: "copylinesup"

--- a/src/mouse/touch_handler.js
+++ b/src/mouse/touch_handler.js
@@ -34,7 +34,7 @@ exports.addTouchListeners = function(el, editor) {
                     clipboard && ["span", { class: "ace_mobile-button", action: "paste" }, "Paste"],
                     hasUndo && ["span", { class: "ace_mobile-button", action: "undo" }, "Undo"],
                     ["span", { class: "ace_mobile-button", action: "find" }, "Find"],
-                    ["span", { class: "ace_mobile-button", action: "openCommandPallete" }, "Palette"]
+                    ["span", { class: "ace_mobile-button", action: "openCommandPalette" }, "Palette"]
                 ] : ["span"]),
                 contextMenu.firstChild
             );
@@ -62,7 +62,7 @@ exports.addTouchListeners = function(el, editor) {
             }
             contextMenu.firstChild.style.display = "none";
             isOpen = false;
-            if (action != "openCommandPallete")
+            if (action != "openCommandPalette")
                 editor.focus();
         };
         contextMenu = dom.buildDom(["div",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Typo in the naming of `openCommandPalette` action

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
