### PR TITLE
Fix completions replacement range calculation

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -372,7 +372,6 @@ class Autocomplete {
         var completionOptions = { exactMatch: this.exactMatch };
         this.getCompletionProvider({
             prefix,
-            base: this.base,
             pos
         }).provideCompletions(this.editor, completionOptions, function(err, completions, finished) {
             var filtered = completions.filtered;
@@ -594,7 +593,7 @@ Autocomplete.startCommand = {
 class CompletionProvider {
 
     /**
-     * @param {{base: Anchor, pos: Position, prefix: string}} initialPosition
+     * @param {{pos: Position, prefix: string}} initialPosition
      */
     constructor(initialPosition) {
         this.initialPosition = initialPosition;

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -644,7 +644,7 @@ class CompletionProvider {
             }
           
             if (data.snippet) {
-                snippetManager.insertSnippet(editor, data.snippet, {range: undefined});
+                snippetManager.insertSnippet(editor, data.snippet);
             }
             else {
                 this.$insertString(editor, data);

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -131,7 +131,7 @@ module.exports = {
             });
         });
     },
-    "test: correct completion replacement range when filterText has more than one letter": function (done) {
+    "test: correct completion replacement range when completion prefix has more than one letter": function (done) {
         var editor = initEditor("<");
 
         editor.completers = [
@@ -173,7 +173,7 @@ module.exports = {
             }, 10);
         }
     },
-    "test: filterText does not trigger selection range removal when completions range is present": function (done) {
+    "test: symbols after selection are not removed when replacement range is present": function (done) {
         var editor = initEditor("{}");
         editor.completers = [
             {

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -32,6 +32,13 @@ function initEditor(value) {
     return editor;
 }
 
+function afterRenderCheck(popup, callback) {
+    popup.renderer.on("afterRender", function wait() {
+        popup.renderer.off("afterRender", wait);
+        callback();
+    });
+}
+
 module.exports = {
     tearDown: function() {
         if (editor) {
@@ -95,7 +102,7 @@ module.exports = {
                             snippet: "will: $1",
                             meta: "snippet",
                             command: "startAutocomplete",
-                            range: new Range(0, 4, 0, 6)
+                            range: new Range(0, 4, 0, 7)
                         }, {
                             caption: "here",
                             value: "-here",
@@ -110,12 +117,12 @@ module.exports = {
         editor.moveCursorTo(0, 6);
         sendKey("w");
         var popup = editor.completer.popup;
-        check(function () {
+        afterRenderCheck(popup, function () {
             assert.equal(popup.data.length, 1);
             editor.onCommandKey(null, 0, 13);
             assert.equal(popup.data.length, 2);
             assert.equal(editor.getValue(), "goodwill: ");
-            check(function () {
+            afterRenderCheck(popup, function () {
                 editor.onCommandKey(null, 0, 13);
                 assert.equal(editor.getValue(), "goodwill-here");
                 editor.destroy();
@@ -123,14 +130,79 @@ module.exports = {
                 done();
             });
         });
+    },
+    "test: correct completion replacement range when filterText has more than one letter": function (done) {
+        var editor = initEditor("<");
+
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "div",
+                            value: "div",
+                            range: new Range(0, 1, 0, 3)
+                        }, {
+                            caption: "dialog",
+                            value: "dialog",
+                            range: new Range(0, 1, 0, 3)
+                        }
+                    ];
+                    callback(null, completions);
+                }
+            }
+        ];
+
+        editor.moveCursorTo(0, 1);
+        sendKey("di");
+        var popup = editor.completer.popup;
+        check(function () {
+            assert.equal(popup.data.length, 2);
+            editor.onCommandKey(null, 0, 13);
+            check(function () {
+                assert.equal(editor.getValue(), "<dialog");
+                editor.destroy();
+                editor.container.remove();
+                done();
+            });
+        });
 
         function check(callback) {
-            popup = editor.completer.popup;
-            popup.renderer.on("afterRender", function wait() {
-                popup.renderer.off("afterRender", wait);
+            setTimeout(function wait() {
                 callback();
-            });
+            }, 10);
         }
+    },
+    "test: filterText does not trigger selection range removal when completions range is present": function (done) {
+        var editor = initEditor("{}");
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "apple",
+                            snippet: "apple: $1",
+                            meta: "snippet",
+                            range: new Range(0, 1, 0, 2)
+                        }, {
+                            caption: "pineapple",
+                            value: "pineapple",
+                            range: new Range(0, 1, 0, 2)
+                        }
+                    ];
+                    callback(null, completions);
+                }
+            }
+        ];
+        editor.moveCursorTo(0, 1);
+        sendKey("a");
+        var popup = editor.completer.popup;
+        afterRenderCheck(popup, function () {
+            assert.equal(popup.data.length, 2);
+            editor.onCommandKey(null, 0, 13);
+            assert.equal(editor.getValue(), "{apple: }");
+            done();
+            });
     },
     "test: different completers tooltips": function (done) {
         var editor = initEditor("");
@@ -183,6 +255,8 @@ module.exports = {
                 id: "secondCompleter"
             }
         ];
+        
+        
 
         sendKey("c");
         var popup = editor.completer.popup;

--- a/src/ext/inline_autocomplete.js
+++ b/src/ext/inline_autocomplete.js
@@ -165,9 +165,9 @@ class InlineAutocomplete {
         }
     }
 
-    getCompletionProvider() {
+    getCompletionProvider(initialPosition) {
         if (!this.completionProvider)
-            this.completionProvider = new CompletionProvider();
+            this.completionProvider = new CompletionProvider(initialPosition);
         return this.completionProvider;
     }
 
@@ -219,7 +219,11 @@ class InlineAutocomplete {
             exactMatch: true,
             ignoreCaption: true
         };
-        this.getCompletionProvider().provideCompletions(this.editor, options, function(err, completions, finished) {
+        this.getCompletionProvider({
+            prefix,
+            base: this.base,
+            pos
+        }).provideCompletions(this.editor, options, function(err, completions, finished) {
             var filtered = completions.filtered;
             var prefix = util.getCompletionPrefix(this.editor);
 

--- a/src/snippets.js
+++ b/src/snippets.js
@@ -356,9 +356,6 @@ class SnippetManager {
         var processedSnippet = processSnippetText.call(this, editor, snippetText, options);
         
         var range = editor.getSelectionRange();
-        if (options.range && options.range.compareRange(range) === 0) {
-            range = options.range;
-        }
         var end = editor.session.replace(range, processedSnippet.text);
 
         var tabstopManager = new TabstopManager(editor);
@@ -368,8 +365,6 @@ class SnippetManager {
     
     insertSnippet(editor, snippetText, options={}) {
         var self = this;
-        if (options.range && !(options.range instanceof Range))
-            options.range = Range.fromPoints(options.range.start, options.range.end);
         
         if (editor.inVirtualSelectionMode)
             return self.insertSnippetForSelection(editor, snippetText, options);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR addresses two primary concerns related to the completion replacement ranges:

1. Incorrect Replacement After Initial Letters:

**Issue:** Upon starting to type the beginning of the completion, the replacement range became unsynchronized by the second letter. This led to incorrect replacements, such as `<didiv` in place of `<div`.
**Solution:** Reverted the changes from [my prior PR](https://github.com/ajaxorg/ace/pull/5249), which resolved this issue but led to the second concern.

2. Deletion of Symbols Post-Cursor:

**Issue:** Given symbols following the cursor, like in between of "<>", when attempting to insert a tag between the symbols, the ">" would be erroneously deleted.
**Solution:** While the previously [reverted PR](https://github.com/ajaxorg/ace/pull/5279) addressed this issue, it also reintroduced the first issue.

To holistically address both concerns, i've introduced a new mechanism for calculating replacement ranges. Now, we preserve the initial cursor/base/prefix state prior to fetching completions. This stored state aids in accurately computing the necessary shift during the `insertMatch` process.

This revised method ensures both efficient replacement of initial letters and the preservation of subsequent symbols.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
