### PR TITLE
fix: add updated monospace font for Windows

### DIFF
--- a/src/css/editor.css.js
+++ b/src/css/editor.css.js
@@ -31,7 +31,7 @@ module.exports = `
     position: relative;
     overflow: hidden;
     padding: 0;
-    font: 12px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+    font: 12px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace;
     direction: ltr;
     text-align: left;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);

--- a/src/ext/static.css.js
+++ b/src/ext/static.css.js
@@ -1,5 +1,5 @@
 module.exports = `.ace_static_highlight {
-    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', 'Droid Sans Mono', monospace;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', 'Droid Sans Mono', monospace;
     font-size: 12px;
     white-space: pre-wrap
 }


### PR DESCRIPTION
*Description of changes:*

This PR adds a "Source Code Pro" font, which is available in newer windows versions. This addresses the same issue as ace-builds PR https://github.com/ajaxorg/ace-builds/pull/63.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
