### PR TITLE
Update JSHint version to 2.13.6

### DIFF
--- a/lib/ace/mode/javascript/jshint.js
+++ b/lib/ace/mode/javascript/jshint.js
@@ -2392,13 +2392,13 @@ module.exports = slice;
     exports.noConflict = function () { global._ = current; return exports; };
   }()));
 }(this, (function () {
-  //     Underscore.js 1.13.4
+  //     Underscore.js 1.13.6
   //     https://underscorejs.org
   //     (c) 2009-2022 Jeremy Ashkenas, Julian Gonggrijp, and DocumentCloud and Investigative Reporters & Editors
   //     Underscore may be freely distributed under the MIT license.
 
   // Current version.
-  var VERSION = '1.13.4';
+  var VERSION = '1.13.6';
 
   // Establish the root object, `window` (`self`) in the browser, `global`
   // on the server, or `this` in some virtual machines. We use `self`
@@ -4461,7 +4461,7 @@ module.exports = slice;
 /*exported console */
 
 var _            = _dereq_("underscore");
-_.clone          = _dereq_("lodash.clone");
+_.clone = _dereq_("lodash.clone");
 var events       = _dereq_("events");
 var vars         = _dereq_("./vars.js");
 var messages     = _dereq_("./messages.js");
@@ -8930,7 +8930,7 @@ var JSHINT = (function() {
         var id = state.tokens.prev;
         value = expression(context, 10);
         if (value) {
-          if (value.identifier && value.value === "undefined") {
+          if (!isConst && value.identifier && value.value === "undefined") {
             warning("W080", id, id.value);
           }
           if (!lone) {
@@ -13527,7 +13527,7 @@ var errors = {
 
   // Constants
   E011: "'{a}' has already been declared.",
-  E012: "const '{a}' is initialized to 'undefined'.",
+  E012: "Missing initializer for constant '{a}'.",
   E013: "Attempting to override '{a}' which is a constant.",
 
   // Regular expressions
@@ -15122,7 +15122,7 @@ exports.regexpDot = /(^|[^\\])(\\\\)*\./;
  */
 
 var _      = _dereq_("underscore");
-_.slice    = _dereq_("lodash.slice");
+_.slice = _dereq_("lodash.slice");
 var events = _dereq_("events");
 
 // Used to denote membership in lookup tables (a primitive value such as `true`

--- a/lib/ace/mode/javascript_worker.js
+++ b/lib/ace/mode/javascript_worker.js
@@ -79,7 +79,7 @@ oop.inherits(JavaScriptWorker, Mirror);
         this.options = options || {
             // undef: true,
             // unused: true,
-            esnext: true,
+            esversion: 11,
             moz: true,
             devel: true,
             browser: true,


### PR DESCRIPTION
*Issue #, if available:* #4756

*Description of changes:*
- Update JSHint version to current latest
- Change default option to target ECMAScript 11 
- Replace [deprecated property `esnext`](https://jshint.com/docs/options/#esnext) with `esversion`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
