### PR TITLE
NSIS mode: add !assert command

### DIFF
--- a/src/mode/nsis_highlight_rules.js
+++ b/src/mode/nsis_highlight_rules.js
@@ -10,7 +10,7 @@ var NSISHighlightRules = function() {
     this.$rules = {
         start: [{
             token: "keyword.compiler.nsis",
-            regex: /^\s*!(?:include|addincludedir|addplugindir|appendfile|cd|delfile|echo|error|execute|packhdr|pragma|finalize|getdllversion|gettlbversion|system|tempfile|warning|verbose|define|undef|insertmacro|macro|macroend|makensis|searchparse|searchreplace|uninstfinalize)\b/,
+            regex: /^\s*!(?:include|addincludedir|addplugindir|appendfile|assert|cd|delfile|echo|error|execute|packhdr|pragma|finalize|getdllversion|gettlbversion|system|tempfile|warning|verbose|define|undef|insertmacro|macro|macroend|makensis|searchparse|searchreplace|uninstfinalize)\b/,
             caseInsensitive: true
         }, {
             token: "keyword.command.nsis",


### PR DESCRIPTION
*Description of changes:*

- adds `!assert` command, as introduced by NSIS v3.09 (see [changelog](https://nsis.sourceforge.io/Docs/AppendixF.html#v3.09))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
