### PR TITLE
feat: Keep focus on same item in completion popup when slow completer delivers results.

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -75,8 +75,8 @@ class Autocomplete {
 
         this.tooltipTimer = lang.delayedCall(this.updateDocTooltip.bind(this), 50);
 
-        this.keepSelectedRowTimer = lang.delayedCall(function() {
-            this.keepSelectedRow = true;
+        this.keepPreviouslySelectedRowTimer = lang.delayedCall(function() {
+            this.keepPreviouslySelectedRow = true;
         }.bind(this), 500);
     }
 
@@ -110,8 +110,8 @@ class Autocomplete {
             this.inlineRenderer.hide();
         }
         this.hideDocTooltip();
-        this.keepSelectedRowTimer.cancel();
-        this.keepSelectedRow = false;
+        this.keepPreviouslySelectedRowTimer.cancel();
+        this.keepPreviouslySelectedRow = false;
     }
 
     $onPopupChange(hide) {
@@ -128,8 +128,8 @@ class Autocomplete {
 
     $onPopupShow(hide) {
         this.$onPopupChange(hide);
-        this.keepSelectedRow = false;
-        this.keepSelectedRowTimer.schedule();
+        this.keepPreviouslySelectedRow = false;
+        this.keepPreviouslySelectedRowTimer.schedule();
     }
 
     observeLayoutChanges() {
@@ -220,7 +220,7 @@ class Autocomplete {
         
         var newRow = this.popup.data.indexOf(previousSelectedItem);
 
-        if (newRow && this.keepSelectedRow)
+        if (newRow && this.keepPreviouslySelectedRow)
             this.popup.setRow(this.autoSelect ? newRow : -1);
         else
             this.popup.setRow(this.autoSelect ? 0 : -1);

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -76,9 +76,7 @@ class Autocomplete {
         this.tooltipTimer = lang.delayedCall(this.updateDocTooltip.bind(this), 50);
 
         this.keepSelectedRowTimer = lang.delayedCall(function() {
-            console.log("timer trig");
             this.keepSelectedRow = true;
-            console.log(this.keepSelectedRow);
         }.bind(this), 500);
     }
 
@@ -112,7 +110,6 @@ class Autocomplete {
             this.inlineRenderer.hide();
         }
         this.hideDocTooltip();
-        console.log("hide popup")
         this.keepSelectedRowTimer.cancel();
         this.keepSelectedRow = false;
     }
@@ -227,9 +224,6 @@ class Autocomplete {
             this.popup.setRow(this.autoSelect ? newRow : -1);
         else
             this.popup.setRow(this.autoSelect ? 0 : -1);
-
-        console.log(this.keepSelectedRow)
-        console.log(this.popup.getRow())
 
         if (!keepPopupPosition) {
             this.popup.setTheme(editor.getTheme());

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -545,6 +545,133 @@ module.exports = {
         assert.equal(completer.popup.getRow(), 0);
 
         done();
+    },
+    "test: should respect hideInlinePreview": function(done) {
+        var editor = initEditor("hello world\n");
+        
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "option 1",
+                            value: "one",
+                            score: 3
+                        }
+                    ];
+                    callback(null, completions);
+                },
+                hideInlinePreview: true
+            }, {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "option 2",
+                            value: "two",
+                            score: 2
+                        }
+                    ];
+                    callback(null, completions);
+                },
+                hideInlinePreview: false
+            }, {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "option 3",
+                            value: "three",
+                            score: 1
+                        }
+                    ];
+                    callback(null, completions);
+                }
+            }
+        ];
+        
+        var completer = Autocomplete.for(editor);
+        completer.inlineEnabled = true;
+
+        user.type("Ctrl-Space");
+        var inline = completer.inlineRenderer;
+
+        assert.equal(editor.completer.popup.isOpen, true);  
+        
+        // Row 0, should hide inline preview.
+        assert.equal(completer.popup.getRow(), 0);
+        assert.strictEqual(inline.isOpen(), false);
+
+        sendKey("Down");
+
+        // Row 1, should show inline preview.
+        assert.equal(completer.popup.getRow(), 1);
+        assert.strictEqual(inline.isOpen(), true);
+
+        sendKey("Down");
+
+        // Row 2, should show inline preview.
+        assert.equal(completer.popup.getRow(), 2);
+        assert.strictEqual(inline.isOpen(), true);
+
+
+        done();
+    },
+    "test: should maintain selection on fast completer item when slow completer results come in": function(done) {
+        var editor = initEditor("hello world\n");
+        
+        var slowCompleter = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        caption: "slow option 1",
+                        value: "s1",
+                        score: 3
+                    }, {
+                        caption: "slow option 2",
+                        value: "s2",
+                        score: 0
+                    }, 
+                ];
+                setTimeout(() => {
+                    callback(null,  completions)
+                }, 1000);
+            }
+        };
+
+        var fastCompleter = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        caption: "fast option 1",
+                        value: "f1",
+                        score: 2
+                    }, {
+                        caption: "fast option 2",
+                        value: "f2",
+                        score: 1
+                    }, 
+                ];
+                callback(null, completions);
+            }
+        };
+
+        editor.completers = [fastCompleter, slowCompleter];
+        
+        var completer = Autocomplete.for(editor);
+        user.type("Ctrl-Space");
+        assert.equal(completer.popup.isOpen, true);    
+        assert.equal(completer.popup.data.length, 2); 
+        assert.equal(completer.popup.getRow(), 0);
+
+        setTimeout(() => {
+            completer.popup.renderer.$loop._flush();
+            assert.equal(completer.popup.data.length, 4);
+            console.log(completer.popup.getData(0))
+            console.log(completer.popup.getData(1))
+            console.log(completer.popup.getData(2))
+            assert.equal(completer.popup.getRow(), 1);
+     
+            done();
+        }, 2000)    
     }
 };
 

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -665,9 +665,6 @@ module.exports = {
         setTimeout(() => {
             completer.popup.renderer.$loop._flush();
             assert.equal(completer.popup.data.length, 4);
-            console.log(completer.popup.getData(0))
-            console.log(completer.popup.getData(1))
-            console.log(completer.popup.getData(2))
             assert.equal(completer.popup.getRow(), 1);
      
             done();


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Currently, when there are new async completion results delivered by a completer, the active row of the popup is set back to 0. This is jarring when there are completers which are sufficiently slow that the user has already started to interact with the other, faster, completion results.

This adds a timer such that when completions are delivered 500ms after opening the popup, the item in focus remains in focus after the new results are added to the popup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
