### PR TITLE
fix: include ace-modes to the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "src",
         "styles",
         "ace.d.ts",
+        "ace-modes.d.ts",
         "esm-resolver.js",
         "translations",
         "!**/*_test.js",


### PR DESCRIPTION
Forgot to include the ace-modes.d.ts types to the npm package in this PR: https://github.com/ajaxorg/ace/pull/5142

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
