### PR TITLE
fix: autocompletion threshold doesn't apply to trigger characters

### DIFF
--- a/src/ext/language_tools.js
+++ b/src/ext/language_tools.js
@@ -162,7 +162,7 @@ var showLiveAutocomplete = function(e) {
     var prefix = util.getCompletionPrefix(editor);
     // Only autocomplete if there's a prefix that can be matched or previous char is trigger character 
     var triggerAutocomplete = util.triggerAutocomplete(editor);
-    if ((prefix || triggerAutocomplete) && prefix.length >= editor.$liveAutocompletionThreshold) {
+    if (prefix && prefix.length >= editor.$liveAutocompletionThreshold || triggerAutocomplete) {
         var completer = Autocomplete.for(editor);
         // Set a flag for auto shown
         completer.autoShown = true;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: When [Live autocompletion threshold](https://github.com/ajaxorg/ace/pull/5177/files) was introduced, it changed the behavior of [special trigger characters](https://github.com/ajaxorg/ace/pull/5147). 
Special trigger characters are an array of simple chars that should open the autocompletion popup immediately. And LiveAutocompletionThreshold applies to simple prefix, not trigger character.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
