### PR TITLE
feat: Cuttlefish highlighter

### DIFF
--- a/demo/kitchen-sink/docs/cuttlefish.conf
+++ b/demo/kitchen-sink/docs/cuttlefish.conf
@@ -1,0 +1,11 @@
+include extras.conf     # overflow config file
+
+ring_size = 32
+
+# experimental
+anti_entropy = debug
+
+# logging
+log.error.file = /var/log/error.log
+log.console.file = /var/log/console.log
+log.syslog = on

--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -73,6 +73,7 @@ var supportedModes = {
     Csound_Score: ["sco"],
     CSS:         ["css"],
     Curly:       ["curly"],
+    Cuttlefish:  ["conf"],
     D:           ["d|di"],
     Dart:        ["dart"],
     Diff:        ["diff|patch"],

--- a/src/mode/cuttlefish.js
+++ b/src/mode/cuttlefish.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var CuttlefishHighlightRules = require("./cuttlefish_highlight_rules").CuttlefishHighlightRules;
+
+var Mode = function() {
+    this.HighlightRules = CuttlefishHighlightRules;
+    this.foldingRules = null;
+    this.$behaviour = this.$defaultBehaviour;
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.lineCommentStart = "#";
+    this.blockComment = null;
+    this.$id = "ace/mode/cuttlefish";
+}).call(Mode.prototype);
+
+exports.Mode = Mode;

--- a/src/mode/cuttlefish_highlight_rules.js
+++ b/src/mode/cuttlefish_highlight_rules.js
@@ -1,0 +1,36 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+
+var CuttlefishHighlightRules = function () {
+    this.$rules = {
+        start: [{
+            token: ['text', 'comment'],
+            regex: /^([ \t]*)(#.*)$/
+        }, {
+            token: ['text', 'keyword', 'text', 'string', 'text', 'comment'],
+            regex: /^([ \t]*)(include)([ \t]*)([A-Za-z0-9-\_\.\*\/]+)([ \t]*)(#.*)?$/
+        }, {
+            token: ['text', 'keyword', 'text', 'operator', 'text', 'string', 'text', 'comment'],
+            regex: /^([ \t]*)([A-Za-z0-9-_]+(?:\.[A-Za-z0-9-_]+)*)([ \t]*)(=)([ \t]*)([^ \t#][^#]*?)([ \t]*)(#.*)?$/
+        }, {
+            defaultToken: 'invalid'
+        }]
+    };
+
+    this.normalizeRules();
+};
+
+CuttlefishHighlightRules.metaData = {
+    fileTypes: ['conf'],
+    keyEquivalent: '^~C',
+    name: 'Cuttlefish',
+    scopeName: 'source.conf'
+};
+
+
+oop.inherits(CuttlefishHighlightRules, TextHighlightRules);
+
+exports.CuttlefishHighlightRules = CuttlefishHighlightRules;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added a highlighter for the [Cuttlefish format](https://github.com/Kyorai/cuttlefish), used in Erlang applications.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.