### PR TITLE
feat: Add support for time units in PRQL

### DIFF
--- a/src/mode/prql_highlight_rules.js
+++ b/src/mode/prql_highlight_rules.js
@@ -37,6 +37,7 @@ var PrqlHighlightRules = function() {
     
     var escapeRe = /\\(\d+|['"\\&bfnrt]|u[0-9a-fA-F]{4})/;
     var identifierRe = /[A-Za-z_][a-z_A-Z0-9]/.source;
+    var numRe = /(?:\d\d*(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+\b)?/.source;
     var bidi = "[\\u202A\\u202B\\u202D\\u202E\\u2066\\u2067\\u2068\\u202C\\u2069]";
 
     this.$rules = {
@@ -54,7 +55,7 @@ var PrqlHighlightRules = function() {
             regex: 'r"',
             next: "rstring"
         }, {
-            token: "string",
+            token: "string.single",
             start: "'",
             end: "'"
         }, {
@@ -64,16 +65,19 @@ var PrqlHighlightRules = function() {
             token: "constant.language",
             regex: "^" + identifierRe + "*"
         }, {
+            token : ["constant.numeric", "keyword"],
+            regex : "(" + numRe + ")(years|months|weeks|days|hours|minutes|seconds|milliseconds|microseconds)"
+        }, {
             token: "constant.numeric", // hexadecimal, octal and binary
             regex: /0(?:[xX][0-9a-fA-F]+|[oO][0-7]+|[bB][01]+)\b/
         }, {
             token: "constant.numeric", // decimal integers and floats
-            regex: /(?:\d\d*(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+\b)?/
+            regex: numRe
         }, {
-            token: "comment.block",
+            token: "comment.block.documentation",
             regex: "#!.*"
         }, {
-            token: "comment.line",
+            token: "comment.line.number-sign",
             regex: "#.*"
         }, {
             token: "keyword.operator",
@@ -122,7 +126,7 @@ var PrqlHighlightRules = function() {
             token: "invalid.illegal",
             regex: bidi
         }, {
-            defaultToken: "string"
+            defaultToken: "string.double"
         }],
         stringGap: [{
             token: "text",

--- a/src/mode/prql_highlight_rules.js
+++ b/src/mode/prql_highlight_rules.js
@@ -35,7 +35,7 @@ var PrqlHighlightRules = function() {
        "support.type": builtinTypes
     }, "identifier");
     
-    var escapeRe = /\\(\d+|['"\\&bfnrt]|u[0-9a-fA-F]{4})/;
+    var escapeRe = /\\(\d+|['"\\&bfnrt]|U[0-9a-fA-F]{8}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2})/;
     var identifierRe = /[A-Za-z_][a-z_A-Z0-9]/.source;
     var numRe = /(?:\d\d*(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+\b)?/.source;
     var bidi = "[\\u202A\\u202B\\u202D\\u202E\\u2066\\u2067\\u2068\\u202C\\u2069]";


### PR DESCRIPTION
*Description of changes:*
- Adds support for time units (e.g. `years`, `months`, `days`, etc).
- Change the token `comment.block` to `comment.block.documentation`.
- Change the token `comment.line` to `comment.line.number-sign`.
- Change the tokens `string` to `string.single` and `string.double`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
