### PR TITLE
Add Nixx Web Tools icon to Ace website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1151,7 +1151,7 @@ if (match) {
                                     <a href="https://www.domoticz.com/">Domoticz</a>
                                 </li>
                                 <li>
-                                    <img lazy-src="https://code.nixx.dev/favicon.png" style="width: 72px; left: 15px; top: 0px;">
+                                    <img lazy-src="https://nixx.dev/static/hotlink-ok/logo-alt.png" style="width: 72px; left: 15px; top: 0px;">
                                     <a href="https://nixx.dev">Nixx Web Tools</a>
                                 </li>
                                 <li id="add_your_site">

--- a/index.html
+++ b/index.html
@@ -1150,6 +1150,10 @@ if (match) {
                                     <div class="text-logo">Domoticz</div>
                                     <a href="https://www.domoticz.com/">Domoticz</a>
                                 </li>
+                                <li>
+                                    <img lazy-src="https://code.nixx.dev/favicon.png" style="width: 72px; left: 15px; top: 0px;">
+                                    <a href="https://nixx.dev">Nixx Web Tools</a>
+                                </li>
                                 <li id="add_your_site">
                                     <p>+</p>
                                     <a href="https://github.com/ajaxorg/ace/issues/new?assignees=&labels=website%2Cneeds-triage&projects=&template=add-to-website.yml&title=Add+project+%28project+name%29+to+the+list+of+projects+using+Ace+on+its+website">Your Site Here</a>


### PR DESCRIPTION
*Issue #, if available:* 5247

*Description of changes:* Adds logo and link to users on Ace website.

<img width="799" alt="Screenshot 2023-07-10 195136" src="https://github.com/ajaxorg/ace/assets/34573235/48965d7f-ebd7-4612-99a4-ae65db08fb69">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
