### PR TITLE
feat(autocomplete): ellipsis is shown when suggestions is longer than popover width

### DIFF
--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -443,10 +443,16 @@ dom.importCssString(`
 }
 .ace_autocomplete .ace_line {
     display: flex;
+    align-items: center;
 }
-.ace_autocomplete .ace_line .ace_ {
+.ace_autocomplete .ace_line > * {
+    min-width: 0;
+    flex: 0 0 auto;
     overflow: hidden;
     white-space: nowrap;
+}
+.ace_autocomplete .ace_line .ace_ {
+    flex: 0 1 auto; 
     text-overflow: ellipsis;
 }
 .ace_autocomplete .ace_completion-spacer {

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -439,10 +439,15 @@ dom.importCssString(`
     color: #c1c1c1;
 }
 .ace_autocomplete_right .ace_text-layer  {
-    width: calc(100% - 8px);
+    width: 100%;
 }
 .ace_autocomplete_right .ace_line {
     display: flex;
+}
+.ace_autocomplete_right .ace_line .ace_ {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 .ace_autocomplete_right .ace_completion-spacer {
     flex: 1;

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -438,18 +438,18 @@ dom.importCssString(`
     background: #25282c;
     color: #c1c1c1;
 }
-.ace_autocomplete_right .ace_text-layer  {
+.ace_autocomplete .ace_text-layer  {
     width: 100%;
 }
-.ace_autocomplete_right .ace_line {
+.ace_autocomplete .ace_line {
     display: flex;
 }
-.ace_autocomplete_right .ace_line .ace_ {
+.ace_autocomplete .ace_line .ace_ {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
 }
-.ace_autocomplete_right .ace_completion-spacer {
+.ace_autocomplete .ace_completion-spacer {
     flex: 1;
 }
 `, "autocompletion.css", false);

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -410,7 +410,7 @@ dom.importCssString(`
 }
 .ace_completion-meta {
     opacity: 0.5;
-    margin: 0 0.9em;
+    margin-left: 0.9em;
 }
 .ace_completion-message {
     color: blue;
@@ -439,7 +439,7 @@ dom.importCssString(`
     color: #c1c1c1;
 }
 .ace_autocomplete .ace_text-layer  {
-    width: 100%;
+    width: calc(100% - 8px);
 }
 .ace_autocomplete .ace_line {
     display: flex;

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -448,11 +448,11 @@ dom.importCssString(`
 .ace_autocomplete .ace_line > * {
     min-width: 0;
     flex: 0 0 auto;
-    overflow: hidden;
-    white-space: nowrap;
 }
 .ace_autocomplete .ace_line .ace_ {
-    flex: 0 1 auto; 
+    flex: 0 1 auto;
+    overflow: hidden;
+    white-space: nowrap;
     text-overflow: ellipsis;
 }
 .ace_autocomplete .ace_completion-spacer {

--- a/src/ext/prompt.js
+++ b/src/ext/prompt.js
@@ -72,7 +72,6 @@ function prompt(editor, message, options, callback) {
     if (options.getCompletions) {
         var popup = new AcePopup();
         popup.renderer.setStyle("ace_autocomplete_inline");
-        popup.renderer.setStyle("ace_autocomplete_right");
         popup.container.style.display = "block";
         popup.container.style.maxWidth = "600px";
         popup.container.style.width = "100%";


### PR DESCRIPTION
When the completion suggestion is larger than the autocomplete popover width, we need to show elipsis(...) to convey this information.
This PR also makes right-alignment of meta default fixing #3785.

![Screenshot 2023-06-13 at 16 43 01](https://github.com/ajaxorg/ace/assets/12100596/58b8b0e5-8ddb-420d-81de-d5296727f4cf)

![Screenshot 2023-06-13 at 16 52 09](https://github.com/ajaxorg/ace/assets/12100596/c518710e-10a8-4444-ad9e-a5125db6fe5f)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
