### PR TITLE
Add option to prevent keyboard focus trapping

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -227,7 +227,7 @@ export namespace Ace {
     value: string;
     session: EditSession;
     relativeLineNumbers: boolean;
-    preventKeyboardTrapping: boolean;
+    keyboardAccessibilityMode: 'content' | 'off';
   }
 
   export interface SearchOptions {

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -226,6 +226,7 @@ export namespace Ace {
     value: string;
     session: EditSession;
     relativeLineNumbers: boolean;
+    preventKeyboardTrapping: boolean;
   }
 
   export interface SearchOptions {

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -227,7 +227,7 @@ export namespace Ace {
     value: string;
     session: EditSession;
     relativeLineNumbers: boolean;
-    keyboardAccessibilityMode: 'content' | 'off';
+    enableKeyboardAccessibility: boolean;
   }
 
   export interface SearchOptions {

--- a/src/commands/default_commands.js
+++ b/src/commands/default_commands.js
@@ -17,6 +17,7 @@ exports.commands = [{
     description: "Show settings menu",
     bindKey: bindKey("Ctrl-,", "Command-,"),
     exec: function(editor) {
+        console.log("show settings");
         config.loadModule("ace/ext/settings_menu", function(module) {
             module.init(editor);
             editor.showSettingsMenu();
@@ -35,6 +36,15 @@ exports.commands = [{
     scrollIntoView: "animate",
     readOnly: true
 }, {
+    name: "blurTextInput",
+    description: "Set focus to the editor content div to allow tabbing through the page",
+    bindKey: "Esc",
+    exec: function(editor) {
+        editor.blur();
+        editor.renderer.content.focus();
+    },
+    readOnly: false
+},  {
     name: "goToPreviousError",
     description: "Go to previous error",
     bindKey: bindKey("Alt-Shift-E", "Shift-F4"),

--- a/src/commands/default_commands.js
+++ b/src/commands/default_commands.js
@@ -34,7 +34,7 @@ exports.commands = [{
     },
     scrollIntoView: "animate",
     readOnly: true
-},  {
+}, {
     name: "goToPreviousError",
     description: "Go to previous error",
     bindKey: bindKey("Alt-Shift-E", "Shift-F4"),

--- a/src/commands/default_commands.js
+++ b/src/commands/default_commands.js
@@ -17,7 +17,6 @@ exports.commands = [{
     description: "Show settings menu",
     bindKey: bindKey("Ctrl-,", "Command-,"),
     exec: function(editor) {
-        console.log("show settings");
         config.loadModule("ace/ext/settings_menu", function(module) {
             module.init(editor);
             editor.showSettingsMenu();
@@ -35,15 +34,6 @@ exports.commands = [{
     },
     scrollIntoView: "animate",
     readOnly: true
-}, {
-    name: "blurTextInput",
-    description: "Set focus to the editor content div to allow tabbing through the page",
-    bindKey: "Esc",
-    exec: function(editor) {
-        editor.blur();
-        editor.renderer.content.focus();
-    },
-    readOnly: false
 },  {
     name: "goToPreviousError",
     description: "Go to previous error",

--- a/src/css/editor.css.js
+++ b/src/css/editor.css.js
@@ -58,7 +58,7 @@ module.exports = `
     font-variant-ligatures: no-common-ligatures;
 }
 
-.ace_content:focus {
+.ace_keyboard-focus:focus {
     box-shadow: inset 0 0 0 2px #5E9ED6;
     outline: none;
 }

--- a/src/css/editor.css.js
+++ b/src/css/editor.css.js
@@ -58,6 +58,11 @@ module.exports = `
     font-variant-ligatures: no-common-ligatures;
 }
 
+.ace_content:focus {
+    box-shadow: inset 0 0 0 2px #5E9ED6;
+    outline: none;
+}
+
 .ace_dragging .ace_scroller:before{
     position: absolute;
     top: 0;

--- a/src/editor.js
+++ b/src/editor.js
@@ -2859,7 +2859,7 @@ config.defineOptions(Editor.prototype, "editor", {
             this.$updatePlaceholder();
         }
     },
-    preventKeyboardTrapping: {
+    keyboardAccessibilityMode: {
         set: function(value) {
             var blurCommand = {
                 name: "blurTextInput",
@@ -2882,21 +2882,25 @@ config.defineOptions(Editor.prototype, "editor", {
 
             // If true, prevent focus to be captured when tabbing through the page. When focus is set to the content div, 
             // press Enter key to give focus to Ace and press Esc to allow again to tab through the page.
-            if (value){
+            if (value === 'content'){
                 this.textInput.getElement().setAttribute("tabindex", -1);
                 this.renderer.content.setAttribute("tabindex", 0);
+                this.renderer.content.setAttribute("aria-label",
+                    "Editor, press Enter key to start editing, press Escape key to exit"
+                );
 
                 this.renderer.content.addEventListener("keydown", focusCommand.bind(this));
                 this.commands.addCommand(blurCommand);
-            } else {
+            } else if (value === 'off') {
                 this.textInput.getElement().setAttribute("tabindex", 0);
                 this.renderer.content.setAttribute("tabindex", -1);
-
+                this.renderer.content.setAttribute("aria-label", "");
+            
                 this.renderer.content.removeEventListener("keydown", focusCommand.bind(this));
                 this.commands.removeCommand(blurCommand);
             }
         },
-        initialValue: false
+        initialValue: 'off'
     },
     customScrollbar: "renderer",
     hScrollBarAlwaysVisible: "renderer",

--- a/src/editor.js
+++ b/src/editor.js
@@ -50,6 +50,23 @@ class Editor {
             new FoldHandler(this);
         }
 
+        // TODO: move to editor options
+        var preventKeyboardTrapping = true;
+
+        // if preventKeyboardTrapping is true, prevent direct stepping into the text input 
+        // and set focus only on keypress.
+        if (preventKeyboardTrapping){
+            this.textInput.getElement().setAttribute("tabindex", -1);
+            this.renderer.content.setAttribute("tabindex", 0);
+            this.renderer.content.addEventListener("keydown", (e) => {
+                if (e.target == this.renderer.content && e.keyCode === 13){
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.focus();
+                }
+            });
+        }
+
         this.keyBinding = new KeyBinding(this);
 
         this.$search = new Search().set({

--- a/src/editor.js
+++ b/src/editor.js
@@ -19,6 +19,7 @@ var TokenIterator = require("./token_iterator").TokenIterator;
 var LineWidgets = require("./line_widgets").LineWidgets;
 
 var clipboard = require("./clipboard");
+var keys = require('./lib/keys');
 
 /**
  * The main entry point into the Ace functionality.
@@ -2872,8 +2873,7 @@ config.defineOptions(Editor.prototype, "editor", {
             };
 
             var focusCommand = function (e) {
-                // Keycode 13 == enter key.
-                if (e.target == this.renderer.content && e.keyCode === 13){
+                if (e.target == this.renderer.content && e.keyCode === keys['enter']){
                     e.stopPropagation();
                     e.preventDefault();
                     this.focus();
@@ -2886,13 +2886,13 @@ config.defineOptions(Editor.prototype, "editor", {
                 this.textInput.getElement().setAttribute("tabindex", -1);
                 this.renderer.content.setAttribute("tabindex", 0);
 
-                this.renderer.content.addEventListener("keydown", focusCommand);
+                this.renderer.content.addEventListener("keydown", focusCommand.bind(this));
                 this.commands.addCommand(blurCommand);
             } else {
                 this.textInput.getElement().setAttribute("tabindex", 0);
                 this.renderer.content.setAttribute("tabindex", -1);
 
-                this.renderer.content.removeEventListener("keydown", focusCommand);
+                this.renderer.content.removeEventListener("keydown", focusCommand.bind(this));
                 this.commands.removeCommand(blurCommand);
             }
         },

--- a/src/editor.js
+++ b/src/editor.js
@@ -2859,7 +2859,7 @@ config.defineOptions(Editor.prototype, "editor", {
             this.$updatePlaceholder();
         }
     },
-    keyboardAccessibilityMode: {
+    enableKeyboardAccessibility: {
         set: function(value) {
             var blurCommand = {
                 name: "blurTextInput",
@@ -2884,7 +2884,7 @@ config.defineOptions(Editor.prototype, "editor", {
 
             // Prevent focus to be captured when tabbing through the page. When focus is set to the content div, 
             // press Enter key to give focus to Ace and press Esc to again allow to tab through the page.
-            if (value === 'content'){
+            if (value){
                 this.textInput.getElement().setAttribute("tabindex", -1);
                 this.renderer.content.setAttribute("tabindex", 0);
                 this.renderer.content.classList.add(keyboardFocusClassName);
@@ -2894,7 +2894,7 @@ config.defineOptions(Editor.prototype, "editor", {
 
                 this.renderer.content.addEventListener("keyup", focusOnEnterKeyup.bind(this));
                 this.commands.addCommand(blurCommand);
-            } else if (value === 'off') {
+            } else {
                 this.textInput.getElement().setAttribute("tabindex", 0);
                 this.renderer.content.setAttribute("tabindex", -1);
                 this.renderer.content.classList.remove(keyboardFocusClassName);
@@ -2904,7 +2904,7 @@ config.defineOptions(Editor.prototype, "editor", {
                 this.commands.removeCommand(blurCommand);
             }
         },
-        initialValue: 'off'
+        initialValue: false
     },
     customScrollbar: "renderer",
     hScrollBarAlwaysVisible: "renderer",

--- a/src/editor.js
+++ b/src/editor.js
@@ -2880,8 +2880,8 @@ config.defineOptions(Editor.prototype, "editor", {
                 }
             };
 
-            // If true, prevent focus to be captured when tabbing through the page. When focus is set to the content div, 
-            // press Enter key to give focus to Ace and press Esc to allow again to tab through the page.
+            // Prevent focus to be captured when tabbing through the page. When focus is set to the content div, 
+            // press Enter key to give focus to Ace and press Esc to again allow to tab through the page.
             if (value === 'content'){
                 this.textInput.getElement().setAttribute("tabindex", -1);
                 this.renderer.content.setAttribute("tabindex", 0);

--- a/src/editor.js
+++ b/src/editor.js
@@ -2871,7 +2871,7 @@ config.defineOptions(Editor.prototype, "editor", {
                 readOnly: true
             };
 
-            var focusCommand = (e) => {
+            var focusCommand = function (e) {
                 // Keycode 13 == enter key.
                 if (e.target == this.renderer.content && e.keyCode === 13){
                     e.stopPropagation();
@@ -2880,6 +2880,8 @@ config.defineOptions(Editor.prototype, "editor", {
                 }
             };
 
+            // If true, prevent focus to be captured when tabbing through the page. When focus is set to the content div, 
+            // press Enter key to give focus to Ace and press Esc to allow again to tab through the page.
             if (value){
                 this.textInput.getElement().setAttribute("tabindex", -1);
                 this.renderer.content.setAttribute("tabindex", 0);

--- a/src/editor.js
+++ b/src/editor.js
@@ -2872,7 +2872,7 @@ config.defineOptions(Editor.prototype, "editor", {
                 readOnly: true
             };
 
-            var focusCommand = function (e) {
+            var focusOnEnterKeyup = function (e) {
                 if (e.target == this.renderer.content && e.keyCode === keys['enter']){
                     e.stopPropagation();
                     e.preventDefault();
@@ -2880,23 +2880,27 @@ config.defineOptions(Editor.prototype, "editor", {
                 }
             };
 
+            var keyboardFocusClassName = "ace_keyboard-focus";
+
             // Prevent focus to be captured when tabbing through the page. When focus is set to the content div, 
             // press Enter key to give focus to Ace and press Esc to again allow to tab through the page.
             if (value === 'content'){
                 this.textInput.getElement().setAttribute("tabindex", -1);
                 this.renderer.content.setAttribute("tabindex", 0);
+                this.renderer.content.classList.add(keyboardFocusClassName);
                 this.renderer.content.setAttribute("aria-label",
                     "Editor, press Enter key to start editing, press Escape key to exit"
                 );
 
-                this.renderer.content.addEventListener("keydown", focusCommand.bind(this));
+                this.renderer.content.addEventListener("keyup", focusOnEnterKeyup.bind(this));
                 this.commands.addCommand(blurCommand);
             } else if (value === 'off') {
                 this.textInput.getElement().setAttribute("tabindex", 0);
                 this.renderer.content.setAttribute("tabindex", -1);
+                this.renderer.content.classList.remove(keyboardFocusClassName);
                 this.renderer.content.setAttribute("aria-label", "");
             
-                this.renderer.content.removeEventListener("keydown", focusCommand.bind(this));
+                this.renderer.content.removeEventListener("keyup", focusOnEnterKeyup.bind(this));
                 this.commands.removeCommand(blurCommand);
             }
         },

--- a/src/editor_navigation_test.js
+++ b/src/editor_navigation_test.js
@@ -174,8 +174,8 @@ module.exports = {
         editor.onCommandKey({}, 0, keys["escape"]);
  
         // Focus should be on the content div after pressing Esc
-        assert.notEqual(document.activeElement, editor.textInput.getElement());
         assert.equal(document.activeElement, editor.renderer.content);
+        assert.notEqual(document.activeElement, editor.textInput.getElement());
 
         // Should trap focus
         editor.setOption('keyboardAccessibilityMode', 'off');

--- a/src/editor_navigation_test.js
+++ b/src/editor_navigation_test.js
@@ -162,7 +162,7 @@ module.exports = {
         var editor = new Editor(new VirtualRenderer(), new EditSession(["1234", "1234567890"]));
 
         // Should not trap focus
-        editor.setOption("preventKeyboardTrapping", true);
+        editor.setOption('keyboardAccessibilityMode', 'content');
 
         // Focus on editor
         editor.focus();
@@ -178,7 +178,7 @@ module.exports = {
         assert.equal(document.activeElement, editor.renderer.content);
 
         // Should trap focus
-        editor.setOption("preventKeyboardTrapping", false);
+        editor.setOption('keyboardAccessibilityMode', 'off');
 
         // Focus on editor
         editor.focus();

--- a/src/editor_navigation_test.js
+++ b/src/editor_navigation_test.js
@@ -162,7 +162,7 @@ module.exports = {
         var editor = new Editor(new VirtualRenderer(), new EditSession(["1234", "1234567890"]));
 
         // Should not trap focus
-        editor.setOption('keyboardAccessibilityMode', 'content');
+        editor.setOption('enableKeyboardAccessibility', true);
 
         // Focus on editor
         editor.focus();
@@ -178,7 +178,7 @@ module.exports = {
         assert.notEqual(document.activeElement, editor.textInput.getElement());
 
         // Should trap focus
-        editor.setOption('keyboardAccessibilityMode', 'off');
+        editor.setOption('enableKeyboardAccessibility', false);
 
         // Focus on editor
         editor.focus();

--- a/src/editor_navigation_test.js
+++ b/src/editor_navigation_test.js
@@ -8,7 +8,9 @@ if (typeof process !== "undefined") {
 var EditSession = require("./edit_session").EditSession;
 var Editor = require("./editor").Editor;
 var MockRenderer = require("./test/mockrenderer").MockRenderer;
+var VirtualRenderer = require("./virtual_renderer").VirtualRenderer;
 var assert = require("./test/assertions");
+var keys = require('./lib/keys');
 
 module.exports = {
     createEditSession : function(rows, cols) {
@@ -154,6 +156,44 @@ module.exports = {
         
         editor.navigateDown();
         assert.position(editor.getCursorPosition(), 1, 7);
+    },
+
+    "test: when not using keyboard navigation option should not allow escaping focus": function() {
+        var editor = new Editor(new VirtualRenderer(), new EditSession(["1234", "1234567890"]));
+
+        editor.setOption("preventKeyboardTrapping", false);
+
+        // Focus on editor
+        editor.focus();
+
+        // Focus should be on textInput
+        assert.equal(document.activeElement, editor.textInput.getElement());
+        assert.notEqual(document.activeElement, editor.renderer.content);
+
+        editor.onCommandKey({}, 0, keys["escape"]);
+ 
+        // Focus should be on the content div after pressing Esc
+        assert.equal(document.activeElement, editor.textInput.getElement());
+        assert.notEqual(document.activeElement, editor.renderer.content);
+    },
+
+    "test: when using keyboard navigation option should allow escaping focus": function() {
+        var editor = new Editor(new VirtualRenderer(), new EditSession(["1234", "1234567890"]));
+
+        editor.setOption("preventKeyboardTrapping", true);
+
+        // Focus on editor
+        editor.focus();
+
+        // Focus should be on textInput
+        assert.equal(document.activeElement, editor.textInput.getElement());
+        assert.notEqual(document.activeElement, editor.renderer.content);
+
+        editor.onCommandKey({}, 0, keys["escape"]);
+ 
+        // Focus should be on the content div after pressing Esc
+        assert.notEqual(document.activeElement, editor.textInput.getElement());
+        assert.equal(document.activeElement, editor.renderer.content);
     }
 };
 

--- a/src/editor_navigation_test.js
+++ b/src/editor_navigation_test.js
@@ -158,28 +158,10 @@ module.exports = {
         assert.position(editor.getCursorPosition(), 1, 7);
     },
 
-    "test: when not using keyboard navigation option should not allow escaping focus": function() {
+    "test: should allow to toggle between keyboard trapping modes": function() {
         var editor = new Editor(new VirtualRenderer(), new EditSession(["1234", "1234567890"]));
 
-        editor.setOption("preventKeyboardTrapping", false);
-
-        // Focus on editor
-        editor.focus();
-
-        // Focus should be on textInput
-        assert.equal(document.activeElement, editor.textInput.getElement());
-        assert.notEqual(document.activeElement, editor.renderer.content);
-
-        editor.onCommandKey({}, 0, keys["escape"]);
- 
-        // Focus should be on the content div after pressing Esc
-        assert.equal(document.activeElement, editor.textInput.getElement());
-        assert.notEqual(document.activeElement, editor.renderer.content);
-    },
-
-    "test: when using keyboard navigation option should allow escaping focus": function() {
-        var editor = new Editor(new VirtualRenderer(), new EditSession(["1234", "1234567890"]));
-
+        // Should not trap focus
         editor.setOption("preventKeyboardTrapping", true);
 
         // Focus on editor
@@ -194,6 +176,22 @@ module.exports = {
         // Focus should be on the content div after pressing Esc
         assert.notEqual(document.activeElement, editor.textInput.getElement());
         assert.equal(document.activeElement, editor.renderer.content);
+
+        // Should trap focus
+        editor.setOption("preventKeyboardTrapping", false);
+
+        // Focus on editor
+        editor.focus();
+
+        // Focus should be on textInput
+        assert.equal(document.activeElement, editor.textInput.getElement());
+        assert.notEqual(document.activeElement, editor.renderer.content);
+
+        editor.onCommandKey({}, 0, keys["escape"]);
+ 
+        // Focus should still be on the textInput
+        assert.equal(document.activeElement, editor.textInput.getElement());
+        assert.notEqual(document.activeElement, editor.renderer.content);
     }
 };
 

--- a/src/ext/options.js
+++ b/src/ext/options.js
@@ -197,7 +197,7 @@ var optionGroups = {
         },
         "Prevent keyboard trapping": {
             path: "preventKeyboardTrapping"
-        },
+        }
     }
 };
 

--- a/src/ext/options.js
+++ b/src/ext/options.js
@@ -199,7 +199,7 @@ var optionGroups = {
             path: "useSvgGutterIcons"
         },
         "Keyboard Accessibility Mode": {
-            path: "enableKeyboardAccessibility",
+            path: "enableKeyboardAccessibility"
         }
     }
 };

--- a/src/ext/options.js
+++ b/src/ext/options.js
@@ -199,11 +199,7 @@ var optionGroups = {
             path: "useSvgGutterIcons"
         },
         "Keyboard Accessibility Mode": {
-            path: "keyboardAccessibilityMode",
-            items: [
-                { caption : "Content",  value : "content" },
-                { caption : "Off",   value : "off" }
-             ]
+            path: "enableKeyboardAccessibility",
         }
     }
 };

--- a/src/ext/options.js
+++ b/src/ext/options.js
@@ -194,7 +194,10 @@ var optionGroups = {
         },
         "Custom scrollbar": {
             path: "customScrollbar"
-        }
+        },
+        "Prevent keyboard trapping": {
+            path: "preventKeyboardTrapping"
+        },
     }
 };
 

--- a/src/ext/options.js
+++ b/src/ext/options.js
@@ -195,11 +195,15 @@ var optionGroups = {
         "Custom scrollbar": {
             path: "customScrollbar"
         },
-        "Prevent keyboard trapping": {
-            path: "preventKeyboardTrapping"
-        },
         "Use SVG gutter icons": {
             path: "useSvgGutterIcons"
+        },
+        "Keyboard Accessibility Mode": {
+            path: "keyboardAccessibilityMode",
+            items: [
+                { caption : "Content",  value : "content" },
+                { caption : "Off",   value : "off" }
+             ]
         }
     }
 };


### PR DESCRIPTION
Issue #3149

When keyboard navigating through a page containing Ace, Ace will capture focus and prevent from leaving using the keyboard. This prevents users who use keyboard navigation to navigate a page with Ace present which present an accessibility concern.

When `preventKeyboardTrapping  = true` focus will be set to the div containing the Ace content (instead of given immediately to Ace itself), the user then needs to press the `Enter` key to enter Ace. After pressing `Esc` they can freely tab/shift-tab though the page again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
