### PR TITLE
fix bracket highlighting for brackets in open/close tags

### DIFF
--- a/src/edit_session/bracket_match.js
+++ b/src/edit_session/bracket_match.js
@@ -126,6 +126,7 @@ function BracketMatch() {
                 "(\\.?" +
                 token.type.replace(".", "\\.").replace("rparen", ".paren")
                     .replace(/\b(?:end)\b/, "(?:start|begin|end)")
+                    .replace(/-close\b/, "-(close|open)")
                 + ")+"
             );
         }
@@ -183,6 +184,7 @@ function BracketMatch() {
                 "(\\.?" +
                 token.type.replace(".", "\\.").replace("lparen", ".paren")
                     .replace(/\b(?:start|begin)\b/, "(?:start|begin|end)")
+                    .replace(/-open\b/, "-(close|open)")
                 + ")+"
             );
         }


### PR DESCRIPTION
fixes issue introduced by token name change in https://github.com/ajaxorg/ace/pull/5098, when { } did not match due to different token name
