### PR TITLE
fix: don't throw unhandled errors in TabstopManager when EditSession becomes `undefined`

### DIFF
--- a/src/keyboard/hash_handler.js
+++ b/src/keyboard/hash_handler.js
@@ -6,11 +6,15 @@ var KEY_MODS = keyUtil.KEY_MODS;
 
 class MultiHashHandler {
     constructor(config, platform) {
+        this.$init(config, platform, false);
+    }
+
+    $init(config, platform, $singleCommand) {
         this.platform = platform || (useragent.isMac ? "mac" : "win");
         this.commands = {};
         this.commandKeyBinding = {};
         this.addCommands(config);
-        this.$singleCommand = false;
+        this.$singleCommand = $singleCommand;
     }
 
     addCommand(command) {
@@ -218,6 +222,13 @@ class HashHandler extends MultiHashHandler {
         this.$singleCommand = true;
     }
 }
+
+HashHandler.call = function(thisArg, config, platform) {
+    MultiHashHandler.prototype.$init.call(thisArg, config, platform, true);
+};
+MultiHashHandler.call = function(thisArg, config, platform) {
+    MultiHashHandler.prototype.$init.call(thisArg, config, platform, false);
+};
 
 exports.HashHandler = HashHandler;
 exports.MultiHashHandler = MultiHashHandler;

--- a/src/keyboard/hash_handler.js
+++ b/src/keyboard/hash_handler.js
@@ -4,25 +4,16 @@ var keyUtil = require("../lib/keys");
 var useragent = require("../lib/useragent");
 var KEY_MODS = keyUtil.KEY_MODS;
 
-function HashHandler(config, platform) {
-    this.platform = platform || (useragent.isMac ? "mac" : "win");
-    this.commands = {};
-    this.commandKeyBinding = {};
-    this.addCommands(config);
-    this.$singleCommand = true;
-}
+class MultiHashHandler {
+    constructor(config, platform) {
+        this.platform = platform || (useragent.isMac ? "mac" : "win");
+        this.commands = {};
+        this.commandKeyBinding = {};
+        this.addCommands(config);
+        this.$singleCommand = false;
+    }
 
-function MultiHashHandler(config, platform) {
-    HashHandler.call(this, config, platform);
-    this.$singleCommand = false;
-}
-
-MultiHashHandler.prototype = HashHandler.prototype;
-
-(function() {
-    
-
-    this.addCommand = function(command) {
+    addCommand(command) {
         if (this.commands[command.name])
             this.removeCommand(command);
 
@@ -30,9 +21,9 @@ MultiHashHandler.prototype = HashHandler.prototype;
 
         if (command.bindKey)
             this._buildKeyHash(command);
-    };
+    }
 
-    this.removeCommand = function(command, keepCommand) {
+    removeCommand(command, keepCommand) {
         var name = command && (typeof command === 'string' ? command : command.name);
         command = this.commands[name];
         if (!keepCommand)
@@ -54,9 +45,9 @@ MultiHashHandler.prototype = HashHandler.prototype;
                 }
             }
         }
-    };
+    }
 
-    this.bindKey = function(key, command, position) {
+    bindKey(key, command, position) {
         if (typeof key == "object" && key) {
             if (position == undefined)
                 position = key.position;
@@ -84,14 +75,9 @@ MultiHashHandler.prototype = HashHandler.prototype;
             var id = KEY_MODS[binding.hashId] + binding.key;
             this._addCommandToBinding(chain + id, command, position);
         }, this);
-    };
-    
-    function getPosition(command) {
-        return typeof command == "object" && command.bindKey
-            && command.bindKey.position 
-            || (command.isDefault ? -100 : 0);
     }
-    this._addCommandToBinding = function(keyId, command, position) {
+    
+    _addCommandToBinding(keyId, command, position) {
         var ckb = this.commandKeyBinding, i;
         if (!command) {
             delete ckb[keyId];
@@ -117,9 +103,9 @@ MultiHashHandler.prototype = HashHandler.prototype;
             }
             commands.splice(i, 0, command);
         }
-    };
+    }
 
-    this.addCommands = function(commands) {
+    addCommands(commands) {
         commands && Object.keys(commands).forEach(function(name) {
             var command = commands[name];
             if (!command)
@@ -139,27 +125,27 @@ MultiHashHandler.prototype = HashHandler.prototype;
 
             this.addCommand(command);
         }, this);
-    };
+    }
 
