### PR TITLE
prevent unwanted zoom on mobile when viewport is not specified

### DIFF
--- a/src/virtual_renderer.js
+++ b/src/virtual_renderer.js
@@ -18,7 +18,6 @@ var editorCss = require("./css/editor.css");
 var Decorator = require("./layer/decorators").Decorator;
 
 var useragent = require("./lib/useragent");
-var HIDE_TEXTAREA = useragent.isIE;
 
 dom.importCssString(editorCss, "ace_editor.css", false);
 
@@ -632,7 +631,7 @@ var VirtualRenderer = function(container, theme) {
         var posLeft = pixelPos.left;
         posTop -= config.offset;
 
-        var h = composition && composition.useTextareaForIME ? this.lineHeight : HIDE_TEXTAREA ? 0 : 1;
+        var h = composition && composition.useTextareaForIME || useragent.isMobile ? this.lineHeight : 1;
         if (posTop < 0 || posTop > config.height - h) {
             dom.translate(this.textarea, 0, 0);
             return;


### PR DESCRIPTION
when `<meta name="viewport" content="width=device-width,height=device-height" />` is not specified like on ace.c9.io, browser attempts to zoom page when editor is clicked, and with 1px height it was zooming too much.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
