### PR TITLE
Generate esm-resolver.d.ts to provide intellisense

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -190,6 +190,7 @@ function buildTypes() {
 
     var pathModules = [
         "declare module 'ace-builds/webpack-resolver';",
+        "declare module 'ace-builds/esm-resolver';",
         "declare module 'ace-builds/src-noconflict/ace';"
     ].concat(paths.map(function(path) {
         if (moduleNameRegex.test(path)) {

--- a/tool/esm_resolver_generator.js
+++ b/tool/esm_resolver_generator.js
@@ -8,7 +8,10 @@ function buildResolver() {
         return `ace.config.setModuleLoader('${moduleName}', () => import('./${moduleName.replace("ace", "src") + ".js"}'));`;
     }).join('\n') + "\n\nexport * as default from \"./src/ace\";";
 
+    var declaration = generateDeclaration();
+
     fs.writeFileSync(__dirname + '/../esm-resolver.js', loader, "utf8");
+    fs.writeFileSync(__dirname + '/../esm-resolver.d.ts', declaration, "utf8");
 }
 
 function getModuleNames() {
@@ -36,6 +39,10 @@ function getModuleNames() {
     });
     paths.push(...modeNamePaths, ...snippetsPaths, ...themesPaths, ...keyBindingsPaths, ...extPaths);
     return paths;
+}
+
+function generateDeclaration() {
+    return "export * from \"ace-code\";" 
 }
 
 buildResolver();

--- a/tool/esm_resolver_generator.js
+++ b/tool/esm_resolver_generator.js
@@ -8,7 +8,7 @@ function buildResolver() {
         return `ace.config.setModuleLoader('${moduleName}', () => import('./${moduleName.replace("ace", "src") + ".js"}'));`;
     }).join('\n') + "\n\nexport * as default from \"./src/ace\";";
 
-    var declaration = generateDeclaration();
+    var declaration = 'export * from "./ace"';
 
     fs.writeFileSync(__dirname + '/../esm-resolver.js', loader, "utf8");
     fs.writeFileSync(__dirname + '/../esm-resolver.d.ts', declaration, "utf8");
@@ -39,10 +39,6 @@ function getModuleNames() {
     });
     paths.push(...modeNamePaths, ...snippetsPaths, ...themesPaths, ...keyBindingsPaths, ...extPaths);
     return paths;
-}
-
-function generateDeclaration() {
-    return "export * from \"ace-code\";" 
 }
 
 buildResolver();


### PR DESCRIPTION
*Issue #, if available:* #5206

*Description of changes:*
This auto-generated declaration should enable Intellisense for different IDE's:
![image](https://github.com/ajaxorg/ace/assets/32402726/75fef5d7-673c-4ada-a1ba-a5ccb0d24f7e)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
