### PR TITLE
Allow copy pasting from hover tooltips

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -325,7 +325,7 @@ class HoverTooltip extends Tooltip {
     hide(e) {
         if (!e && document.activeElement == this.getElement())
             return;
-        if (e && e.target && e.type != "keydown" && this.$element.contains(e.target))
+        if (e && e.target && (e.type != "keydown" || e.ctrlKey || e.metaKey) && this.$element.contains(e.target))
             return;
         this.lastEvent = null;
         if (this.timeout) clearTimeout(this.timeout);


### PR DESCRIPTION
*Description of changes:*
While the hover tooltips are focusable and selectable, key down closes the tooltip.

Now we allow CTRL/CMD key bindings to be pressed, and we keep the popup open.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
