### PR TITLE
fix instances of exponential backtracking found by recheck

### DIFF
--- a/demo/kitchen-sink/docs/clojure.clj
+++ b/demo/kitchen-sink/docs/clojure.clj
@@ -17,3 +17,7 @@
 (println (parting "Mark")) ; -> Goodbye, Mark
 (println (parting "Mark" "es")) ; -> Adios, Mark
 (println (parting "Mark", "xy")) ; -> java.lang.IllegalArgumentException: unsupported language xy
+
+(print (re-matches #"abc(.*)
+            (r)" "abcxyz
+            r") )

--- a/src/mode/_test/tokens_clojure.json
+++ b/src/mode/_test/tokens_clojure.json
@@ -159,4 +159,31 @@
   ["keyword","))"],
   ["text"," "],
   ["comment","; -> java.lang.IllegalArgumentException: unsupported language xy"]
+],[
+   "start"
+],[
+   "regex",
+  ["keyword","("],
+  ["support.function","print"],
+  ["text"," "],
+  ["keyword","("],
+  ["support.function","re-matches"],
+  ["text"," "],
+  ["string.regexp","#\"abc"],
+  ["constant.language.escape","(.*)"]
+],[
+   "string",
+  ["string.regexp","            "],
+  ["constant.language.escape","("],
+  ["string.regexp","r"],
+  ["constant.language.escape",")"],
+  ["string.regexp","\""],
+  ["text"," "],
+  ["string","\"abcxyz"]
+],[
+   "start",
+  ["string","            r\""],
+  ["keyword",")"],
+  ["text"," "],
+  ["keyword",")"]
 ]]

--- a/src/mode/clojure_highlight_rules.js
+++ b/src/mode/clojure_highlight_rules.js
@@ -108,6 +108,10 @@ var ClojureHighlightRules = function() {
                 token : "keyword", //vectors
                 regex : "[\\[|\\]]"
             }, {
+                token : "string.regexp", //Regular Expressions
+                regex : '#"',
+                next: "regex"
+            }, {
                 token : "keyword", //sets and maps
                 regex : "[\\{|\\}|\\#\\{|\\#\\}]"
             }, {
@@ -141,9 +145,6 @@ var ClojureHighlightRules = function() {
             }, {
                 token : "constant", // symbol
                 regex : /:[^()\[\]{}'"\^%`,;\s]+/
-            }, {
-                token : "string.regexp", //Regular Expressions
-                regex : '/#"(?:\\.|(?:\\")|[^""\n])*"/g'
             }
 
         ],
@@ -153,11 +154,50 @@ var ClojureHighlightRules = function() {
                 regex : "\\\\.|\\\\$"
             }, {
                 token : "string",
-                regex : '[^"\\\\]+'
-            }, {
-                token : "string",
                 regex : '"',
                 next : "start"
+            }, {
+                defaultToken: "string"
+            }
+        ],
+         "regex": [
+            {
+                // escapes
+                token: "regexp.keyword.operator",
+                regex: "\\\\(?:u[\\da-fA-F]{4}|x[\\da-fA-F]{2}|.)"
+            }, {
+                // flag
+                token: "string.regexp",
+                regex: '"',
+                next: "start"
+            }, {
+                // operators
+                token : "constant.language.escape",
+                regex: /\(\?[:=!]|\)|\{\d+\b,?\d*\}|[+*]\?|[()$^+*?.]/
+            }, {
+                token : "constant.language.delimiter",
+                regex: /\|/
+            }, {
+                token: "constant.language.escape",
+                regex: /\[\^?/,
+                next: "regex_character_class"
+            }, {
+                defaultToken: "string.regexp"
+            }
+        ],
+        "regex_character_class": [
+            {
+                token: "regexp.charclass.keyword.operator",
+                regex: "\\\\(?:u[\\da-fA-F]{4}|x[\\da-fA-F]{2}|.)"
+            }, {
+                token: "constant.language.escape",
+                regex: "]",
+                next: "regex"
+            }, {
+                token: "constant.language.escape",
+                regex: "-"
+            }, {
+                defaultToken: "string.regexp.charachterclass"
             }
         ]
     };

--- a/src/mode/ion_highlight_rules.js
+++ b/src/mode/ion_highlight_rules.js
@@ -268,7 +268,7 @@
                 "variable.language.annotation.ion",
                 "punctuation.definition.annotation.ion"
               ],
-              "regex": "('(?:[^']|\\\\\\\\|\\\\')*')\\s*(::)"
+              "regex": /('(?:[^'\\]|\\.)*')\s*(::)/
             },
             {
               "token": [

--- a/src/mode/raku_highlight_rules.js
+++ b/src/mode/raku_highlight_rules.js
@@ -173,11 +173,7 @@ var RakuHighlightRules = function() {
 	// Numbers - Hexadecimal
 	var hex = {	token : "constant.numeric", regex : "0x[0-9a-fA-F]+\\b" };
 	// Numbers - Num & Rat
-	var num_rat = { token : "constant.numeric", regex : "[+-.]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b" };
-	// Numbers - With _
-	var num_with_ = { token : "constant.numeric", regex : "(?:\\d+_?\\d+)+\\b" };
-	// Numbers - Complex
-	var complex_numbers = { token : "constant.numeric", regex : "\\+?\\d+i\\b" };
+	var num_rat = { token : "constant.numeric", regex : "[+-.]?\\d[\\d_]*(?:(?:\\.\\d[\\d_]*)?(?:[eE][+-]?\\d[\\d_]*)?)?i?\\b" };
 	// Booleans
 	var booleans = { token : "constant.language.boolean", regex : "(?:True|False)\\b" };
 	// Versions
@@ -238,8 +234,6 @@ var RakuHighlightRules = function() {
 			},
 			hex,
 			num_rat,
-			num_with_,
-			complex_numbers,
 			booleans,
 			versions,
 			lang_keywords,
@@ -283,8 +277,6 @@ var RakuHighlightRules = function() {
 		"qqinterpolation" : [
 			hex,
 			num_rat,
-			num_with_,
-			complex_numbers,
 			booleans,
 			versions,
 			lang_keywords,
@@ -338,8 +330,6 @@ var RakuHighlightRules = function() {
 		"qqheredocinterpolation" : [
 			hex,
 			num_rat,
-			num_with_,
-			complex_numbers,
 			booleans,
 			versions,
 			lang_keywords,


### PR DESCRIPTION
https://www.npmjs.com/package/recheck is able to find slow regexps in many cases. It helped to find two instances of such behavior. Unfortunately it is not fast enough to run after each pull request, so i've commented out the test code, but perhaps it is worth to add a separate workflow to run recheck only for changed mode files.