### PR TITLE
add mts and cts file extensions for typescript

### DIFF
--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -213,7 +213,7 @@ var supportedModes = {
     TSX:         ["tsx"],
     Turtle:      ["ttl"],
     Twig:        ["twig|swig"],
-    Typescript:  ["ts|typescript|str"],
+    Typescript:  ["ts|mts|cts|typescript|str"],
     Vala:        ["vala"],
     VBScript:    ["vbs|vb"],
     Velocity:    ["vm"],


### PR DESCRIPTION
Without these cloud9 does not recognize files correctly
