### PR TITLE
Resize observer

### DIFF
--- a/doc/site/js/main.js
+++ b/doc/site/js/main.js
@@ -153,12 +153,6 @@ $(function() {
             $.bbq.pushState(state);
      });
 
-    $('#tabnav a[data-toggle="tab"]').on('shown', function (e) {
-        $(".tab-content .tab-pane.active .ace_editor").each(function(i, el){
-            el.env.onResize();
-        });
-    });
-
     $(window).on("hashchange", function(e) {
         _gaq.push(['_trackPageview',location.pathname + location.search  + location.hash]);
         tabs.each(function() {

--- a/doc/site/style.css
+++ b/doc/site/style.css
@@ -497,3 +497,5 @@ img {
 .nav>li>a.external-nav:hover {
     text-decoration: underline;
 }
+
+pre { background-color: white!important }

--- a/src/ace.js
+++ b/src/ace.js
@@ -8,7 +8,6 @@
 "include loader_build";
 
 var dom = require("./lib/dom");
-var event = require("./lib/event");
 
 var Range = require("./range").Range;
 var Editor = require("./editor").Editor;
@@ -66,9 +65,7 @@ exports.edit = function(el, options) {
         onResize: editor.resize.bind(editor, null)
     };
     if (oldNode) env.textarea = oldNode;
-    event.addListener(window, "resize", env.onResize);
     editor.on("destroy", function() {
-        event.removeListener(window, "resize", env.onResize);
         env.editor.container.env = null; // prevent memory leak on old ie
     });
     editor.container.env = editor.env = env;

--- a/src/editor.js
+++ b/src/editor.js
@@ -2897,6 +2897,7 @@ config.defineOptions(Editor.prototype, "editor", {
     hasCssTransforms: "renderer",
     maxPixelHeight: "renderer",
     useTextareaForIME: "renderer",
+    useResizeObserver: "renderer",
 
     scrollSpeed: "$mouseHandler",
     dragDelay: "$mouseHandler",


### PR DESCRIPTION
users too often forget to call editor.resize after changing the size of the editor.
Since ResizeObserver is now supported on all browsers we can check for size changes ourselves.
I have added an option in case someone needs more fine grained control over resize during the animations.

includes https://github.com/ajaxorg/ace/pull/5094 to use the dialog in kitchen-sink added by it.