### PR TITLE
Add toJSON method to EditSession

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -620,6 +620,8 @@ export namespace Ace {
     documentToScreenColumn(row: number, docColumn: number): number;
     documentToScreenRow(docRow: number, docColumn: number): number;
     getScreenLength(): number;
+    fromJSON(session: string): EditSession;
+    toJSON(): string;
     destroy(): void;
   }
 

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -620,7 +620,7 @@ export namespace Ace {
     documentToScreenColumn(row: number, docColumn: number): number;
     documentToScreenRow(docRow: number, docColumn: number): number;
     getScreenLength(): number;
-    toJSON(): string;
+    toJSON(): Object;
     destroy(): void;
   }
 

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -620,7 +620,6 @@ export namespace Ace {
     documentToScreenColumn(row: number, docColumn: number): number;
     documentToScreenRow(docRow: number, docColumn: number): number;
     getScreenLength(): number;
-    fromJSON(session: string): EditSession;
     toJSON(): string;
     destroy(): void;
   }

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -268,15 +268,15 @@ class EditSession {
      */
      fromJSON(session) {
         session = JSON.parse(session);
-        const undoManager = new ace.UndoManager();
+        const undoManager = new UndoManager();
         undoManager.$undoStack = session.history.undo;
         undoManager.$redoStack = session.history.redo;
         undoManager.mark = session.history.mark;
         undoManager.$rev = session.history.rev;
     
-        const editSession = new ace.EditSession(session.value);
+        const editSession = new EditSession(session.value);
         session.folds.forEach(function(fold) {
-          editSession.addFold("...", ace.Range.fromPoints(fold.start, fold.end));
+          editSession.addFold("...", Range.fromPoints(fold.start, fold.end));
         });
         editSession.setAnnotations(session.annotations);
         editSession.setBreakpoints(session.breakpoints);

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -266,7 +266,7 @@ class EditSession {
      * @param {String} session The EditSession state.
      * @returns {EditSession}
      */
-     fromJSON(session) {
+     static fromJSON(session) {
         session = JSON.parse(session);
         const undoManager = new UndoManager();
         undoManager.$undoStack = session.history.undo;

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -260,9 +260,35 @@ class EditSession {
         this.getUndoManager().reset();
     }
 
+     /**
+     * Returns a new instance of EditSession with state from JSON.
+     * @method fromJSON
+     * @returns {EditSession}
+     */
+     fromJSON(session) {
+        const undoManager = new ace.UndoManager();
+        undoManager.$undoStack = session.history.undo;
+        undoManager.$redoStack = session.history.redo;
+        undoManager.mark = session.history.mark;
+        undoManager.$rev = session.history.rev;
+    
+        const editSession = new ace.EditSession(session.value);
+        session.folds.forEach(function(fold) {
+          editSession.addFold("...", ace.Range.fromPoints(fold.start, fold.end));
+        });
+        editSession.setAnnotations(session.annotations);
+        editSession.setBreakpoints(session.breakpoints);
+        editSession.setMode(session.mode);
+        editSession.setScrollLeft(session.scrollLeft);
+        editSession.setScrollTop(session.scrollTop);
+        editSession.setUndoManager(undoManager);
+        editSession.selection.fromJSON(session.selection);
+    
+        return editSession;
+    }
+ 
     /**
      * Returns the current edit session as a JSON string.
-     * @private
      * @method toJSON
      * @returns {String}
      */

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -263,9 +263,11 @@ class EditSession {
      /**
      * Returns a new instance of EditSession with state from JSON.
      * @method fromJSON
+     * @param {String} session The EditSession state.
      * @returns {EditSession}
      */
      fromJSON(session) {
+        session = JSON.parse(session);
         const undoManager = new ace.UndoManager();
         undoManager.$undoStack = session.history.undo;
         undoManager.$redoStack = session.history.redo;

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -11,6 +11,7 @@ var Range = require("./range").Range;
 var Document = require("./document").Document;
 var BackgroundTokenizer = require("./background_tokenizer").BackgroundTokenizer;
 var SearchHighlight = require("./search_highlight").SearchHighlight;
+var UndoManager = require("./undomanager").UndoManager;
 
 //{ events
 /**

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -283,7 +283,7 @@ class EditSession {
             selection: this.selection.toJSON(),
             value: this.doc.getValue()
         };
-    };
+    }
  
     /**
      * Returns the current [[Document `Document`]] as a string.

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -259,7 +259,32 @@ class EditSession {
         this.setUndoManager(this.$undoManager);
         this.getUndoManager().reset();
     }
-    
+
+    /**
+     * Returns the current edit session as a JSON string.
+     * @private
+     * @method toJSON
+     * @returns {String}
+     */
+    toJSON() {
+        return {
+            annotations: this.$annotations,
+            breakpoints: this.$breakpoints,
+            folds: this.getAllFolds().map(function(fold) {
+                return fold.range;
+            }),
+            history: {
+                undo: this.getUndoManager().$undoStack,
+                redo: this.getUndoManager().$redoStack
+            },
+            mode: this.$mode.$id,
+            scrollLeft: this.$scrollLeft,
+            scrollTop: this.$scrollTop,
+            selection: this.selection.toJSON(),
+            value: this.doc.getValue()
+        };
+    };
+ 
     /**
      * Returns the current [[Document `Document`]] as a string.
      * @method toString

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -291,9 +291,9 @@ class EditSession {
     }
  
     /**
-     * Returns the current edit session as a JSON string.
+     * Returns the current edit session.
      * @method toJSON
-     * @returns {String}
+     * @returns {Object}
      */
     toJSON() {
         return {
@@ -302,10 +302,7 @@ class EditSession {
             folds: this.getAllFolds().map(function(fold) {
                 return fold.range;
             }),
-            history: {
-                undo: this.getUndoManager().$undoStack,
-                redo: this.getUndoManager().$redoStack
-            },
+            history: this.getUndoManager(),
             mode: this.$mode.$id,
             scrollLeft: this.$scrollLeft,
             scrollTop: this.$scrollTop,

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1145,7 +1145,7 @@ module.exports = {
         session.setMode("ace/mode/javascript");
         var json = JSON.parse(JSON.stringify(session));
         assert.equal(json.annotations.length, 1);
-        assert.equal(json.folds, []);
+        assert.equal(json.folds.length, 0);
         assert.equal(json.mode, "ace/mode/javascript");
         assert.equal(json.scrollLeft, 0);
         assert.equal(json.scrollTop, 0);

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1146,7 +1146,6 @@ module.exports = {
         session = EditSession.fromJSON(JSON.stringify(session));
         
         assert.equal(session.getAnnotations().length, 1);
-        assert.equal(session.getFolds().length, 0);
         assert.equal(session.getMode(), "ace/mode/javascript");
         assert.equal(session.getScrollLeft(), 0);
         assert.equal(session.getScrollTop(), 0);

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1146,8 +1146,8 @@ module.exports = {
         var json = JSON.parse(JSON.stringify(session));
         assert.equal(json.annotations.length, 1);
         assert.equal(json.mode, "ace/mode/javascript");
-        assert.equal(json.scrollLeft, 0)
-        assert.equal(json.scrollTop, 0)
+        assert.equal(json.scrollLeft, 0);
+        assert.equal(json.scrollTop, 0);
         assert.equal(json.value, "Hello world!");
     }
 };

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1143,13 +1143,14 @@ module.exports = {
         var session = new EditSession(["Hello world!"]);
         session.setAnnotations([{row: 0, column: 0, text: "error test", type: "error"}]);
         session.setMode("ace/mode/javascript");
-        var json = JSON.parse(JSON.stringify(session));
-        assert.equal(json.annotations.length, 1);
-        assert.equal(json.folds.length, 0);
-        assert.equal(json.mode, "ace/mode/javascript");
-        assert.equal(json.scrollLeft, 0);
-        assert.equal(json.scrollTop, 0);
-        assert.equal(json.value, "Hello world!");
+        session = EditSession.fromJSON(JSON.stringify(session));
+        
+        assert.equal(session.getAnnotations().length, 1);
+        assert.equal(session.getFolds().length, 0);
+        assert.equal(session.getMode(), "ace/mode/javascript");
+        assert.equal(session.getScrollLeft(), 0);
+        assert.equal(session.getScrollTop(), 0);
+        assert.equal(session.getValue(), "Hello world!");
     }
 };
 

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1146,7 +1146,7 @@ module.exports = {
         session = EditSession.fromJSON(JSON.stringify(session));
         
         assert.equal(session.getAnnotations().length, 1);
-        assert.equal(session.getMode(), "ace/mode/javascript");
+        assert.equal(session.getMode().$id, "ace/mode/javascript");
         assert.equal(session.getScrollLeft(), 0);
         assert.equal(session.getScrollTop(), 0);
         assert.equal(session.getValue(), "Hello world!");

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1137,7 +1137,7 @@ module.exports = {
         session.destroy();
         assert.equal(session.destroyed, true);
         assert.notEqual(session.bgTokenizer, null);
-    }
+    },
 
     "test: JSON serialization": function() {
         var session = new EditSession(["Hello world!"]);

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1138,6 +1138,20 @@ module.exports = {
         assert.equal(session.destroyed, true);
         assert.notEqual(session.bgTokenizer, null);
     }
+
+    "test: JSON serialization": function() {
+        var session = new EditSession(["Hello world!"]);
+        session.setAnnotations([{row: 0, column: 0, text: "error test", type: "error"}]);
+        session.setBreakpoints([1]);
+        session.setMode("ace/mode/javascript");
+        var json = JSON.parse(JSON.stringify(session));
+        assert.equal(json.annotations.length, 1);
+        assert.equal(json.breakpoints, [1]);
+        assert.equal(json.mode, "ace/mode/javascript");
+        assert.equal(json.scrollLeft, 0)
+        assert.equal(json.scrollTop, 0)
+        assert.equal(json.value, "Hello world!");
+    }
 };
 
 if (typeof module !== "undefined" && module === require.main) {

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1142,11 +1142,9 @@ module.exports = {
     "test: JSON serialization": function() {
         var session = new EditSession(["Hello world!"]);
         session.setAnnotations([{row: 0, column: 0, text: "error test", type: "error"}]);
-        session.setBreakpoints([1]);
         session.setMode("ace/mode/javascript");
         var json = JSON.parse(JSON.stringify(session));
         assert.equal(json.annotations.length, 1);
-        assert.equal(json.breakpoints, [1]);
         assert.equal(json.mode, "ace/mode/javascript");
         assert.equal(json.scrollLeft, 0)
         assert.equal(json.scrollTop, 0)

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1145,6 +1145,7 @@ module.exports = {
         session.setMode("ace/mode/javascript");
         var json = JSON.parse(JSON.stringify(session));
         assert.equal(json.annotations.length, 1);
+        assert.equal(json.folds, []);
         assert.equal(json.mode, "ace/mode/javascript");
         assert.equal(json.scrollLeft, 0);
         assert.equal(json.scrollTop, 0);


### PR DESCRIPTION
*Issue #, if available:* #1452

*Description of changes:*
Adds a [`toJSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior) method to facilitate serialization of the the `EditSession` object into JSON through the [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.