### PR TITLE
Allow custom parentNode for hover tooltips

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -167,8 +167,8 @@ exports.Tooltip = Tooltip;
 
 
 class HoverTooltip extends Tooltip {
-    constructor() {
-        super(document.body);
+    constructor(parentNode=document.body) {
+        super(parentNode);
         
         this.timeout = undefined;
         this.lastT = 0;

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -186,8 +186,8 @@ class HoverTooltip extends Tooltip {
         el.addEventListener("mouseout", this.onMouseOut);
         el.tabIndex = -1;
         
-        el.addEventListener("blur", function() {
-            if (document.activeElement != el) this.hide();
+        el.addEventListener("blur", function(e) {
+            if (document.activeElement != el && !el.contains(document.activeElement)) this.hide(e);
         }.bind(this));
     }
     
@@ -219,7 +219,7 @@ class HoverTooltip extends Tooltip {
                 || isMousePressed
                 || this.isOutsideOfText(this.lastEvent)
             ) {
-                this.hide();
+                this.hide(e);
             }
         }
         if (this.timeout || isMousePressed) return;
@@ -362,7 +362,7 @@ class HoverTooltip extends Tooltip {
         if (!e.relatedTarget || e.relatedTarget == this.getElement()) return;
 
         if (e && e.currentTarget.contains(e.relatedTarget)) return;
-        if (!e.relatedTarget.classList.contains("ace_content")) this.hide();
+        if (!e.relatedTarget.classList.contains("ace_content")) this.hide(e);
     }
 }
 

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -187,7 +187,7 @@ class HoverTooltip extends Tooltip {
         el.tabIndex = -1;
         
         el.addEventListener("blur", function() {
-            if (document.activeElement != el && !el.contains(document.activeElement)) this.hide();
+            if (!el.contains(document.activeElement)) this.hide();
         }.bind(this));
     }
     

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -186,8 +186,8 @@ class HoverTooltip extends Tooltip {
         el.addEventListener("mouseout", this.onMouseOut);
         el.tabIndex = -1;
         
-        el.addEventListener("blur", function(e) {
-            if (document.activeElement != el && !el.contains(document.activeElement)) this.hide(e);
+        el.addEventListener("blur", function() {
+            if (document.activeElement != el && !el.contains(document.activeElement)) this.hide();
         }.bind(this));
     }
     
@@ -219,7 +219,7 @@ class HoverTooltip extends Tooltip {
                 || isMousePressed
                 || this.isOutsideOfText(this.lastEvent)
             ) {
-                this.hide(e);
+                this.hide();
             }
         }
         if (this.timeout || isMousePressed) return;
@@ -362,7 +362,7 @@ class HoverTooltip extends Tooltip {
         if (!e.relatedTarget || e.relatedTarget == this.getElement()) return;
 
         if (e && e.currentTarget.contains(e.relatedTarget)) return;
-        if (!e.relatedTarget.classList.contains("ace_content")) this.hide(e);
+        if (!e.relatedTarget.classList.contains("ace_content")) this.hide();
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Just like tooltips, we allow custom parent nodes such that the hover tooltip could also be added to Ace editor instead of document body.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
