### PR TITLE
Custom empty message when no completion found

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -1056,6 +1056,8 @@ export namespace Ace {
     autoSelect?: boolean;
     exactMatch?: boolean;
     inlineEnabled?: boolean;
+    parentNode?: HTMLElement;
+    emptyMessage?(prefix: String): String;
     getPopup(): AcePopup;
     showPopup(editor: Editor, options: CompletionOptions): void;
     detach(): void;

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -1054,6 +1054,7 @@ export namespace Ace {
     constructor();
     autoInsert?: boolean;
     autoSelect?: boolean;
+    autoShown?: boolean;
     exactMatch?: boolean;
     inlineEnabled?: boolean;
     parentNode?: HTMLElement;

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -345,9 +345,6 @@ class Autocomplete {
 
             if (finished) {
                 // No results
-                if (!filtered.length && (!this.emptyMessage || this.autoShown))
-                    return this.detach();
-
                 if (!filtered.length) {
                     var emptyMessage = !this.autoShown && this.emptyMessage;
                     if ( typeof emptyMessage == "function")
@@ -359,8 +356,9 @@ class Autocomplete {
                         }];
                         this.completions = new FilteredList(completionsForEmpty);
                         this.openPopup(this.editor, prefix, keepPopupPosition);
+                        return;
                     }
-                    return;
+                    return this.detach();
                 }
 
                 // One result equals to the prefix

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -60,7 +60,6 @@ class Autocomplete {
         this.inlineEnabled = false;
         this.keyboardHandler = new HashHandler();
         this.keyboardHandler.bindKeys(this.commands);
-        this.emptyMessage = null;
         this.parentNode = null;
 
         this.blurListener = this.blurListener.bind(this);
@@ -349,14 +348,18 @@ class Autocomplete {
                 if (!filtered.length && (!this.emptyMessage || this.autoShown))
                     return this.detach();
 
-                if (!filtered.length && this.emptyMessage && !this.autoShown) {
-                    var completionsForEmpty = [{
-                        caption: this.emptyMessage(prefix),
-                        value: ""
-                    }];
-                    this.completions = new FilteredList(completionsForEmpty);
-                    this.completions.exactMatch = true;
-                    this.openPopup(this.editor, prefix, keepPopupPosition);
+                if (!filtered.length) {
+                    var emptyMessage = !this.autoShown && this.emptyMessage;
+                    if ( typeof emptyMessage == "function")
+                          emptyMessage = this.emptyMessage(prefix);
+                    if (emptyMessage) {
+                        var completionsForEmpty = [{
+                            caption: this.emptyMessage(prefix),
+                            value: ""
+                        }];
+                        this.completions = new FilteredList(completionsForEmpty);
+                        this.openPopup(this.editor, prefix, keepPopupPosition);
+                    }
                     return;
                 }
 
@@ -365,7 +368,7 @@ class Autocomplete {
                     return this.detach();
 
                 // Autoinsert if one result
-                if (this.autoInsert && !autoShown && filtered.length == 1)
+                if (this.autoInsert && !this.autoShown && filtered.length == 1)
                     return this.insertMatch(filtered[0]);
             }
             this.completions = completions;

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -55,6 +55,7 @@ class Autocomplete {
     constructor() {
         this.autoInsert = false;
         this.autoSelect = true;
+        this.autoShown = false;
         this.exactMatch = false;
         this.inlineEnabled = false;
         this.keyboardHandler = new HashHandler();
@@ -345,10 +346,10 @@ class Autocomplete {
 
             if (finished) {
                 // No results
-                if (!filtered.length && !this.emptyMessage)
+                if (!filtered.length && (!this.emptyMessage || this.autoShown))
                     return this.detach();
 
-                if (!filtered.length && this.emptyMessage) {
+                if (!filtered.length && this.emptyMessage && !this.autoShown) {
                     var completionsForEmpty = [{
                         caption: this.emptyMessage(prefix),
                         value: ""
@@ -364,7 +365,7 @@ class Autocomplete {
                     return this.detach();
 
                 // Autoinsert if one result
-                if (this.autoInsert && filtered.length == 1)
+                if (this.autoInsert && !autoShown && filtered.length == 1)
                     return this.insertMatch(filtered[0]);
             }
             this.completions = completions;
@@ -541,6 +542,7 @@ Autocomplete.startCommand = {
         var completer = Autocomplete.for(editor);
         completer.autoInsert = false;
         completer.autoSelect = true;
+        completer.autoShown = false;
         completer.showPopup(editor, options);
         // prevent ctrl-space opening context menu on firefox on mac
         completer.cancelContextMenu();

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -42,7 +42,6 @@ class AcePopup {
         var popup = new $singleLineEditor(el);
 
         if (parentNode) {
-            // console.log(parentNode);
             parentNode.appendChild(el);
         }
         el.style.display = "none";

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -41,8 +41,10 @@ class AcePopup {
         var el = dom.createElement("div");
         var popup = new $singleLineEditor(el);
 
-        if (parentNode)
+        if (parentNode) {
+            // console.log(parentNode);
             parentNode.appendChild(el);
+        }
         el.style.display = "none";
         popup.renderer.content.style.cursor = "default";
         popup.renderer.setStyle("ace_autocomplete");

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -174,16 +174,16 @@ module.exports = {
         var popup = editor.completer.popup;
         check(function () {
             assert.equal(popup.data.length, 4);
-            assert.equal(document.body.lastChild.innerHTML, firstDoc);
+            assert.equal(popup.container.lastChild.innerHTML, firstDoc);
             sendKey("Down");
             check(function () {
-                assert.equal(document.body.lastChild.innerHTML, secondDoc);
+                assert.equal(popup.container.lastChild.innerHTML, secondDoc);
                 sendKey("Down");
                 check(function () {
-                    assert.equal(document.body.lastChild.innerHTML, firstDoc);
+                    assert.equal(popup.container.lastChild.innerHTML, firstDoc);
                     sendKey("Down");
                     check(function () {
-                        assert.equal(document.body.lastChild.innerHTML, secondDoc);
+                        assert.equal(popup.container.lastChild.innerHTML, secondDoc);
                         editor.destroy();
                         editor.container.remove();
                         done();

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -7,8 +7,10 @@ if (typeof process !== "undefined") {
 var sendKey = require("./test/user").type;
 var ace = require("./ace");
 var assert = require("./test/assertions");
+var user = require("./test/user");
 var Range = require("./range").Range;
 require("./ext/language_tools");
+var Autocomplete = require("./autocomplete").Autocomplete;
 
 function initEditor(value) {
     var editor = ace.edit(null, {
@@ -246,6 +248,24 @@ module.exports = {
             editor.container.remove();
             done();
         }, 10);
+    },
+    "test: empty message if no suggestions available": function(done) {
+        var editor = initEditor("");
+        var emptyMessageText = "No suggestions.";
+        var autocomplete = Autocomplete.for(editor);
+        autocomplete.emptyMessage = () => emptyMessageText;
+
+        user.type("thereisnoautosuggestionforthisword");
+
+        // Open autocompletion via key-binding and verify empty message
+        user.type("Ctrl-Space");
+        assert.equal(editor.completer.popup.isOpen, true);
+        assert.equal(editor.completer.popup.data[0].caption, emptyMessageText);
+
+        user.type("Return");
+        assert.equal(editor.completer.popup.isOpen, false);
+
+        done();
     }
 };
 

--- a/src/ext/language_tools.js
+++ b/src/ext/language_tools.js
@@ -146,8 +146,8 @@ var doLiveAutocomplete = function(e) {
         // Only autocomplete if there's a prefix that can be matched
         if (prefix && !hasCompleter) {
             var completer = Autocomplete.for(editor);
-            // Disable autoInsert
-            completer.autoInsert = false;
+            // Set a flag for auto shown
+            completer.autoShown = true;
             completer.showPopup(editor);
         }
     }


### PR DESCRIPTION
1. Rebased #4959.
> Add support for setting a completer.emptyMessage function which
generates a message to display in the completions popup when there
are no completions.
  This enables configuring the editor to always give the user feedback
when they ask for suggestions, even if it is just to note that there
are none.

2. Allows users to pass a parent node to autocomplete popover (it was `body`).
3. Makes doc-tooltips a child of autocomplete popover.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
