### PR TITLE
Fix: wrong next state in regex state in Lucene and SQLServer modes

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -54,6 +54,7 @@ jobs:
     - run: node_modules/.bin/tsc --noImplicitAny --strict --noUnusedLocals --noImplicitReturns --noUnusedParameters --noImplicitThis ace.d.ts
     - uses: codecov/codecov-action@v3
       with:
+        token: d8edca4b-8e97-41e5-b54e-34c7cf3b2d47
         file: ./coverage/coverage.json
         flags: unittests
         name: codecov-umbrella

--- a/src/mode/_test/highlight_rules_test.js
+++ b/src/mode/_test/highlight_rules_test.js
@@ -45,7 +45,8 @@ function checkModes() {
         if (!m.$behaviour)
             console.warn("missing behavior in " + modeName);
         var tokenizer = m.getTokenizer();
-        
+
+        testNextState(tokenizer, modeName);
         testComments(m.lineCommentStart, testLineComment, tokenizer, modeName);
         testComments(m.blockComment, testBlockComment, tokenizer, modeName);
         testBrackets(m, modeName);
@@ -63,6 +64,26 @@ function checkModes() {
     if (Object.keys(snippets).length) {
         console.error("Snippet files missing", snippets);
         throw new Error("Snippet files missing");
+    }
+    
+    function testNextState(tokenizer, modeName) {
+        let keys = Object.keys(tokenizer.states);
+        for (let i = 0; i < keys.length; i++) {
+            let key = keys[i];
+            let tokens = tokenizer.states[key];
+            for (let j = 0; j < tokens.length; j++) {
+                let token = tokens[j];
+                checkState(keys, token, "nextState", modeName);
+                checkState(keys, token, "next", modeName);
+            }
+        }
+    }
+
+    function checkState(stateNames, token, property, modeName) {
+        if (token.hasOwnProperty(property) && typeof token[property] === "string" && !stateNames.includes(
+            token[property])) {
+            console.warn("non-existent next state '" + token[property] + "' in " + modeName);
+        }
     }
     
     function testComments(desc, fn, tokenizer, modeName) {

--- a/src/mode/_test/text_lucene.txt
+++ b/src/mode/_test/text_lucene.txt
@@ -55,3 +55,4 @@ esc\:aped
 esc\\aped
 esc\ aped:foo
 "foo\"bar"
+foo:/bar/

--- a/src/mode/_test/tokens_lucene.json
+++ b/src/mode/_test/tokens_lucene.json
@@ -328,5 +328,11 @@
    "start",
   ["string","\"foo\\\"bar\""]
 ],[
+   "start",
+  ["keyword","foo:"],
+  ["string.regexp.start","/"],
+  ["string.regexp","bar"],
+  ["string.regexp.end","/"]
+],[
    "start"
 ]]

--- a/src/mode/lucene_highlight_rules.js
+++ b/src/mode/lucene_highlight_rules.js
@@ -73,7 +73,7 @@ var LuceneHighlightRules = function() {
                 // flag
                 token: "string.regexp.end",
                 regex: "/[sxngimy]*",
-                next: "no_regex"
+                next: "start"
             }, {
                 // invalid operators
                 token : "invalid",
@@ -96,7 +96,7 @@ var LuceneHighlightRules = function() {
             }, {
                 token: "empty",
                 regex: "$",
-                next: "no_regex"
+                next: "start"
             }, {
                 defaultToken: "string.regexp"
             }
@@ -115,9 +115,9 @@ var LuceneHighlightRules = function() {
             }, {
                 token: "empty",
                 regex: "$",
-                next: "no_regex"
+                next: "start"
             }, {
-                defaultToken: "string.regexp.charachterclass"
+                defaultToken: "string.regexp.characterclass"
             }
         ]
     };

--- a/src/mode/sqlserver_highlight_rules.js
+++ b/src/mode/sqlserver_highlight_rules.js
@@ -160,7 +160,7 @@ var SqlServerHighlightRules = function() {
         DocCommentHighlightRules.getTagRule(), {
             token: "comment",
             regex: "\\*\\/",
-            next: "no_regex"
+            next: "start"
         }, {
             defaultToken: "comment",
             caseInsensitive: true


### PR DESCRIPTION
*Issue #, if available:* #5135

*Description of changes:*
- Fix wrong next state in Lucene mode
- Fix wrong next state in SQLServer mode
- Add test to check all modes for possible wrong next states

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
