### PR TITLE
Add missing SQL keywords: IS and IN

### DIFF
--- a/src/mode/sql_highlight_rules.js
+++ b/src/mode/sql_highlight_rules.js
@@ -8,7 +8,7 @@ var SqlHighlightRules = function() {
     var keywords = (
         "select|insert|update|delete|from|where|and|or|group|by|order|limit|offset|having|as|case|" +
         "when|then|else|end|type|left|right|join|on|outer|desc|asc|union|create|table|primary|key|if|" +
-        "foreign|not|references|default|null|inner|cross|natural|database|drop|grant|distinct"
+        "foreign|not|references|default|null|inner|cross|natural|database|drop|grant|distinct|is|in"
     );
 
     var builtinConstants = (


### PR DESCRIPTION
**Description:**
This pull request addresses an issue where the SQL keywords 'IS' and 'IN' are not currently highlighted in the editor's SQL mode. To enhance the SQL syntax highlighting and improve the overall user experience, I have added support for highlighting these missing keywords.

<img width="362" alt="is" src="https://github.com/ajaxorg/ace/assets/568977/039bb92c-4a3e-4c4f-a7a7-94597782414c">

<img width="344" alt="id" src="https://github.com/ajaxorg/ace/assets/568977/19d7cb12-44a9-4618-98f9-41666a782670">


**Proposed Changes:**

Added 'IS' and 'IN' to the list of recognized SQL keywords in the editor's SQL mode.
Updated the syntax highlighting rules to ensure proper rendering of 'IS' and 'IN' in SQL queries.