### PR TITLE
Fix documentation link and incorrect declarations in ace.d.ts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -99,7 +99,7 @@ Documentation
 
 Additional usage information, including events to listen to and extending syntax highlighters, can be found [on the main Ace website](http://ace.c9.io).
 
-You can also find API documentation at [http://ace.c9.io/#nav=api](http://ace.c9.io/#nav=api).
+You can also find API documentation at [https://ajaxorg.github.io/ace-api-docs/](https://ajaxorg.github.io/ace-api-docs/).
 
 Also check out the sample code for the kitchen sink [demo app](https://github.com/ajaxorg/ace/blob/master/demo/kitchen-sink/demo.js).
 

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -284,8 +284,8 @@ export namespace Ace {
 
   export class MarkerGroup {
     constructor(session: EditSession);
-    setMarkers: (markers: MarkerGroupItem[]) => void;
-    getMarkerAtPosition: (pos: Position) => MarkerGroupItem;
+    setMarkers(markers: MarkerGroupItem[]): void;
+    getMarkerAtPosition(pos: Position): MarkerGroupItem;
   }
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Replace outdated link to ace documentation site
- Replace property declarations with method signatures in `ace.d.ts` to reflect actual code piece

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
