### PR TITLE
chore: add rel="noopener noreferrer" to links which open in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,13 +47,13 @@
                             <a href="#higlighter" data-toggle="tab">Syntax Highlighters</a>
                         </li>
                         <li>
-                            <a href="https://ajaxorg.github.io/ace-api-docs/index.html" target="_blank" class="external-nav">API Reference</a>
+                            <a href="https://ajaxorg.github.io/ace-api-docs/index.html" target="_blank" rel="noopener noreferrer" class="external-nav">API Reference</a>
                         </li>
                         <li>
                             <a href="#production" data-toggle="tab">Real World Users</a>
                         </li>
                         <li class="last-tab">
-                            <a href="https://mkslanc.github.io/ace-playground/" target="_blank" class="external-nav">Try</a>
+                            <a href="https://mkslanc.github.io/ace-playground/" target="_blank" rel="noopener noreferrer" class="external-nav">Try</a>
                         </li>
                     </ul>
                     <div class="tab-content">
@@ -85,7 +85,7 @@ console.log(addResult);
 </pre>
                             <p id="embed_link"><a href="#nav=embedding">Learn how to embed this in your own site</a></p>
                             <p class="highlight_note">Looking for a more full-featured demo? Check out the
-                                <a href="build/kitchen-sink.html" target="_blank"  rel="noreferer">kitchen sink</a>.
+                                <a href="build/kitchen-sink.html" target="_blank" rel="noopener noreferrer">kitchen sink</a>.
                             </p>
                             <h2>Features</h2>
                             <ul class="content-list">
@@ -221,12 +221,12 @@ editor.getOption("optionName");
                             <h3>Changing the size of the editor</h3>
                             <p>Ace only checks for changes of the size of it's container when window is resized. If you resize the editor div in another manner, and need Ace to resize, use the following:</p>
                             <pre><code class="javascript">editor.resize()</code></pre>
-                            <p>if you want editor to change it's size based on contents, use maxLines option as shown in <a target="_blank" rel="noreferer noopener" href="https://ace.c9.io/demo/autoresize.html">https://ace.c9.io/demo/autoresize.html</a></p>
+                            <p>if you want editor to change it's size based on contents, use maxLines option as shown in <a target="_blank" rel="noopener noreferrer" href="https://ace.c9.io/demo/autoresize.html">https://ace.c9.io/demo/autoresize.html</a></p>
                             <h2>Setting Themes</h2>
                             <p>Themes are loaded on demand; all you have to do is pass the string name:</p>
                             <pre><code class="javascript">editor.setTheme("ace/theme/twilight");</code></pre>
-                            <p><span class="expand_arrow">&gt;</span> <a href="https://github.com/ajaxorg/ace/tree/master/src/theme" target="_blank" rel="noreferer noopener">See all themes.</a>
-                            Or use <a href="https://github.com/ajaxorg/ace/blob/master/src/ext/themelist.js" target="_blank" rel="noreferer noopener">themelist extension</a> to get the list of available themes at runtime.
+                            <p><span class="expand_arrow">&gt;</span> <a href="https://github.com/ajaxorg/ace/tree/master/src/theme" target="_blank" rel="noopener noreferrer">See all themes.</a>
+                            Or use <a href="https://github.com/ajaxorg/ace/blob/master/src/ext/themelist.js" target="_blank" rel="noopener noreferrer">themelist extension</a> to get the list of available themes at runtime.
                             </p>
                             <h2>Setting the Programming Language Mode</h2>
                             <p>By default, the editor supports plain text mode. All other language modes are available as separate modules, loaded on demand like this:</p>
@@ -289,7 +289,7 @@ editor.insertSnippet("x$0y");</code></pre>
 session.$undoManager.markIgnored(rev); // mark the new group as ignored</code></pre>
 
 
-                            <p>To implement undo/redo buttons see <a target="_blank" rel="noreferer noopener" href="https://ace.c9.io/demo/toolbar.html">https://ace.c9.io/demo/toolbar.html</a></p>
+                            <p>To implement undo/redo buttons see <a target="_blank" rel="noopener noreferrer" href="https://ace.c9.io/demo/toolbar.html">https://ace.c9.io/demo/toolbar.html</a></p>
 
                             <h3>Searching</h3>
                             <pre><code class="language-javascript">editor.find('needle',{


### PR DESCRIPTION
*Description of changes:*

Some links in index.html with `target="_blank"` were missing `rel="noopener noreferrer"`, and some had `referrer` spelled with a typo (with one r).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
