### PR TITLE
fix: add mode declarations and types, improve type definitions

### DIFF
--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -1,0 +1,1152 @@
+declare module "ace-code/src/mode/matching_brace_outdent" {
+  export const MatchingBraceOutdent: new () => import(".").Ace.Outdent;
+}
+declare module "ace-code/src/mode/matching_highlight_rules" {
+  export const MatchingHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/matching_parens_outdent" {
+  export const MatchingParensOutdent: new () => import(".").Ace.Outdent;
+}
+declare module "ace-code/src/mode/matching_highlight_rules" {
+  export const MatchingHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+
+declare module "ace-code/src/mode/behaviour" {
+  export const Behaviour: new () => import(".").Ace.Behaviour;
+}
+declare module "ace-code/src/mode/behaviour/css" {
+  export const CssBehaviour: new () => import(".").Ace.Behaviour;
+}
+declare module "ace-code/src/mode/behaviour/cstyle" {
+  export const CstyleBehaviour: new () => import(".").Ace.Behaviour;
+}
+declare module "ace-code/src/mode/behaviour/html" {
+  export const HtmlBehaviour: new () => import(".").Ace.Behaviour;
+}
+declare module "ace-code/src/mode/behaviour/liquid" {
+  export const LiquidBehaviour: new () => import(".").Ace.Behaviour;
+}
+declare module "ace-code/src/mode/behaviour/xml" {
+  export const XmlBehaviour: new () => import(".").Ace.Behaviour;
+}
+declare module "ace-code/src/mode/behaviour/xquery" {
+  export const XQueryBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+
+declare module "ace-code/src/mode/folding/fold_mode" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/asciidoc" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/c9search" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/coffee" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/csharp" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/cstyle" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/diff" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/drools" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/haskell_cabal" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/html" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/ini" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/java" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/latex" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/lua" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/markdown" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/mixed" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/pythonic" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/ruby" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/sql" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/sqlserver" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/vbscript" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/velocity" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+declare module "ace-code/src/mode/folding/xml" {
+  export const FoldMode: new () => import(".").Ace.FoldMode;
+}
+
+
+declare module "ace-code/src/mode/abap" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/abap_highlight_rules" {
+  export const AbapHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/abc" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/abc_highlight_rules" {
+  export const ABCHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/actionscript" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/actionscript_highlight_rules" {
+  export const ActionScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/ada" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/ada_highlight_rules" {
+  export const AdaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/alda" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/alda_highlight_rules" {
+  export const AldaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/apache_conf" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/apache_conf_highlight_rules" {
+  export const ApacheConfHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/apex" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/apex_highlight_rules" {
+  export const ApexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/aql" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/aql_highlight_rules" {
+  export const AqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/asciidoc" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/asciidoc_highlight_rules" {
+  export const AsciidocHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/asl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/asl_highlight_rules" {
+  export const ASLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/assembly_x86" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/assembly_x86_highlight_rules" {
+  export const AssemblyX86HighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/autohotkey" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/autohotkey_highlight_rules" {
+  export const AutoHotKeyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/batchfile" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/batchfile_highlight_rules" {
+  export const BatchFileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/bibtex" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/bibtex_highlight_rules" {
+  export const BibTeXHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/c_cpp" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/c_cpp_highlight_rules" {
+  export const c_cppHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/c9search" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/c9search_highlight_rules" {
+  export const C9SearchHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/cirru" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/cirru_highlight_rules" {
+  export const CirruHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/clojure" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/clojure_highlight_rules" {
+  export const ClojureHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/cobol" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/cobol_highlight_rules" {
+  export const CobolHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/coffee" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/coffee_highlight_rules" {
+  export const CoffeeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/coldfusion" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/coldfusion_highlight_rules" {
+  export const ColdfusionHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/crystal" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/crystal_highlight_rules" {
+  export const CrystalHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/csharp" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/csharp_highlight_rules" {
+  export const CSharpHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/csound_document" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/csound_document_highlight_rules" {
+  export const CsoundDocumentHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/csound_orchestra" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/csound_orchestra_highlight_rules" {
+  export const CsoundOrchestraHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/csound_score" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/csound_score_highlight_rules" {
+  export const CsoundScoreHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/css" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/css_highlight_rules" {
+  export const CssHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/curly" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/curly_highlight_rules" {
+  export const CurlyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/d" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/d_highlight_rules" {
+  export const DHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/dart" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/dart_highlight_rules" {
+  export const DartHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/diff" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/diff_highlight_rules" {
+  export const DiffHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/dockerfile" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/dockerfile_highlight_rules" {
+  export const DockerfileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/dot" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/dot_highlight_rules" {
+  export const DotHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/drools" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/drools_highlight_rules" {
+  export const DroolsHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/edifact" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/edifact_highlight_rules" {
+  export const EdifactHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/eiffel" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/eiffel_highlight_rules" {
+  export const EiffelHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/ejs" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/ejs_highlight_rules" {
+  export const EjsHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/elixir" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/elixir_highlight_rules" {
+  export const ElixirHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/elm" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/elm_highlight_rules" {
+  export const ElmHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/erlang" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/erlang_highlight_rules" {
+  export const ErlangHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/forth" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/forth_highlight_rules" {
+  export const ForthHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/fortran" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/fortran_highlight_rules" {
+  export const FortranHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/fsharp" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/fsharp_highlight_rules" {
+  export const FSharpHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/fsl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/fsl_highlight_rules" {
+  export const FSLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/ftl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/ftl_highlight_rules" {
+  export const FtlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/gcode" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/gcode_highlight_rules" {
+  export const GcodeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/gherkin" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/gherkin_highlight_rules" {
+  export const GherkinHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/gitignore" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/gitignore_highlight_rules" {
+  export const GitignoreHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/glsl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/glsl_highlight_rules" {
+  export const glslHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/gobstones" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/gobstones_highlight_rules" {
+  export const GobstonesHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/golang" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/golang_highlight_rules" {
+  export const GolangHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/graphqlschema" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/graphqlschema_highlight_rules" {
+  export const GraphQLSchemaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/groovy" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/groovy_highlight_rules" {
+  export const GroovyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/haml" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/haml_highlight_rules" {
+  export const HamlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/handlebars" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/handlebars_highlight_rules" {
+  export const HandlebarsHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/haskell" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/haskell_highlight_rules" {
+  export const HaskellHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/haskell_cabal" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/haskell_highlight_rules" {
+  export const HaskellHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/haxe" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/haxe_highlight_rules" {
+  export const HaxeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/hjson" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/hjson_highlight_rules" {
+  export const HjsonHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/html" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/html_highlight_rules" {
+  export const HtmlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/html_elixir" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/html_elixir_highlight_rules" {
+  export const HtmlElixirHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/html_ruby" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/html_ruby_highlight_rules" {
+  export const HtmlRubyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/ini" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/ini_highlight_rules" {
+  export const IniHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/io" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/io_highlight_rules" {
+  export const IoHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/ion" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/ion_highlight_rules" {
+  export const IonHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/jack" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/jack_highlight_rules" {
+  export const JackHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/jade" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/jade_highlight_rules" {
+  export const JadeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/java" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/java_highlight_rules" {
+  export const JavaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/javascript" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/javascript_highlight_rules" {
+  export const JavaScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/jexl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/jexl_highlight_rules" {
+  export const JexlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/json" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/json_highlight_rules" {
+  export const JsonHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/json5" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/json5_highlight_rules" {
+  export const Json5HighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/jsp" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/jsp_highlight_rules" {
+  export const JspHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/jssm" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/jssm_highlight_rules" {
+  export const JSSMHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/jsx" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/jsx_highlight_rules" {
+  export const JsxHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/julia" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/julia_highlight_rules" {
+  export const JuliaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/kotlin" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/kotlin_highlight_rules" {
+  export const KotlinHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/latex" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/latex_highlight_rules" {
+  export const LatexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/latte" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/latte_highlight_rules" {
+  export const LatteHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/less" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/less_highlight_rules" {
+  export const LessHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/liquid" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/liquid_highlight_rules" {
+  export const LiquidHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/lisp" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/lisp_highlight_rules" {
+  export const LispHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/livescript" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/logiql" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/logiql_highlight_rules" {
+  export const LogiQLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/logtalk" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/logtalk_highlight_rules" {
+  export const LogtalkHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/lsl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/lsl_highlight_rules" {
+  export const LSLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/lua" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/lua_highlight_rules" {
+  export const LuaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/luapage" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/luapage_highlight_rules" {
+  export const LuaPageHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/lucene" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/lucene_highlight_rules" {
+  export const LuceneHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/makefile" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/makefile_highlight_rules" {
+  export const MakefileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/markdown" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/markdown_highlight_rules" {
+  export const MarkdownHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/mask" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/mask_highlight_rules" {
+  export const MaskHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/matlab" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/matlab_highlight_rules" {
+  export const MatlabHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/maze" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/maze_highlight_rules" {
+  export const MazeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/mediawiki" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/mediawiki_highlight_rules" {
+  export const MediaWikiHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/mel" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/mel_highlight_rules" {
+  export const MELHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/mips" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/mips_highlight_rules" {
+  export const MIPSHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/mixal" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/mixal_highlight_rules" {
+  export const MixalHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/mushcode" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/mushcode_highlight_rules" {
+  export const MushCodeRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/mysql" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/mysql_highlight_rules" {
+  export const MysqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/nginx" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/nginx_highlight_rules" {
+  export const NginxHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/nim" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/nim_highlight_rules" {
+  export const NimHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/nix" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/nix_highlight_rules" {
+  export const NixHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/nsis" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/nsis_highlight_rules" {
+  export const NSISHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/nunjucks" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/nunjucks_highlight_rules" {
+  export const NunjucksHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/objectivec" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/objectivec_highlight_rules" {
+  export const ObjectiveCHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/ocaml" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/ocaml_highlight_rules" {
+  export const OcamlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/partiql" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/partiql_highlight_rules" {
+  export const PartiqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/pascal" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/pascal_highlight_rules" {
+  export const PascalHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/perl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/perl_highlight_rules" {
+  export const PerlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/pgsql" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/pgsql_highlight_rules" {
+  export const PgsqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/php" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/php_highlight_rules" {
+  export const PhpHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/php_laravel_blade" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/php_highlight_rules" {
+  export const PhpHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/pig" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/pig_highlight_rules" {
+  export const PigHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/plsql" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/plsql_highlight_rules" {
+  export const plsqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/powershell" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/powershell_highlight_rules" {
+  export const PowershellHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/praat" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/praat_highlight_rules" {
+  export const PraatHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/prisma" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/prisma_highlight_rules" {
+  export const PrismaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/prolog" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/prolog_highlight_rules" {
+  export const PrologHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/properties" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/properties_highlight_rules" {
+  export const PropertiesHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/protobuf" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/protobuf_highlight_rules" {
+  export const ProtobufHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/puppet" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/puppet_highlight_rules" {
+  export const PuppetHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/python" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/python_highlight_rules" {
+  export const PythonHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/qml" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/qml_highlight_rules" {
+  export const QmlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/r" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/r_highlight_rules" {
+  export const RHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/raku" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/raku_highlight_rules" {
+  export const RakuHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/razor" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/razor_highlight_rules" {
+  export const RazorHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/rdoc" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/rdoc_highlight_rules" {
+  export const RDocHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/red" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/red_highlight_rules" {
+  export const RedHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/rhtml" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/rhtml_highlight_rules" {
+  export const RHtmlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/robot" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/robot_highlight_rules" {
+  export const RobotHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/rst" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/rst_highlight_rules" {
+  export const RSTHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/ruby" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/ruby_highlight_rules" {
+  export const RubyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/rust" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/rust_highlight_rules" {
+  export const RustHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/sac" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/sac_highlight_rules" {
+  export const sacHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/sass" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/sass_highlight_rules" {
+  export const SassHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/scad" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/scad_highlight_rules" {
+  export const scadHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/scala" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/scala_highlight_rules" {
+  export const ScalaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/scheme" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/scheme_highlight_rules" {
+  export const SchemeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/scrypt" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/scrypt_highlight_rules" {
+  export const scryptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/scss" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/scss_highlight_rules" {
+  export const ScssHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/sh" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/sh_highlight_rules" {
+  export const ShHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/sjs" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/sjs_highlight_rules" {
+  export const SJSHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/slim" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/slim_highlight_rules" {
+  export const SlimHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/smarty" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/smarty_highlight_rules" {
+  export const SmartyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/smithy" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/smithy_highlight_rules" {
+  export const SmithyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/snippets" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/soy_template" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/soy_template_highlight_rules" {
+  export const SoyTemplateHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/space" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/space_highlight_rules" {
+  export const SpaceHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/sparql" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/sparql_highlight_rules" {
+  export const SPARQLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/sql" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/sql_highlight_rules" {
+  export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/sqlserver" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/sqlserver_highlight_rules" {
+  export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/stylus" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/stylus_highlight_rules" {
+  export const StylusHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/svg" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/svg_highlight_rules" {
+  export const SvgHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/swift" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/swift_highlight_rules" {
+  export const SwiftHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/tcl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/tcl_highlight_rules" {
+  export const TclHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/terraform" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/terraform_highlight_rules" {
+  export const TerraformHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/tex" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/tex_highlight_rules" {
+  export const TexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/text" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/text_highlight_rules" {
+  export const TextHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/textile" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/textile_highlight_rules" {
+  export const TextileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/toml" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/toml_highlight_rules" {
+  export const TomlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/tsx" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/turtle" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/turtle_highlight_rules" {
+  export const TurtleHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/twig" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/twig_highlight_rules" {
+  export const TwigHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/typescript" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/typescript_highlight_rules" {
+  export const TypeScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/vala" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/vala_highlight_rules" {
+  export const ValaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/vbscript" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/vbscript_highlight_rules" {
+  export const VBScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/velocity" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/velocity_highlight_rules" {
+  export const VelocityHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/verilog" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/verilog_highlight_rules" {
+  export const VerilogHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/vhdl" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/vhdl_highlight_rules" {
+  export const VHDLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/visualforce" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/visualforce_highlight_rules" {
+  export const VisualforceHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/wollok" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/wollok_highlight_rules" {
+  export const WollokHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/xml" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/xml_highlight_rules" {
+  export const XmlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/yaml" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/yaml_highlight_rules" {
+  export const YamlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/zeek" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+declare module "ace-code/src/mode/zeek_highlight_rules" {
+  export const ZeekHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+declare module "ace-code/src/mode/django" {
+  export const Mode: new () => import(".").Ace.SyntaxMode;
+}

--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -1,14 +1,8 @@
 declare module "ace-code/src/mode/matching_brace_outdent" {
   export const MatchingBraceOutdent: new () => import(".").Ace.Outdent;
 }
-declare module "ace-code/src/mode/matching_highlight_rules" {
-  export const MatchingHighlightRules: new () => import(".").Ace.HighlightRules;
-}
 declare module "ace-code/src/mode/matching_parens_outdent" {
   export const MatchingParensOutdent: new () => import(".").Ace.Outdent;
-}
-declare module "ace-code/src/mode/matching_highlight_rules" {
-  export const MatchingHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
 
@@ -445,8 +439,8 @@ declare module "ace-code/src/mode/haskell_highlight_rules" {
 declare module "ace-code/src/mode/haskell_cabal" {
   export const Mode: new () => import(".").Ace.SyntaxMode;
 }
-declare module "ace-code/src/mode/haskell_highlight_rules" {
-  export const HaskellHighlightRules: new () => import(".").Ace.HighlightRules;
+declare module "ace-code/src/mode/haskell_cabal_highlight_rules" {
+  export const CabalHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 declare module "ace-code/src/mode/haxe" {
   export const Mode: new () => import(".").Ace.SyntaxMode;
@@ -778,8 +772,8 @@ declare module "ace-code/src/mode/php_highlight_rules" {
 declare module "ace-code/src/mode/php_laravel_blade" {
   export const Mode: new () => import(".").Ace.SyntaxMode;
 }
-declare module "ace-code/src/mode/php_highlight_rules" {
-  export const PhpHighlightRules: new () => import(".").Ace.HighlightRules;
+declare module "ace-code/src/mode/php_laravel_blade_highlight_rules" {
+  export const PHPLaravelBladeHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 declare module "ace-code/src/mode/pig" {
   export const Mode: new () => import(".").Ace.SyntaxMode;

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -380,10 +380,6 @@ export namespace Ace {
   export type KeywordMapper = (keyword: string) => string;
 
   export interface HighlightRules {
-    $rules: HighlightRulesMap;
-    $embeds?: string[];
-    $keywordList?: string[];
-    $keywords?: KeywordMapper;
     addRules(rules: HighlightRulesMap, prefix?: string): void;
     getRules(): HighlightRulesMap;
     embedRules(rules: (new () => HighlightRules) | HighlightRulesMap, prefix: string, escapeRules?: boolean, append?: boolean): void;
@@ -406,7 +402,6 @@ export namespace Ace {
   type BehaviorMap = Record<string, Record<string, BehaviorAction>>;
 
   export interface Behaviour {
-    $behaviours: BehaviorMap;
     add(name: string, action: string, callback: BehaviorAction): void;
     addBehaviours(behaviours: BehaviorMap): void;
     remove(name: string): void;
@@ -417,7 +412,6 @@ export namespace Ace {
   export interface Outdent {
     checkOutdent(line: string, input: string): boolean;
     autoOutdent(doc: Document, row: number): number | undefined;
-    $getIndent(line: string): string;
   }
 
   export interface SyntaxMode {

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -432,7 +432,6 @@ export namespace Ace {
     getNextLineIndent(state: any, line: string, tab: string): string;
     checkOutdent(state: any, line: string, input: string): boolean;
     autoOutdent(state: any, doc: Document, row: number): void;
-    $getIndent(line: string): string;
     // TODO implement WorkerClient types
     createWorker(session: EditSession): any;
     createModeDelegates(mapping: { [key: string]: string }): void;


### PR DESCRIPTION
This change adds a new `ace-modes.d.ts` file (referenced in the main ace.d.ts), which declares types for everything in the `ace/src/mode` folder. This is useful for people who depend on `ace-code` in their typescript projects and what to import and use existing mode utilities to define their custom modes.

The `ace-modes.d.ts` has been created semi-automatically, and so every mode or highlight rules have the same base type, even though technically different modes can have different sub-types (so currently we are omitting some information). The expectation is to update this file manually if we need it (e.g. when a new mode is added, or more specific sub-type has to be defined).

Type definitions are excluded in the ace-builds package.

Also included small fixes for existing types, like EditSession or Config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
