### PR TITLE
Try rendering hover tooltip above mouse

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -282,28 +282,16 @@ class HoverTooltip extends Tooltip {
         element.style.display = "block";
         
         var position = renderer.textToScreenCoordinates(range.start.row, range.start.column);
-        var cursorPos = editor.getCursorPosition();
         
         var labelHeight = element.clientHeight;
         var rect = renderer.scroller.getBoundingClientRect();
 
-        var isTopdown = true;
-        if (this.row > cursorPos.row) {
-            // don't obscure cursor
-            isTopdown = true; 
-        } else if (this.row < cursorPos.row) {
-            // don't obscure cursor
-            isTopdown = false;
-        }
-        
+        var isAbove = true;
         if (position.pageY - labelHeight + renderer.lineHeight < rect.top) {
             // not enough space above us
-            isTopdown = true; 
-        } else if (position.pageY + labelHeight > rect.bottom) {
-            isTopdown = false;
+            isAbove = false;
         }
-
-        if (!isTopdown) {
+        if (isAbove) {
             position.pageY -= labelHeight; 
         } else {
             position.pageY += renderer.lineHeight;

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -286,13 +286,13 @@ class HoverTooltip extends Tooltip {
         var labelHeight = element.clientHeight;
         var rect = renderer.scroller.getBoundingClientRect();
 
-        var isAbove = true;
-        if (position.pageY - labelHeight + renderer.lineHeight < rect.top) {
-            // not enough space above us
+        let isAbove = true;
+        if (position.pageY - labelHeight < 0) {
+            // does not fit in window
             isAbove = false;
         }
         if (isAbove) {
-            position.pageY -= labelHeight; 
+            position.pageY -= labelHeight;
         } else {
             position.pageY += renderer.lineHeight;
         }


### PR DESCRIPTION
*Description of changes:*
Currently, Ace renders the hover tooltip below the mouse. But in the most common scenarios, where the user is typing code and using auto-complete, the hover tooltip tends to overlap the auto-complete.

<img width="667" alt="screenshot of tooltip overlapping the autocomplete" src="https://github.com/ajaxorg/ace/assets/184182/0820654a-7d43-4910-a1f5-7d1badf30852">

By moving the hover tooltip above the mouse there is much less chance of overlapping with autocomplete, as the autocomplete renders below and the hover tooltip will go above. 

It would be possible to have a more advanced collision detection and try to render the hover tooltip in any position that is not blocking the autocomplete. But that could be a future improvement and this PR as is would already improve most use cases.

This PR also allows the tooltip to render outside the editor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
