### PR TITLE
fix: adds missing 'on' method for 'guttermousedown'

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -792,6 +792,7 @@ export namespace Ace {
     on(name: 'mouseup', callback: (e: any) => void): void;
     on(name: 'mousewheel', callback: (e: any) => void): void;
     on(name: 'click', callback: (e: any) => void): void;
+    on(name: 'guttermousedown', callback: (e: any) => void): void;
 
     onPaste(text: string, event: any): void;
 


### PR DESCRIPTION
*Description of changes:*
Added an on-method for guttermousedown in 'ace.d.ts'.
Without this method I get the following error message.

```

> error TS7006: Parameter 'e' implicitly has an 'any' type.
> 
> 79     this.aceEditor.on("guttermousedown", function (e) {

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
