### PR TITLE
do not create getAccelKey method in event constructor

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -633,22 +633,19 @@ class Document {
         return index + pos.column;
     }
 
+    /**
+     * Splits a string of text on any newline (`\n`) or carriage-return (`\r`) characters.
+     *
+     * @method $split
+     * @param {String} text The text to work with
+     * @returns {String} A String array, with each index containing a piece of the original `text` string.
+     *
+     **/
+    $split(text) {
+        return text.split(/\r\n|\r|\n/);
+    }
 }
 
-/**
- * Splits a string of text on any newline (`\n`) or carriage-return (`\r`) characters.
- *
- * @method $split
- * @param {String} text The text to work with
- * @returns {String} A String array, with each index containing a piece of the original `text` string.
- *
- **/
-// check for IE split bug
-Document.prototype.$split = ("aaa".split(/a/).length === 0) ? function (text) {
-    return text.replace(/\r\n|\r/g, "\n").split("\n");
-} : function (text) {
-    return text.split(/\r\n|\r|\n/);
-};
 Document.prototype.$autoNewLine = "";
 Document.prototype.$newLineMode = "auto";
 

--- a/src/mouse/mouse_event.js
+++ b/src/mouse/mouse_event.js
@@ -19,12 +19,6 @@ class MouseEvent {
 
         this.propagationStopped = false;
         this.defaultPrevented = false;
-
-        this.getAccelKey = useragent.isMac ? function () {
-            return this.domEvent.metaKey;
-        } : function () {
-            return this.domEvent.ctrlKey;
-        };
     }
     
     stopPropagation() {
@@ -93,7 +87,10 @@ class MouseEvent {
     getShiftKey() {
         return this.domEvent.shiftKey;
     }
-    
+
+    getAccelKey() {
+        return useragent.isMac ? this.domEvent.metaKey : this.domEvent.ctrlKey;
+    }
 }
 
 exports.MouseEvent = MouseEvent;


### PR DESCRIPTION
This is a followup to https://github.com/ajaxorg/ace/pull/5134, moving two functions, that were not causing problems but were in wrong place. 
The buggy split workaround was for ie7, and could have been removed long ago.