### PR TITLE
fix: don't add additional asterisks in c style docs

### DIFF
--- a/src/mode/behaviour/behaviour_test.js
+++ b/src/mode/behaviour/behaviour_test.js
@@ -435,6 +435,15 @@ module.exports = {
         editor.setValue("    /**", 1);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "    /**\n     * \n     */");
+
+        // Test case 4: Pressing enter before an asterisk (*)
+        editor.setValue("/**\n * \n */");
+        editor.gotoLine(1, 0);
+        exec("insertstring", 1, "\n");
+        assert.equal(editor.getValue(), "\n/**\n * \n */");
+        editor.gotoLine(3, 1);
+        exec("insertstring", 1, "\n");
+        assert.equal(editor.getValue(), "\n/**\n \n * \n */");
     }
 };
 

--- a/src/mode/behaviour/cstyle.js
+++ b/src/mode/behaviour/cstyle.js
@@ -311,7 +311,8 @@ var CstyleBehaviour = function(options) {
                 var line = session.doc.getLine(cursor.row);
                 var nextLine = session.doc.getLine(cursor.row + 1);
                 var indent = this.$getIndent(line);
-                if (/\s*\*/.test(nextLine)) {
+                const beforeCursor = line.substring(0, cursor.column);
+                if (/\s*\*/.test(nextLine) && /\*/.test(beforeCursor)) {
                     if (/^\s*\*/.test(line)) {
                         return {
                             text: text + indent + "* ",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/ajaxorg/ace/issues/5320

*Description of changes:*
* now we check if the cursor is before the doc starts or after it, if it's after then we have doc mode as usual, but if the cursor is before then we don't do anything.
* Current experience, notice the problem anytime a cursor is behind an "*" sign:  
![current-ace-cdocs](https://github.com/ajaxorg/ace/assets/30181549/b3c3363c-b139-4514-baac-2ea0b512cb9d)
* New experience 
![c-style-new](https://github.com/ajaxorg/ace/assets/30181549/fc6ad2e6-4cd7-4456-a699-5ce236df4a94)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


