### PR TITLE
chore: add Acode to users on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1154,6 +1154,10 @@ if (match) {
                                     <img lazy-src="https://nixx.dev/static/hotlink-ok/logo-alt.png" style="width: 72px; left: 15px; top: 0px;">
                                     <a href="https://nixx.dev">Nixx Web Tools</a>
                                 </li>
+                                <li>
+                                    <img lazy-src="https://acode.foxdebug.com/logo.svg" style="width: 72px; left: 15px; top: 10px;">
+                                    <a href="https://acode.foxdebug.com">Acode</a>
+                                </li>
                                 <li id="add_your_site">
                                     <p>+</p>
                                     <a href="https://github.com/ajaxorg/ace/issues/new?assignees=&labels=website%2Cneeds-triage&projects=&template=add-to-website.yml&title=Add+project+%28project+name%29+to+the+list+of+projects+using+Ace+on+its+website">Your Site Here</a>


### PR DESCRIPTION
*Issue #, if available:*
#5290 
*Description of changes:*
Adds logo and link to users on Ace website.


![Screenshot 2023-08-27 at 20 51 28](https://github.com/ajaxorg/ace/assets/12100596/20137254-d633-4b61-bb1f-601b515bc58d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