-    this.removeCommands = function(commands) {
+    removeCommands(commands) {
         Object.keys(commands).forEach(function(name) {
             this.removeCommand(commands[name]);
         }, this);
-    };
+    }
 
-    this.bindKeys = function(keyList) {
+    bindKeys(keyList) {
         Object.keys(keyList).forEach(function(key) {
             this.bindKey(key, keyList[key]);
         }, this);
-    };
+    }
 
-    this._buildKeyHash = function(command) {
+    _buildKeyHash(command) {
         this.bindKey(command.bindKey, command);
-    };
+    }
 
     // accepts keys in the form ctrl+Enter or ctrl-Enter
     // keys without modifiers or shift only 
-    this.parseKeys = function(keys) {
+    parseKeys(keys) {
         var parts = keys.toLowerCase().split(/[\-\+]([\-\+])?/).filter(function(x){return x;});
         var key = parts.pop();
 
@@ -182,14 +168,14 @@ MultiHashHandler.prototype = HashHandler.prototype;
             hashId |= modifier;
         }
         return {key: key, hashId: hashId};
-    };
+    }
 
-    this.findKeyCommand = function findKeyCommand(hashId, keyString) {
+    findKeyCommand(hashId, keyString) {
         var key = KEY_MODS[hashId] + keyString;
         return this.commandKeyBinding[key];
-    };
+    }
 
-    this.handleKeyboard = function(data, hashId, keyString, keyCode) {
+    handleKeyboard(data, hashId, keyString, keyCode) {
         if (keyCode < 0) return;
         var key = KEY_MODS[hashId] + keyString;
         var command = this.commandKeyBinding[key];
@@ -212,13 +198,26 @@ MultiHashHandler.prototype = HashHandler.prototype;
                 data.$keyChain = ""; // reset keyChain
         }
         return {command: command};
-    };
+    }
     
-    this.getStatusText = function(editor, data) {
+    getStatusText(editor, data) {
         return data.$keyChain || "";
-    };
+    }
 
-}).call(HashHandler.prototype);
+}
+
+function getPosition(command) {
+    return typeof command == "object" && command.bindKey
+        && command.bindKey.position 
+        || (command.isDefault ? -100 : 0);
+}
+
+class HashHandler extends MultiHashHandler {
+    constructor(config, platform) {
+        super(config, platform);
+        this.$singleCommand = true;
+    }
+}
 
 exports.HashHandler = HashHandler;
 exports.MultiHashHandler = MultiHashHandler;

