### PR TITLE
fix: invoke only completers who have matching trigger characters

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -666,8 +666,10 @@ class CompletionProvider {
     
         var matches = [];
         this.completers = editor.completers;
-        var total = editor.completers.length;
-        editor.completers.forEach(function(completer, i) {
+        var matchingCompleters = util.getCompletersMatchingTriggerCharacter(editor);
+        if (matchingCompleters.length === 0) matchingCompleters = editor.completers;
+        var total = matchingCompleters.length;
+        matchingCompleters.forEach(function(completer, i) {
             completer.getCompletions(editor, session, pos, prefix, function(err, results) {
                 if (!err && results)
                     matches = matches.concat(results);

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -667,7 +667,11 @@ class CompletionProvider {
         var matches = [];
         this.completers = editor.completers;
         var matchingCompleters = util.getCompletersMatchingTriggerCharacter(editor);
-        if (matchingCompleters.length === 0) matchingCompleters = editor.completers;
+        // if there are no matches or there is a prefix, and the prefix is longer than the threshold,
+        // then use all completers
+        if (matchingCompleters.length === 0 || (prefix && prefix.length >= editor.$liveAutocompletionThreshold)) {
+            matchingCompleters = editor.completers;
+        }
         var total = matchingCompleters.length;
         matchingCompleters.forEach(function(completer, i) {
             completer.getCompletions(editor, session, pos, prefix, function(err, results) {

--- a/src/autocomplete/util.js
+++ b/src/autocomplete/util.js
@@ -55,12 +55,12 @@ exports.getCompletionPrefix = function (editor) {
     return prefix || this.retrievePrecedingIdentifier(line, pos.column);
 };
 
-exports.triggerAutocomplete = function (editor) {
+exports.getCompletersMatchingTriggerCharacter = function (editor) {
     var pos = editor.getCursorPosition();
     var line = editor.session.getLine(pos.row);
     var column = (pos.column === 0) ? 0 : pos.column - 1;
     var previousChar = line[column];
-    return editor.completers.some((el) => {
+    return editor.completers.filter((el) => {
         if (el.triggerCharacters && Array.isArray(el.triggerCharacters)) {
             return el.triggerCharacters.includes(previousChar);
         }

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -432,6 +432,59 @@ module.exports = {
             });
         }
     },
+    "test: trigger all completers if there is a textual(A-Za-z) trigger character": function (done) {
+        var editor = initEditor("");
+        editor.setOptions({
+            liveAutocompletionThreshold: 0
+        });
+
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "agent",
+                            value: "agent"
+                        }, {
+                            caption: "alarm",
+                            value: "alarm"
+                        }
+                    ];
+                    callback(null, completions);
+                },
+                triggerCharacters: ["a"]
+            },
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "abbath",
+                            value: "abbath"
+                        }
+                    ];
+                    callback(null, completions);
+                }
+            }
+        ];
+        
+        editor.moveCursorTo(0, 0);
+        user.type("a");
+        var popup = editor.completer.popup;
+        check(function () {
+            assert.equal(popup.data.length, 3);
+            editor.onCommandKey(null, 0, 13);
+            assert.equal(editor.getValue(), "abbath");
+            done();
+        });
+
+        function check(callback) {
+            popup = editor.completer.popup;
+            popup.renderer.on("afterRender", function wait() {
+                popup.renderer.off("afterRender", wait);
+                callback();
+            });
+        }
+    },
     "test: empty message if no suggestions available": function(done) {
         var editor = initEditor("");
         var emptyMessageText = "No suggestions.";

--- a/src/ext/language_tools.js
+++ b/src/ext/language_tools.js
@@ -161,7 +161,7 @@ var showLiveAutocomplete = function(e) {
     var editor = e.editor;
     var prefix = util.getCompletionPrefix(editor);
     // Only autocomplete if there's a prefix that can be matched or previous char is trigger character 
-    var triggerAutocomplete = util.triggerAutocomplete(editor);
+    var triggerAutocomplete = util.getCompletersMatchingTriggerCharacter(editor).length > 0;
     if ((prefix || triggerAutocomplete) && prefix.length >= editor.$liveAutocompletionThreshold) {
         var completer = Autocomplete.for(editor);
         // Set a flag for auto shown


### PR DESCRIPTION
*Description of changes:* Currently, when a trigger character of any completer is encountered, all completers are invoked to provide completions. This seems incorrect as different completers might have different trigger characters, so this PR changes the behaviour to invoke only completers who have this trigger character specified in `triggerCharacters` field.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
