### PR TITLE
Fix: replaceRange could be not instance of Range class

### DIFF
--- a/src/range.js
+++ b/src/range.js
@@ -75,7 +75,7 @@ class Range {
      * @returns {Number} This method returns one of the following numbers:
      * * `-2`: (B) is in front of (A), and doesn't intersect with (A)
      * * `-1`: (B) begins before (A) but ends inside of (A)
-     * * `0`: (B) is completely inside of (A) OR (A) is completely inside of (B)
+     * * `0`: (B) is completely inside of (A)
      * * `+1`: (B) begins inside of (A) but ends outside of (A)
      * * `+2`: (B) is after (A) and doesn't intersect with (A)
      * * `42`: FTW state: (B) ends in (A) but starts outside of (A)

--- a/src/snippets.js
+++ b/src/snippets.js
@@ -483,7 +483,7 @@ var SnippetManager = function() {
         var processedSnippet = processSnippetText.call(this, editor, snippetText);
         
         var range = editor.getSelectionRange();
-        if (replaceRange && range.compareRange(replaceRange) === 0) {
+        if (replaceRange && replaceRange.compareRange(range) === 0) {
             range = replaceRange;
         }
         var end = editor.session.replace(range, processedSnippet.text);
@@ -495,6 +495,9 @@ var SnippetManager = function() {
     
     this.insertSnippet = function(editor, snippetText, replaceRange) {
         var self = this;
+        if (replaceRange && !(replaceRange instanceof Range))
+            replaceRange = Range.fromPoints(replaceRange.start, replaceRange.end);
+        
         if (editor.inVirtualSelectionMode)
             return self.insertSnippetForSelection(editor, snippetText, replaceRange);
         

--- a/src/snippets.js
+++ b/src/snippets.js
@@ -483,7 +483,7 @@ var SnippetManager = function() {
         var processedSnippet = processSnippetText.call(this, editor, snippetText);
         
         var range = editor.getSelectionRange();
-        if (replaceRange && replaceRange.compareRange(range) === 0) {
+        if (replaceRange && range.compareRange(replaceRange) === 0) {
             range = replaceRange;
         }
         var end = editor.session.replace(range, processedSnippet.text);

--- a/src/snippets_test.js
+++ b/src/snippets_test.js
@@ -328,6 +328,14 @@ module.exports = {
         this.editor.tabstopManager.tabNext();
         editor.execCommand("insertstring", ".");
         assert.equal(editor.getValue(), "qt qt qt.");
+    },
+    "test: should work as expected with object of Range interface": function () {
+        var content = "test";
+        this.editor.setValue("replace1");
+        snippetManager.insertSnippet(this.editor, content, {
+            start: {row: 0, column: 0}, end: {row: 0, column: 7}
+        });
+        assert.equal(this.editor.getValue(), "test1");
     }
 };
 

--- a/src/snippets_test.js
+++ b/src/snippets_test.js
@@ -333,9 +333,9 @@ module.exports = {
         var content = "test";
         this.editor.setValue("replace1");
         snippetManager.insertSnippet(this.editor, content, {
-            start: {row: 0, column: 0}, end: {row: 0, column: 7}
+            start: {row: 0, column: 0}, end: {row: 0, column: 8}
         });
-        assert.equal(this.editor.getValue(), "test1");
+        assert.equal(this.editor.getValue(), "test");
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In my previous implementation, I had assumed that `replaceRange` would always be an instance of the Range class. However, I discovered that this is not necessarily true, so I made some changes to provide more flexibility with this PR.

- create Range object from `replaceRange`
- correct wrong description of `compareRange`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
