### PR TITLE
Add syntax highlighting for PRQL

### DIFF
--- a/demo/kitchen-sink/docs/prql.prql
+++ b/demo/kitchen-sink/docs/prql.prql
@@ -1,0 +1,22 @@
+from invoices
+filter invoice_date >= @1970-01-16
+derive {
+  transaction_fees = 0.8,
+  income = total - transaction_fees
+}
+filter income > 1
+group customer_id (
+  aggregate {
+    average total,
+    sum_income = sum income,
+    ct = count total,
+  }
+)
+sort {-sum_income}
+take 10
+join c=customers (==customer_id)
+derive name = f"{c.last_name}, {c.first_name}"
+select {
+  c.customer_id, name, sum_income
+}
+derive db_version = s"version()"

--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -170,6 +170,7 @@ var supportedModes = {
     Prolog:      ["plg|prolog"],
     Properties:  ["properties"],
     Protobuf:    ["proto"],
+    PRQL:        ["prql"],
     Puppet:      ["epp|pp"],
     Python:      ["py"],
     QML:         ["qml"],

--- a/src/mode/prql.js
+++ b/src/mode/prql.js
@@ -1,0 +1,21 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var HighlightRules = require("./prql_highlight_rules").PrqlHighlightRules;
+var FoldMode = require("./folding/cstyle").FoldMode;
+
+var Mode = function() {
+    this.HighlightRules = HighlightRules;
+    this.foldingRules = new FoldMode();
+    this.$behaviour = this.$defaultBehaviour;
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.lineCommentStart = "#";
+    // Extra logic goes here.
+    this.$id = "ace/mode/prql";
+}).call(Mode.prototype);
+
+exports.Mode = Mode;

