### PR TITLE
docs: correct type in JSDoc for simple_tokenizer

### DIFF
--- a/src/ext/simple_tokenizer.js
+++ b/src/ext/simple_tokenizer.js
@@ -5,7 +5,7 @@ const isTextToken = require("../layer/text_util").isTextToken;
 class SimpleTokenizer {
     /**
      * @param {string} content 
-     * @param {TokenizerInternal} tokenizer 
+     * @param {Tokenizer} tokenizer 
      */
     constructor(content, tokenizer) {
         this._lines = content.split(/\r\n|\r|\n/);


### PR DESCRIPTION
*Description of changes:*
   * JSDoc typo from https://github.com/ajaxorg/ace/commit/8be84e761c4dfbe43dc7a8cb880cc36c9657c6f1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
