### PR TITLE
New insert snippet option to exclude extra indentation

### DIFF
--- a/src/snippets.js
+++ b/src/snippets.js
@@ -349,7 +349,7 @@ var SnippetManager = function() {
         return result;
     };
 
-    var processSnippetText = function(editor, snippetText, replaceRange) {
+    var processSnippetText = function(editor, snippetText, removeExtraIndent) {
         var cursor = editor.getCursorPosition();
         var line = editor.session.getLine(cursor.row);
         var tabString = editor.session.getTabString();
@@ -363,7 +363,7 @@ var SnippetManager = function() {
         tokens = this.resolveVariables(tokens, editor);
         // indent
         tokens = tokens.map(function(x) {
-            if (x == "\n")
+            if (x == "\n" && !removeExtraIndent)
                 return x + indentString;
             if (typeof x == "string")
                 return x.replace(/\t/g, tabString);
@@ -479,8 +479,8 @@ var SnippetManager = function() {
         return processedSnippet.text;
     };
 
-    this.insertSnippetForSelection = function(editor, snippetText, replaceRange) {
-        var processedSnippet = processSnippetText.call(this, editor, snippetText);
+    this.insertSnippetForSelection = function(editor, snippetText, replaceRange, removeExtraIndent) {
+        var processedSnippet = processSnippetText.call(this, editor, snippetText, removeExtraIndent);
         
         var range = editor.getSelectionRange();
         if (replaceRange && replaceRange.compareRange(range) === 0) {
@@ -493,16 +493,16 @@ var SnippetManager = function() {
         tabstopManager.addTabstops(processedSnippet.tabstops, range.start, end, selectionId);
     };
     
-    this.insertSnippet = function(editor, snippetText, replaceRange) {
+    this.insertSnippet = function(editor, snippetText, replaceRange, removeExtraIndent) {
         var self = this;
         if (replaceRange && !(replaceRange instanceof Range))
             replaceRange = Range.fromPoints(replaceRange.start, replaceRange.end);
         
         if (editor.inVirtualSelectionMode)
-            return self.insertSnippetForSelection(editor, snippetText, replaceRange);
+            return self.insertSnippetForSelection(editor, snippetText, replaceRange, removeExtraIndent);
         
         editor.forEachSelection(function() {
-            self.insertSnippetForSelection(editor, snippetText, replaceRange);
+            self.insertSnippetForSelection(editor, snippetText, replaceRange, removeExtraIndent);
         }, null, {keepOrder: true});
         
         if (editor.tabstopManager)

--- a/src/snippets_test.js
+++ b/src/snippets_test.js
@@ -336,6 +336,29 @@ module.exports = {
             start: {row: 0, column: 0}, end: {row: 0, column: 8}
         });
         assert.equal(this.editor.getValue(), "test");
+    },
+    "test: insert snippet without extra indentation": function() {
+        var editor = this.editor;
+
+        editor.setValue("");
+        snippetManager.insertSnippet(this.editor, "def multiply_with_random(array):\n\t");
+        snippetManager.insertSnippet(this.editor, "for i in range(len(array)):\n\t\tarray[i] *= random.randint(1, 10)\n\treturn array");
+        assert.equal(editor.getValue(), [
+            "def multiply_with_random(array):",
+            "    for i in range(len(array)):",
+            "            array[i] *= random.randint(1, 10)",
+            "        return array",
+        ].join("\n"));
+
+        editor.setValue("");
+        snippetManager.insertSnippet(this.editor, "def multiply_with_random(array):\n\t", undefined, true);
+        snippetManager.insertSnippet(this.editor, "for i in range(len(array)):\n\t\tarray[i] *= random.randint(1, 10)\n\treturn array", undefined, true);
+        assert.equal(editor.getValue(), [
+            "def multiply_with_random(array):",
+            "    for i in range(len(array)):",
+            "        array[i] *= random.randint(1, 10)",
+            "    return array",
+        ].join("\n"));
     }
 };
 


### PR DESCRIPTION
*Issue #, if available: N/A*

*Description of changes:*
By default, when item is inserted, ace will modify snippet and add indentation to match previous code line. However some tooling may already include the proper indent format, thus creating improperly indented code when inserted. This change adds the option to exclude those extra indentations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