--- a/src/mode/prql_highlight_rules.js
+++ b/src/mode/prql_highlight_rules.js
@@ -1,0 +1,104 @@
+// https://github.com/PRQL/prql
+
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var PrqlHighlightRules = function() {
+    var builtinFunctions = "min|max|sum|average|stddev|every|any|concat_array|count|" +
+    "lag|lead|first|last|rank|rank_dense|row_number|" +
+    "round|as|in|" +
+    "tuple_every|tuple_map|tuple_zip|_eq|_is_null|" +
+    "from_text|" +
+    "lower|upper|" +
+    "read_parquet|read_csv";
+
+    var builtinTypes = [
+        "bool",
+        "int",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "float",
+        "text",
+        "set"].join("|");
+
+    var keywordMapper = this.createKeywordMapper({
+       "support.function": builtinFunctions,
+       "support.type": builtinTypes,
+       "constant.language": "true|false|null",
+       "keyword": "let|into|case|prql|type|module|internal"
+    }, "identifier");
+    
+    var escapeRe = /\\(\d+|['"\\&trnbvf]|u[0-9a-fA-F]{4})/;
+    var identifierRe = /[A-Za-z_][a-z_A-Z0-9]/.source;
+
+    this.$rules = {
+        start: [{
+            token: "string.start",
+            regex: '"',
+            next: "string"
+        }, {
+            token: "string.character",
+            regex: "'(?:" + escapeRe.source + "|.)'?"
+        }, {
+            regex: /0(?:[xX][0-9A-Fa-f]+|[oO][0-7]+)|\d+(\.\d+)?([eE][-+]?\d*)?/,
+            token: "constant.numeric"
+        }, {
+            token: "comment",
+            regex: "#.*"
+        }, {
+            token : "keyword",
+            regex : /\.\.|\||:|=|\\|"|->|<-/
+        }, {
+            token : "keyword.operator",
+            regex : /[-!#$%&*+.\/<=>?@\\^|~:]+/
+        }, {
+            token : "operator.punctuation",
+            regex : /[,`]/
+        }, {
+            token : "constant.language",
+            regex : "^" + identifierRe + "*",
+        }, {
+            token : keywordMapper,
+            regex : "[\\w\\xff-\\u218e\\u2455-\\uffff]+\\b"
+        }, {
+            token: "paren.lparen",
+            regex: /[\[({]/ 
+        }, {
+            token: "paren.rparen",
+            regex: /[\])}]/
+        } ],
+        string: [{
+            token: "constant.language.escape",
+            regex: escapeRe
+        }, {
+            token: "text",
+            regex: /\\(\s|$)/,
+            next: "stringGap"
+        }, {
+            token: "string.end",
+            regex: '"',
+            next: "start"
+        }, {
+            defaultToken: "string"
+        }],
+        stringGap: [{
+            token: "text",
+            regex: /\\/,
+            next: "string"
+        }, {
+            token: "error",
+            regex: "",
+            next: "start"
+        }]
+    };
+    
+    this.normalizeRules();
+};
+
+oop.inherits(PrqlHighlightRules, TextHighlightRules);
+
+exports.PrqlHighlightRules = PrqlHighlightRules;

--- a/src/mode/prql_highlight_rules.js
+++ b/src/mode/prql_highlight_rules.js
@@ -6,7 +6,7 @@ var oop = require("../lib/oop");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 
 var PrqlHighlightRules = function() {
-    const builtinFunctions = "min|max|sum|average|stddev|every|any|concat_array|count|" +
+    var builtinFunctions = "min|max|sum|average|stddev|every|any|concat_array|count|" +
     "lag|lead|first|last|rank|rank_dense|row_number|" +
     "round|as|in|" +
     "tuple_every|tuple_map|tuple_zip|_eq|_is_null|" +
@@ -14,7 +14,7 @@ var PrqlHighlightRules = function() {
     "lower|upper|" +
     "read_parquet|read_csv";
 
-    const builtinTypes = [
+    var builtinTypes = [
         "bool",
         "int",
         "int8",

--- a/src/mode/prql_highlight_rules.js
+++ b/src/mode/prql_highlight_rules.js
@@ -1,3 +1,4 @@
+// https://prql-lang.org/
 // https://github.com/PRQL/prql
 
 "use strict";
@@ -26,13 +27,15 @@ var PrqlHighlightRules = function() {
         "set"].join("|");
 
     var keywordMapper = this.createKeywordMapper({
+       "constant.language": "null",
+       "constant.language.boolean": "true|false",
+       "keyword": "let|into|case|prql|type|module|internal",
+       "storage.type": "let|func",
        "support.function": builtinFunctions,
        "support.type": builtinTypes,
-       "constant.language": "true|false|null",
-       "keyword": "let|into|case|prql|type|module|internal"
     }, "identifier");
     
-    var escapeRe = /\\(\d+|['"\\&trnbvf]|u[0-9a-fA-F]{4})/;
+    var escapeRe = /\\(\d+|['"\\&bfnrt]|u[0-9a-fA-F]{4})/;
     var identifierRe = /[A-Za-z_][a-z_A-Z0-9]/.source;
 
     this.$rules = {
@@ -44,23 +47,26 @@ var PrqlHighlightRules = function() {
             token: "string.character",
             regex: "'(?:" + escapeRe.source + "|.)'?"
         }, {
-            regex: /0(?:[xX][0-9A-Fa-f]+|[oO][0-7]+)|\d+(\.\d+)?([eE][-+]?\d*)?/,
-            token: "constant.numeric"
-        }, {
-            token: "comment",
-            regex: "#.*"
-        }, {
-            token : "keyword",
-            regex : /\.\.|\||:|=|\\|"|->|<-/
-        }, {
-            token : "keyword.operator",
-            regex : /[-!#$%&*+.\/<=>?@\\^|~:]+/
-        }, {
-            token : "operator.punctuation",
-            regex : /[,`]/
-        }, {
             token : "constant.language",
             regex : "^" + identifierRe + "*"
+        }, {
+            token : "constant.numeric", // hexadecimal, octal and binary
+            regex : /0(?:[xX][0-9a-fA-F]+|[oO][0-7]+|[bB][01]+)\b/
+        }, {
+            token : "constant.numeric", // decimal integers and floats
+            regex : /(?:\d\d*(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+\b)?/
+        }, {
+            token: "comment.block",
+            regex: "#!.*"
+        }, {
+            token: "comment.line",
+            regex: "#.*"
+        }, {
+            token : "keyword.operator",
+            regex : /->|=>|==|!=|>=|<=|~=|&&|\|\||\?\?|\/\/|@/
+        }, {
+            token : "punctuation.operator",
+            regex : /[,`]/
         }, {
             token : keywordMapper,
             regex : "[\\w\\xff-\\u218e\\u2455-\\uffff]+\\b"
@@ -72,7 +78,7 @@ var PrqlHighlightRules = function() {
             regex: /[\])}]/
         } ],
         string: [{
-            token: "constant.language.escape",
+            token: "constant.character.escape",
             regex: escapeRe
         }, {
             token: "text",
@@ -83,6 +89,9 @@ var PrqlHighlightRules = function() {
             regex: '"',
             next: "start"
         }, {
+            token: "invalid.illegal",
+            regex: "[\\u202A\\u202B\\u202D\\u202E\\u2066\\u2067\\u2068\\u202C\\u2069]"
+        },  {
             defaultToken: "string"
         }],
         stringGap: [{

--- a/src/mode/prql_highlight_rules.js
+++ b/src/mode/prql_highlight_rules.js
@@ -32,11 +32,12 @@ var PrqlHighlightRules = function() {
        "keyword": "let|into|case|prql|type|module|internal",
        "storage.type": "let|func",
        "support.function": builtinFunctions,
-       "support.type": builtinTypes,
+       "support.type": builtinTypes
     }, "identifier");
     
     var escapeRe = /\\(\d+|['"\\&bfnrt]|u[0-9a-fA-F]{4})/;
     var identifierRe = /[A-Za-z_][a-z_A-Z0-9]/.source;
+    var bidi = "[\\u202A\\u202B\\u202D\\u202E\\u2066\\u2067\\u2068\\u202C\\u2069]";
 
     this.$rules = {
         start: [{
@@ -65,6 +66,9 @@ var PrqlHighlightRules = function() {
             token : "keyword.operator",
             regex : /->|=>|==|!=|>=|<=|~=|&&|\|\||\?\?|\/\/|@/
         }, {
+            token: "invalid.illegal",
+            regex: bidi
+        }, {
             token : "punctuation.operator",
             regex : /[,`]/
         }, {
@@ -90,8 +94,8 @@ var PrqlHighlightRules = function() {
             next: "start"
         }, {
             token: "invalid.illegal",
-            regex: "[\\u202A\\u202B\\u202D\\u202E\\u2066\\u2067\\u2068\\u202C\\u2069]"
-        },  {
+            regex: bidi
+        }, {
             defaultToken: "string"
         }],
         stringGap: [{

--- a/src/mode/prql_highlight_rules.js
+++ b/src/mode/prql_highlight_rules.js
@@ -6,7 +6,7 @@ var oop = require("../lib/oop");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 
 var PrqlHighlightRules = function() {
-    var builtinFunctions = "min|max|sum|average|stddev|every|any|concat_array|count|" +
+    const builtinFunctions = "min|max|sum|average|stddev|every|any|concat_array|count|" +
     "lag|lead|first|last|rank|rank_dense|row_number|" +
     "round|as|in|" +
     "tuple_every|tuple_map|tuple_zip|_eq|_is_null|" +
@@ -14,7 +14,7 @@ var PrqlHighlightRules = function() {
     "lower|upper|" +
     "read_parquet|read_csv";
 
-    var builtinTypes = [
+    const builtinTypes = [
         "bool",
         "int",
         "int8",
@@ -60,7 +60,7 @@ var PrqlHighlightRules = function() {
             regex : /[,`]/
         }, {
             token : "constant.language",
-            regex : "^" + identifierRe + "*",
+            regex : "^" + identifierRe + "*"
         }, {
             token : keywordMapper,
             regex : "[\\w\\xff-\\u218e\\u2455-\\uffff]+\\b"


### PR DESCRIPTION
*Description of changes:*
Adds a syntax highlighting mode for the PRQL query language.

PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.
https://prql-lang.org/
https://github.com/PRQL/prql

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
