### PR TITLE
fixes #5130: Wrong text color in solarized_dark.css.js (Updated)

### DIFF
--- a/src/theme/solarized_dark.css.js
+++ b/src/theme/solarized_dark.css.js
@@ -10,12 +10,12 @@ module.exports = `.ace-solarized-dark .ace_gutter {
 
 .ace-solarized-dark {
   background-color: #002B36;
-  color: #93A1A1
+  color: #839496
 }
 
 .ace-solarized-dark .ace_entity.ace_other.ace_attribute-name,
 .ace-solarized-dark .ace_storage {
-  color: #93A1A1
+  color: #839496
 }
 
 .ace-solarized-dark .ace_cursor,


### PR DESCRIPTION
![Screenshot 2023-04-22 at 2 56 40 PM](https://user-images.githubusercontent.com/117713832/233775651-cdc5ffc4-1ec0-4b4d-9e95-65f294293a67.png)
