### PR TITLE
fix regression in searchbar keyboard handler

### DIFF
--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -44,98 +44,6 @@ class SearchBox {
         this.$init();
         this.setEditor(editor);
         dom.importCssString(searchboxCss, "ace_searchbox", editor.container);
-
-
-        //keybinding outside of the searchbox
-        this.$searchBarKb = new HashHandler();
-        this.$searchBarKb.bindKeys({
-            "Ctrl-f|Command-f": function(sb) {
-                var isReplace = sb.isReplace = !sb.isReplace;
-                sb.replaceBox.style.display = isReplace ? "" : "none";
-                sb.replaceOption.checked = false;
-                sb.$syncOptions();
-                sb.searchInput.focus();
-            },
-            "Ctrl-H|Command-Option-F": function(sb) {
-                if (sb.editor.getReadOnly())
-                    return;
-                sb.replaceOption.checked = true;
-                sb.$syncOptions();
-                sb.replaceInput.focus();
-            },
-            "Ctrl-G|Command-G": function(sb) {
-                sb.findNext();
-            },
-            "Ctrl-Shift-G|Command-Shift-G": function(sb) {
-                sb.findPrev();
-            },
-            "esc": function(sb) {
-                setTimeout(function() { sb.hide();});
-            },
-            "Return": function(sb) {
-                if (sb.activeInput == sb.replaceInput)
-                    sb.replace();
-                sb.findNext();
-            },
-            "Shift-Return": function(sb) {
-                if (sb.activeInput == sb.replaceInput)
-                    sb.replace();
-                sb.findPrev();
-            },
-            "Alt-Return": function(sb) {
-                if (sb.activeInput == sb.replaceInput)
-                    sb.replaceAll();
-                sb.findAll();
-            },
-            "Tab": function(sb) {
-                (sb.activeInput == sb.replaceInput ? sb.searchInput : sb.replaceInput).focus();
-            }
-        });
-
-        this.$searchBarKb.addCommands([{
-            name: "toggleRegexpMode",
-            bindKey: {win: "Alt-R|Alt-/", mac: "Ctrl-Alt-R|Ctrl-Alt-/"},
-            exec: function(sb) {
-                sb.regExpOption.checked = !sb.regExpOption.checked;
-                sb.$syncOptions();
-            }
-        }, {
-            name: "toggleCaseSensitive",
-            bindKey: {win: "Alt-C|Alt-I", mac: "Ctrl-Alt-R|Ctrl-Alt-I"},
-            exec: function(sb) {
-                sb.caseSensitiveOption.checked = !sb.caseSensitiveOption.checked;
-                sb.$syncOptions();
-            }
-        }, {
-            name: "toggleWholeWords",
-            bindKey: {win: "Alt-B|Alt-W", mac: "Ctrl-Alt-B|Ctrl-Alt-W"},
-            exec: function(sb) {
-                sb.wholeWordOption.checked = !sb.wholeWordOption.checked;
-                sb.$syncOptions();
-            }
-        }, {
-            name: "toggleReplace",
-            exec: function(sb) {
-                sb.replaceOption.checked = !sb.replaceOption.checked;
-                sb.$syncOptions();
-            }
-        }, {
-            name: "searchInSelection",
-            exec: function(sb) {
-                sb.searchOption.checked = !sb.searchRange;
-                sb.setSearchRange(sb.searchOption.checked && sb.editor.getSelectionRange());
-                sb.$syncOptions();
-            }
-        }]);
-
-        //keybinding outside of the searchbox
-        this.$closeSearchBarKb = new HashHandler([{
-            bindKey: "Esc",
-            name: "closeSearchBar",
-            exec: function(editor) {
-                editor.searchBox.hide();
-            }
-        }]);
     }
     
     setEditor(editor) {
@@ -351,6 +259,100 @@ class SearchBox {
         return el == this.searchInput || el == this.replaceInput;
     }
 }
+
+//keybinding outside of the searchbox
+var $searchBarKb = new HashHandler();
+$searchBarKb.bindKeys({
+    "Ctrl-f|Command-f": function(sb) {
+        var isReplace = sb.isReplace = !sb.isReplace;
+        sb.replaceBox.style.display = isReplace ? "" : "none";
+        sb.replaceOption.checked = false;
+        sb.$syncOptions();
+        sb.searchInput.focus();
+    },
+    "Ctrl-H|Command-Option-F": function(sb) {
+        if (sb.editor.getReadOnly())
+            return;
+        sb.replaceOption.checked = true;
+        sb.$syncOptions();
+        sb.replaceInput.focus();
+    },
+    "Ctrl-G|Command-G": function(sb) {
+        sb.findNext();
+    },
+    "Ctrl-Shift-G|Command-Shift-G": function(sb) {
+        sb.findPrev();
+    },
+    "esc": function(sb) {
+        setTimeout(function() { sb.hide();});
+    },
+    "Return": function(sb) {
+        if (sb.activeInput == sb.replaceInput)
+            sb.replace();
+        sb.findNext();
+    },
+    "Shift-Return": function(sb) {
+        if (sb.activeInput == sb.replaceInput)
+            sb.replace();
+        sb.findPrev();
+    },
+    "Alt-Return": function(sb) {
+        if (sb.activeInput == sb.replaceInput)
+            sb.replaceAll();
+        sb.findAll();
+    },
+    "Tab": function(sb) {
+        (sb.activeInput == sb.replaceInput ? sb.searchInput : sb.replaceInput).focus();
+    }
+});
+
+$searchBarKb.addCommands([{
+    name: "toggleRegexpMode",
+    bindKey: {win: "Alt-R|Alt-/", mac: "Ctrl-Alt-R|Ctrl-Alt-/"},
+    exec: function(sb) {
+        sb.regExpOption.checked = !sb.regExpOption.checked;
+        sb.$syncOptions();
+    }
+}, {
+    name: "toggleCaseSensitive",
+    bindKey: {win: "Alt-C|Alt-I", mac: "Ctrl-Alt-R|Ctrl-Alt-I"},
+    exec: function(sb) {
+        sb.caseSensitiveOption.checked = !sb.caseSensitiveOption.checked;
+        sb.$syncOptions();
+    }
+}, {
+    name: "toggleWholeWords",
+    bindKey: {win: "Alt-B|Alt-W", mac: "Ctrl-Alt-B|Ctrl-Alt-W"},
+    exec: function(sb) {
+        sb.wholeWordOption.checked = !sb.wholeWordOption.checked;
+        sb.$syncOptions();
+    }
+}, {
+    name: "toggleReplace",
+    exec: function(sb) {
+        sb.replaceOption.checked = !sb.replaceOption.checked;
+        sb.$syncOptions();
+    }
+}, {
+    name: "searchInSelection",
+    exec: function(sb) {
+        sb.searchOption.checked = !sb.searchRange;
+        sb.setSearchRange(sb.searchOption.checked && sb.editor.getSelectionRange());
+        sb.$syncOptions();
+    }
+}]);
+
+//keybinding outside of the searchbox
+var $closeSearchBarKb = new HashHandler([{
+    bindKey: "Esc",
+    name: "closeSearchBar",
+    exec: function(editor) {
+        editor.searchBox.hide();
+    }
+}]);
+
+SearchBox.prototype.$searchBarKb = $searchBarKb;
+SearchBox.prototype.$closeSearchBarKb = $closeSearchBarKb;
 
 exports.SearchBox = SearchBox;
 


### PR DESCRIPTION
as reported in https://github.com/ajaxorg/ace/issues/5132#issuecomment-1514167719, during class refactoring search handler was moved from prototype to instance, which have broken the ability to customize search keybindings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