--- a/src/snippets.js
+++ b/src/snippets.js
@@ -964,6 +964,7 @@ var TabstopManager = function(editor) {
     };
     this.removeTabstopMarkers = function(ts) {
         var session = this.editor.session;
+        if (!session) return;
         ts.forEach(function(range) {
             session.removeMarker(range.markerId);
             range.markerId = null;

--- a/src/snippets.js
+++ b/src/snippets.js
@@ -87,19 +87,19 @@ function date(dateFormat) {
     return str.length == 1 ? "0" + str : str;
 }
 
-var SnippetManager = function() {
-    this.snippetMap = {};
-    this.snippetNameMap = {};
-};
+class SnippetManager {
+    constructor() {
+        this.snippetMap = {};
+        this.snippetNameMap = {};
+        this.variables = VARIABLES;
+    }
 
-(function() {
-    oop.implement(this, EventEmitter);
     
-    this.getTokenizer = function() {
+    getTokenizer() {
         return SnippetManager.$tokenizer || this.createTokenizer();
-    };
+    }
     
-    this.createTokenizer = function() {
+    createTokenizer() {
         function TabstopToken(str) {
             str = str.substr(1);
             if (/^\d+$/.test(str))
@@ -218,15 +218,15 @@ var SnippetManager = function() {
             ]
         });
         return SnippetManager.$tokenizer;
-    };
+    }
 
-    this.tokenizeTmSnippet = function(str, startState) {
+    tokenizeTmSnippet(str, startState) {
         return this.getTokenizer().getLineTokens(str, startState).tokens.map(function(x) {
             return x.value || x;
         });
-    };
+    }
     
-    this.getVariableValue = function(editor, name, indentation) {
+    getVariableValue(editor, name, indentation) {
         if (/^\d+$/.test(name))
             return (this.variables.__ || {})[name] || "";
         if (/^[A-Z]\d+$/.test(name))
@@ -239,12 +239,10 @@ var SnippetManager = function() {
         if (typeof value == "function")
             value = this.variables[name](editor, name, indentation);
         return value == null ? "" : value;
-    };
+    }
     
-    this.variables = VARIABLES;
-
     // returns string formatted according to http://manual.macromates.com/en/regular_expressions#replacement_string_syntax_format_strings
-    this.tmStrFormat = function(str, ch, editor) {
+    tmStrFormat(str, ch, editor) {
         if (!ch.fmt) return str;
         var flag = ch.flag || "";
         var re = ch.guard;
@@ -282,17 +280,17 @@ var SnippetManager = function() {
             return fmtParts.join("");
         });
         return formatted;
-    };
+    }
     
-    this.tmFormatFunction = function(str, ch, editor) {
+    tmFormatFunction(str, ch, editor) {
         if (ch.formatFunction == "upcase")
             return str.toUpperCase();
         if (ch.formatFunction == "downcase")
             return str.toLowerCase();
         return str;
-    };
+    }
 
-    this.resolveVariables = function(snippet, editor) {
+    resolveVariables(snippet, editor) {
         var result = [];
         var indentation = "";
         var afterNewLine = true;
@@ -347,139 +345,14 @@ var SnippetManager = function() {
                 i = i1;
         }
         return result;
-    };
+    }
 
-    var processSnippetText = function(editor, snippetText, options={}) {
-        var cursor = editor.getCursorPosition();
-        var line = editor.session.getLine(cursor.row);
-        var tabString = editor.session.getTabString();
-        var indentString = line.match(/^\s*/)[0];
-        
-        if (cursor.column < indentString.length)
-            indentString = indentString.slice(0, cursor.column);
-
-        snippetText = snippetText.replace(/\r/g, "");
-        var tokens = this.tokenizeTmSnippet(snippetText);
-        tokens = this.resolveVariables(tokens, editor);
-        // indent
-        tokens = tokens.map(function(x) {
-            if (x == "\n" && !options.excludeExtraIndent)
-                return x + indentString;
-            if (typeof x == "string")
-                return x.replace(/\t/g, tabString);
-            return x;
-        });
-        // tabstop values
-        var tabstops = [];
-        tokens.forEach(function(p, i) {
-            if (typeof p != "object")
-                return;
-            var id = p.tabstopId;
-            var ts = tabstops[id];
-            if (!ts) {
-                ts = tabstops[id] = [];
-                ts.index = id;
-                ts.value = "";
-                ts.parents = {};
-            }
-            if (ts.indexOf(p) !== -1)
-                return;
-            if (p.choices && !ts.choices)
-                ts.choices = p.choices;
-            ts.push(p);
-            var i1 = tokens.indexOf(p, i + 1);
-            if (i1 === -1)
-                return;
-
-            var value = tokens.slice(i + 1, i1);
-            var isNested = value.some(function(t) {return typeof t === "object";});
-            if (isNested && !ts.value) {
-                ts.value = value;
-            } else if (value.length && (!ts.value || typeof ts.value !== "string")) {
-                ts.value = value.join("");
-            }
-        });
-
-        // expand tabstop values
-        tabstops.forEach(function(ts) {ts.length = 0;});
-        var expanding = {};
-        function copyValue(val) {
-            var copy = [];
-            for (var i = 0; i < val.length; i++) {
-                var p = val[i];
-                if (typeof p == "object") {
-                    if (expanding[p.tabstopId])
-                        continue;
-                    var j = val.lastIndexOf(p, i - 1);
-                    p = copy[j] || {tabstopId: p.tabstopId};
-                }
-                copy[i] = p;
-            }
-            return copy;
-        }
-        for (var i = 0; i < tokens.length; i++) {
-            var p = tokens[i];
-            if (typeof p != "object")
-                continue;
-            var id = p.tabstopId;
-            var ts = tabstops[id];
-            var i1 = tokens.indexOf(p, i + 1);
-            if (expanding[id]) {
-                // if reached closing bracket clear expanding state
-                if (expanding[id] === p) {
-                    delete expanding[id];
-                    Object.keys(expanding).forEach(function(parentId) {
-                        ts.parents[parentId] = true;
-                    });
-                }
-                // otherwise just ignore recursive tabstop
-                continue;
-            }
-            expanding[id] = p;
-            var value = ts.value;
-            if (typeof value !== "string")
-                value = copyValue(value);
-            else if (p.fmt)
-                value = this.tmStrFormat(value, p, editor);
-            tokens.splice.apply(tokens, [i + 1, Math.max(0, i1 - i)].concat(value, p));
-
-            if (ts.indexOf(p) === -1)
-                ts.push(p);
-        }
-        
-        // convert to plain text
-        var row = 0, column = 0;
-        var text = "";
-        tokens.forEach(function(t) {
-            if (typeof t === "string") {
-                var lines = t.split("\n");
-                if (lines.length > 1){
-                    column = lines[lines.length - 1].length;
-                    row += lines.length - 1;
-                } else
-                    column += t.length;
-                text += t;
-            } else if (t) {
-                if (!t.start)
-                    t.start = {row: row, column: column};
-                else
-                    t.end = {row: row, column: column};
-            }
-        });
-
-        return {
-            text,
-            tabstops,
-            tokens
-        };
-    };
-
-    this.getDisplayTextForSnippet = function(editor, snippetText) {
+    getDisplayTextForSnippet(editor, snippetText) {
         var processedSnippet = processSnippetText.call(this, editor, snippetText);
         return processedSnippet.text;
-    };
+    }
 
-    this.insertSnippetForSelection = function(editor, snippetText, options={}) {
+    insertSnippetForSelection(editor, snippetText, options={}) {
         var processedSnippet = processSnippetText.call(this, editor, snippetText, options);
         
         var range = editor.getSelectionRange();
@@ -491,9 +364,9 @@ var SnippetManager = function() {
         var tabstopManager = new TabstopManager(editor);
         var selectionId = editor.inVirtualSelectionMode && editor.selection.index;
         tabstopManager.addTabstops(processedSnippet.tabstops, range.start, end, selectionId);
-    };
+    }
     
-    this.insertSnippet = function(editor, snippetText, options={}) {
+    insertSnippet(editor, snippetText, options={}) {
         var self = this;
         if (options.range && !(options.range instanceof Range))
             options.range = Range.fromPoints(options.range.start, options.range.end);
@@ -507,9 +380,9 @@ var SnippetManager = function() {
         
         if (editor.tabstopManager)
             editor.tabstopManager.tabNext();
-    };
+    }
 
-    this.$getScope = function(editor) {
+    $getScope(editor) {
         var scope = editor.session.$mode.$id || "";
         scope = scope.split("/").pop();
         if (scope === "html" || scope === "php") {
@@ -532,9 +405,9 @@ var SnippetManager = function() {
         }
         
         return scope;
-    };
+    }
 
-    this.getActiveScopes = function(editor) {
+    getActiveScopes(editor) {
         var scope = this.$getScope(editor);
         var scopes = [scope];
         var snippetMap = this.snippetMap;
@@ -543,9 +416,9 @@ var SnippetManager = function() {
         }
         scopes.push("_");
         return scopes;
-    };
+    }
 
-    this.expandWithTab = function(editor, options) {
+    expandWithTab(editor, options) {
         var self = this;
         var result = editor.forEachSelection(function() {
             return self.expandSnippetForSelection(editor, options);
@@ -553,9 +426,9 @@ var SnippetManager = function() {
         if (result && editor.tabstopManager)
             editor.tabstopManager.tabNext();
         return result;
-    };
+    }
     
-    this.expandSnippetForSelection = function(editor, options) {
+    expandSnippetForSelection(editor, options) {
         var cursor = editor.getCursorPosition();
         var line = editor.session.getLine(cursor.row);
         var before = line.substring(0, cursor.column);
@@ -584,9 +457,9 @@ var SnippetManager = function() {
 
         this.variables.M__ = this.variables.T__ = null;
         return true;
-    };
+    }
 
-    this.findMatchingSnippet = function(snippetList, before, after) {
+    findMatchingSnippet(snippetList, before, after) {
         for (var i = snippetList.length; i--;) {
             var s = snippetList[i];
             if (s.startRe && !s.startRe.test(before))
@@ -602,11 +475,9 @@ var SnippetManager = function() {
             s.replaceAfter = s.endTriggerRe ? s.endTriggerRe.exec(after)[0] : "";
             return s;
         }
-    };
+    }
 
-    this.snippetMap = {};
-    this.snippetNameMap = {};
-    this.register = function(snippets, scope) {
+    register(snippets, scope) {
         var snippetMap = this.snippetMap;
         var snippetNameMap = this.snippetNameMap;
         var self = this;
@@ -684,8 +555,8 @@ var SnippetManager = function() {
         }
         
         this._signal("registerSnippets", {scope: scope});
-    };
-    this.unregister = function(snippets, scope) {
+    }
+    unregister(snippets, scope) {
         var snippetMap = this.snippetMap;
         var snippetNameMap = this.snippetNameMap;
 
@@ -703,8 +574,8 @@ var SnippetManager = function() {
             removeSnippet(snippets);
         else if (Array.isArray(snippets))
             snippets.forEach(removeSnippet);
-    };
-    this.parseSnippetFile = function(str) {
+    }
+    parseSnippetFile(str) {
         str = str.replace(/\r/g, "");
         var list = [], snippet = {};
         var re = /^#.*|^({[\s\S]*})\s*$|^(\S+) (.*)$|^((?:\n*\t.*)+)/gm;
@@ -737,8 +608,8 @@ var SnippetManager = function() {
             }
         }
         return list;
-    };
-    this.getSnippetByName = function(name, editor) {
+    }
+    getSnippetByName(name, editor) {
         var snippetMap = this.snippetNameMap;
         var snippet;
         this.getActiveScopes(editor).some(function(scope) {
@@ -748,26 +619,152 @@ var SnippetManager = function() {
             return !!snippet;
         }, this);
         return snippet;
+    }
+}
+
+oop.implement(SnippetManager.prototype, EventEmitter);
+
+var processSnippetText = function(editor, snippetText, options={}) {
+    var cursor = editor.getCursorPosition();
+    var line = editor.session.getLine(cursor.row);
+    var tabString = editor.session.getTabString();
+    var indentString = line.match(/^\s*/)[0];
+    
+    if (cursor.column < indentString.length)
+        indentString = indentString.slice(0, cursor.column);
+
+    snippetText = snippetText.replace(/\r/g, "");
+    var tokens = this.tokenizeTmSnippet(snippetText);
+    tokens = this.resolveVariables(tokens, editor);
+    // indent
+    tokens = tokens.map(function(x) {
+        if (x == "\n" && !options.excludeExtraIndent)
+            return x + indentString;
+        if (typeof x == "string")
+            return x.replace(/\t/g, tabString);
+        return x;
+    });
+    // tabstop values
+    var tabstops = [];
+    tokens.forEach(function(p, i) {
+        if (typeof p != "object")
+            return;
+        var id = p.tabstopId;
+        var ts = tabstops[id];
+        if (!ts) {
+            ts = tabstops[id] = [];
+            ts.index = id;
+            ts.value = "";
+            ts.parents = {};
+        }
+        if (ts.indexOf(p) !== -1)
+            return;
+        if (p.choices && !ts.choices)
+            ts.choices = p.choices;
+        ts.push(p);
+        var i1 = tokens.indexOf(p, i + 1);
+        if (i1 === -1)
+            return;
+
+        var value = tokens.slice(i + 1, i1);
+        var isNested = value.some(function(t) {return typeof t === "object";});
+        if (isNested && !ts.value) {
+            ts.value = value;
+        } else if (value.length && (!ts.value || typeof ts.value !== "string")) {
+            ts.value = value.join("");
+        }
+    });
+
+    // expand tabstop values
+    tabstops.forEach(function(ts) {ts.length = 0;});
+    var expanding = {};
+    function copyValue(val) {
+        var copy = [];
+        for (var i = 0; i < val.length; i++) {
+            var p = val[i];
+            if (typeof p == "object") {
+                if (expanding[p.tabstopId])
+                    continue;
+                var j = val.lastIndexOf(p, i - 1);
+                p = copy[j] || {tabstopId: p.tabstopId};
+            }
+            copy[i] = p;
+        }
+        return copy;
+    }
+    for (var i = 0; i < tokens.length; i++) {
+        var p = tokens[i];
+        if (typeof p != "object")
+            continue;
+        var id = p.tabstopId;
+        var ts = tabstops[id];
+        var i1 = tokens.indexOf(p, i + 1);
+        if (expanding[id]) {
+            // if reached closing bracket clear expanding state
+            if (expanding[id] === p) {
+                delete expanding[id];
+                Object.keys(expanding).forEach(function(parentId) {
+                    ts.parents[parentId] = true;
+                });
+            }
+            // otherwise just ignore recursive tabstop
+            continue;
+        }
+        expanding[id] = p;
+        var value = ts.value;
+        if (typeof value !== "string")
+            value = copyValue(value);
+        else if (p.fmt)
+            value = this.tmStrFormat(value, p, editor);
+        tokens.splice.apply(tokens, [i + 1, Math.max(0, i1 - i)].concat(value, p));
+
+        if (ts.indexOf(p) === -1)
+            ts.push(p);
+    }
+    
+    // convert to plain text
+    var row = 0, column = 0;
+    var text = "";
+    tokens.forEach(function(t) {
+        if (typeof t === "string") {
+            var lines = t.split("\n");
+            if (lines.length > 1){
+                column = lines[lines.length - 1].length;
+                row += lines.length - 1;
+            } else
+                column += t.length;
+            text += t;
+        } else if (t) {
+            if (!t.start)
+                t.start = {row: row, column: column};
+            else
+                t.end = {row: row, column: column};
+        }
+    });
+
+    return {
+        text,
+        tabstops,
+        tokens
     };
-
-}).call(SnippetManager.prototype);
-
-
-var TabstopManager = function(editor) {
-    if (editor.tabstopManager)
-        return editor.tabstopManager;
-    editor.tabstopManager = this;
-    this.$onChange = this.onChange.bind(this);
-    this.$onChangeSelection = lang.delayedCall(this.onChangeSelection.bind(this)).schedule;
-    this.$onChangeSession = this.onChangeSession.bind(this);
-    this.$onAfterExec = this.onAfterExec.bind(this);
-    this.attach(editor);
 };
-(function() {
-    this.attach = function(editor) {
+
+class TabstopManager {
+    constructor(editor) {
         this.index = 0;
         this.ranges = [];
         this.tabstops = [];
+        if (editor.tabstopManager)
+            return editor.tabstopManager;
+        editor.tabstopManager = this;
+        this.$onChange = this.onChange.bind(this);
+        this.$onChangeSelection = lang.delayedCall(this.onChangeSelection.bind(this)).schedule;
+        this.$onChangeSession = this.onChangeSession.bind(this);
+        this.$onAfterExec = this.onAfterExec.bind(this);
+        this.attach(editor);
+    }
+
+    attach(editor) {
         this.$openTabstops = null;
         this.selectedTabstop = null;
 
@@ -777,26 +774,26 @@ var TabstopManager = function(editor) {
         this.editor.on("changeSession", this.$onChangeSession);
         this.editor.commands.on("afterExec", this.$onAfterExec);
         this.editor.keyBinding.addKeyboardHandler(this.keyboardHandler);
-    };
-    this.detach = function() {
+    }
+    detach() {
         this.tabstops.forEach(this.removeTabstopMarkers, this);
-        this.ranges = null;
-        this.tabstops = null;
+        this.ranges.length = 0;
+        this.tabstops.length = 0;
         this.selectedTabstop = null;
-        this.editor.removeListener("change", this.$onChange);
-        this.editor.removeListener("changeSelection", this.$onChangeSelection);
-        this.editor.removeListener("changeSession", this.$onChangeSession);
-        this.editor.commands.removeListener("afterExec", this.$onAfterExec);
+        this.editor.off("change", this.$onChange);
+        this.editor.off("changeSelection", this.$onChangeSelection);
+        this.editor.off("changeSession", this.$onChangeSession);
+        this.editor.commands.off("afterExec", this.$onAfterExec);
         this.editor.keyBinding.removeKeyboardHandler(this.keyboardHandler);
         this.editor.tabstopManager = null;
         this.editor = null;
-    };
+    }
 
-    this.onChange = function(delta) {
+    onChange(delta) {
         var isRemove = delta.action[0] == "r";
         var selectedTabstop = this.selectedTabstop || {};
         var parents = selectedTabstop.parents || {};
-        var tabstops = (this.tabstops || []).slice();
+        var tabstops = this.tabstops.slice();
         for (var i = 0; i < tabstops.length; i++) {
             var ts = tabstops[i];
             var active = ts == selectedTabstop || parents[ts.index];
@@ -817,8 +814,8 @@ var TabstopManager = function(editor) {
         var session = this.editor.session;
         if (!this.$inChange && isRemove && session.getLength() == 1 && !session.getValue())
             this.detach();
-    };
-    this.updateLinkedFields = function() {
+    }
+    updateLinkedFields() {
         var ts = this.selectedTabstop;
         if (!ts || !ts.hasLinkedRanges || !ts.firstNonLinked)
             return;
@@ -834,12 +831,12 @@ var TabstopManager = function(editor) {
             session.replace(range, fmt);
         }
         this.$inChange = false;
-    };
-    this.onAfterExec = function(e) {
+    }
+    onAfterExec(e) {
         if (e.command && !e.command.readOnly)
             this.updateLinkedFields();
-    };
-    this.onChangeSelection = function() {
+    }
+    onChangeSelection() {
         if (!this.editor)
             return;
         var lead = this.editor.selection.lead;
@@ -854,11 +851,11 @@ var TabstopManager = function(editor) {
                 return;
         }
         this.detach();
-    };
-    this.onChangeSession = function() {
+    }
+    onChangeSession() {
         this.detach();
-    };
-    this.tabNext = function(dir) {
+    }
+    tabNext(dir) {
         var max = this.tabstops.length;
         var index = this.index + (dir || 1);
         index = Math.min(Math.max(index, 1), max);
@@ -867,8 +864,8 @@ var TabstopManager = function(editor) {
         this.selectTabstop(index);
         if (index === 0)
             this.detach();
-    };
-    this.selectTabstop = function(index) {
+    }
+    selectTabstop(index) {
         this.$openTabstops = null;
         var ts = this.tabstops[this.index];
         if (ts)
@@ -896,8 +893,8 @@ var TabstopManager = function(editor) {
         this.editor.keyBinding.addKeyboardHandler(this.keyboardHandler);
         if (this.selectedTabstop && this.selectedTabstop.choices)
             this.editor.execCommand("startAutocomplete", {matches: this.selectedTabstop.choices});
-    };
-    this.addTabstops = function(tabstops, start, end) {
+    }
+    addTabstops(tabstops, start, end) {
         var useLink = this.useLink || !this.editor.getOption("enableMultiselect");
         
         if (!this.$openTabstops)
@@ -953,24 +950,24 @@ var TabstopManager = function(editor) {
                 arg.push(arg.splice(2, 1)[0]);
             this.tabstops.splice.apply(this.tabstops, arg);
         }
-    };
+    }
 
-    this.addTabstopMarkers = function(ts) {
+    addTabstopMarkers(ts) {
         var session = this.editor.session;
         ts.forEach(function(range) {
             if  (!range.markerId)
                 range.markerId = session.addMarker(range, "ace_snippet-marker", "text");
         });
-    };
-    this.removeTabstopMarkers = function(ts) {
+    }
+    removeTabstopMarkers(ts) {
         var session = this.editor.session;
         if (!session) return;
         ts.forEach(function(range) {
             session.removeMarker(range.markerId);
             range.markerId = null;
         });
-    };
-    this.removeRange = function(range) {
+    }
+    removeRange(range) {
         var i = range.tabstop.indexOf(range);
         if (i != -1) range.tabstop.splice(i, 1);
         i = this.ranges.indexOf(range);
@@ -985,26 +982,26 @@ var TabstopManager = function(editor) {
             if (!this.tabstops.length)
                 this.detach();
         }
-    };
+    }
+}
 
-    this.keyboardHandler = new HashHandler();
-    this.keyboardHandler.bindKeys({
-        "Tab": function(editor) {
-            if (exports.snippetManager && exports.snippetManager.expandWithTab(editor))
-                return;
-            editor.tabstopManager.tabNext(1);
-            editor.renderer.scrollCursorIntoView();
-        },
-        "Shift-Tab": function(editor) {
-            editor.tabstopManager.tabNext(-1);
-            editor.renderer.scrollCursorIntoView();
-        },
-        "Esc": function(editor) {
-            editor.tabstopManager.detach();
-        }
-    });
-}).call(TabstopManager.prototype);
 
+TabstopManager.prototype.keyboardHandler = new HashHandler();
+TabstopManager.prototype.keyboardHandler.bindKeys({
+    "Tab": function(editor) {
+        if (exports.snippetManager && exports.snippetManager.expandWithTab(editor))
+            return;
+        editor.tabstopManager.tabNext(1);
+        editor.renderer.scrollCursorIntoView();
+    },
+    "Shift-Tab": function(editor) {
+        editor.tabstopManager.tabNext(-1);
+        editor.renderer.scrollCursorIntoView();
+    },
+    "Esc": function(editor) {
+        editor.tabstopManager.detach();
+    }
+});
 
 
 var movePoint = function(point, diff) {

--- a/src/snippets.js
+++ b/src/snippets.js
@@ -769,6 +769,7 @@ class TabstopManager {
         this.selectedTabstop = null;
 
         this.editor = editor;
+        this.session = editor.session;
         this.editor.on("change", this.$onChange);
         this.editor.on("changeSelection", this.$onChangeSelection);
         this.editor.on("changeSession", this.$onChangeSession);
@@ -786,6 +787,7 @@ class TabstopManager {
         this.editor.commands.off("afterExec", this.$onAfterExec);
         this.editor.keyBinding.removeKeyboardHandler(this.keyboardHandler);
         this.editor.tabstopManager = null;
+        this.session = null;
         this.editor = null;
     }
 
@@ -811,7 +813,7 @@ class TabstopManager {
             }
             ts.rangeList.$onChange(delta);
         }
-        var session = this.editor.session;
+        var session = this.session;
         if (!this.$inChange && isRemove && session.getLength() == 1 && !session.getValue())
             this.detach();
     }
@@ -820,7 +822,7 @@ class TabstopManager {
         if (!ts || !ts.hasLinkedRanges || !ts.firstNonLinked)
             return;
         this.$inChange = true;
-        var session = this.editor.session;
+        var session = this.session;
         var text = session.getTextRange(ts.firstNonLinked);
         for (var i = 0; i < ts.length; i++) {
             var range = ts[i];
@@ -953,15 +955,14 @@ class TabstopManager {
     }
 
     addTabstopMarkers(ts) {
-        var session = this.editor.session;
+        var session = this.session;
         ts.forEach(function(range) {
             if  (!range.markerId)
                 range.markerId = session.addMarker(range, "ace_snippet-marker", "text");
         });
     }
     removeTabstopMarkers(ts) {
-        var session = this.editor.session;
-        if (!session) return;
+        var session = this.session;
         ts.forEach(function(range) {
             session.removeMarker(range.markerId);
             range.markerId = null;
@@ -974,7 +975,7 @@ class TabstopManager {
         if (i != -1) this.ranges.splice(i, 1);
         i = range.tabstop.rangeList.ranges.indexOf(range);
         if (i != -1) range.tabstop.splice(i, 1);
-        this.editor.session.removeMarker(range.markerId);
+        this.session.removeMarker(range.markerId);
         if (!range.tabstop.length) {
             i = this.tabstops.indexOf(range.tabstop);
             if (i != -1)

--- a/src/snippets_test.js
+++ b/src/snippets_test.js
@@ -370,6 +370,13 @@ module.exports = {
         editor.insertSnippet("hello $1 world $1");
         editor.onTextInput("!");
         assert.equal(editor.getValue(), "hello ! world !");
+    },
+
+    "test: TabstopManager does not throw unhandled errors when session becomes `undefined`": function() {
+        var editor = new Editor(new MockRenderer());
+        editor.setSession(new EditSession("dummy content"));
+        snippetManager.insertSnippet(editor, "snippet $1 with $2 tabstops");
+        editor.setSession(undefined);
     }
 };
 

--- a/src/snippets_test.js
+++ b/src/snippets_test.js
@@ -374,9 +374,12 @@ module.exports = {
 
     "test: TabstopManager does not throw unhandled errors when session becomes `undefined`": function() {
         var editor = new Editor(new MockRenderer());
-        editor.setSession(new EditSession("dummy content"));
+        var session = new EditSession("dummy content");
+        editor.setSession(session);
         snippetManager.insertSnippet(editor, "snippet $1 with $2 tabstops");
+        assert.equal(session.$backMarkers[5].clazz, "ace_snippet-marker");
         editor.setSession(undefined);
+        assert.equal(session.$backMarkers[5], undefined);
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:*

- N/A

*Description of changes:*

- [`editor.setSession`](https://github.com/ajaxorg/ace/blob/6bebb4eda6f32c0e3bd929bc891aaaf2800b885f/src/editor.js#L284) seems to account for the possibility of `session` being _falsy_ (e.g.: `undefined`, `null`). At the end of this method, [the `editor` signals there was a change in the `session`](https://github.com/ajaxorg/ace/blob/6bebb4eda6f32c0e3bd929bc891aaaf2800b885f/src/editor.js#L352-L355)
- [When the `session` is changed, `TabstopManager` runs its `detach` method](https://github.com/ajaxorg/ace/blob/6bebb4eda6f32c0e3bd929bc891aaaf2800b885f/src/snippets.js#L858-L860). This method was eventually expecting to [use the `session` instance to remove markers](https://github.com/ajaxorg/ace/blob/6bebb4eda6f32c0e3bd929bc891aaaf2800b885f/src/snippets.js#L968), which is not possible when it is `undefined`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
