### PR TITLE
feat: publishing generated styling files to ace-code package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "license": "BSD-3-Clause",
     "files": [
         "src",
+        "styles",
         "ace.d.ts",
         "esm-resolver.js",
         "!**/*_test.js",
@@ -41,7 +42,7 @@
         "lint": "eslint \"src/**/*.js\"",
         "fix": "eslint --fix \"src/**/*.js\"",
         "changelog": "standard-version",
-        "prepack": "node tool/esm_resolver_generator.js"
+        "prepack": "node tool/esm_resolver_generator.js && node Makefile.dryice.js css --target build-styles && mv build-styles/css styles"
     },
     "standard-version": {
         "skip": {


### PR DESCRIPTION
*Description of changes:*

- we now publish to [ace-code](https://www.npmjs.com/package/ace-code) repository the generated `css` folder that we publish to https://github.com/ajaxorg/ace-builds/tree/master/css
- this means that consumers of ace-code will now be able to use strict CSP mode by doing something like
```
import ace from "ace-code";
import 'ace-code/styles/ace.css';
import 'ace-code/styles/theme/dawn.css';
ace.config.set('useStrictCSP', true);
```

### Testing
* Ran `npm publish --dry-run` and verified that the style files are now published. New size of the package is 5.9MB versus previous 4.4MB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
