### PR TITLE
fix: console error when hovering over empty gutter cell with tooltipFollowsMouse set to false

### DIFF
--- a/src/mouse/default_gutter_handler.js
+++ b/src/mouse/default_gutter_handler.js
@@ -48,6 +48,9 @@ function GutterHandler(mouseHandler) {
         }
 
         tooltip.showTooltip(row);
+        
+        if (!tooltip.isOpen)
+            return;
 
         editor.on("mousewheel", hideTooltip);
 

--- a/src/mouse/default_gutter_handler.js
+++ b/src/mouse/default_gutter_handler.js
@@ -39,6 +39,9 @@ function GutterHandler(mouseHandler) {
     function showTooltip() {
         var row = mouseEvent.getDocumentPosition().row;
 
+        if (!gutter.$annotations[row])
+            return hideTooltip();
+
         var maxRow = editor.session.getLength();
         if (row == maxRow) {
             var screenRow = editor.renderer.pixelToScreenCoordinates(0, mouseEvent.y).row;
@@ -49,9 +52,6 @@ function GutterHandler(mouseHandler) {
 
         tooltip.showTooltip(row);
         
-        if (!tooltip.isOpen)
-            return;
-
         editor.on("mousewheel", hideTooltip);
 
         if (mouseHandler.$tooltipFollowsMouse) {

--- a/src/mouse/default_gutter_handler.js
+++ b/src/mouse/default_gutter_handler.js
@@ -39,9 +39,6 @@ function GutterHandler(mouseHandler) {
     function showTooltip() {
         var row = mouseEvent.getDocumentPosition().row;
 
-        if (!gutter.$annotations[row])
-            return hideTooltip();
-
         var maxRow = editor.session.getLength();
         if (row == maxRow) {
             var screenRow = editor.renderer.pixelToScreenCoordinates(0, mouseEvent.y).row;
@@ -51,7 +48,10 @@ function GutterHandler(mouseHandler) {
         }
 
         tooltip.showTooltip(row);
-        
+
+        if (!tooltip.isOpen)
+            return;
+
         editor.on("mousewheel", hideTooltip);
 
         if (mouseHandler.$tooltipFollowsMouse) {


### PR DESCRIPTION
When hovering over an empty gutter cell with `tooltipFollowsMouse` set to `false`, a console error is thrown because the querySelector is trying to find an non-existing element. This fixes that by checking whether there is an annotation in the row before trying to show the tooltip.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
