### PR TITLE
Inline preview/ghost text screen reader a11y

### DIFF
--- a/src/autocomplete/inline.js
+++ b/src/autocomplete/inline.js
@@ -22,9 +22,6 @@ class AceInline {
      * @returns {boolean} True if the completion could be rendered to the editor, false otherwise
      */
     show(editor, completion, prefix) {
-        if (!this.inlineScreenReader)
-            this.inlineScreenReader = new AceInlineScreenReader(editor);
-
         prefix = prefix || "";
         if (editor && this.editor && this.editor !== editor) {
             this.hide();
@@ -33,6 +30,9 @@ class AceInline {
         }
         if (!editor || !completion) {
             return false;
+        }
+        if (!this.inlineScreenReader) {
+            this.inlineScreenReader = new AceInlineScreenReader(editor);
         }
         var displayText = completion.snippet ? snippetManager.getDisplayTextForSnippet(editor, completion.snippet) : completion.value;
         if (completion.hideInlinePreview || !displayText || !displayText.startsWith(prefix)) {
@@ -69,8 +69,10 @@ class AceInline {
     destroy() {
         this.hide();
         this.editor = null;
-        this.inlineScreenReader.destroy();
-        this.inlineScreenReader = null;
+        if (this.inlineScreenReader) {
+            this.inlineScreenReader.destroy();
+            this.inlineScreenReader = null;
+        }
     }
 }
 

--- a/src/autocomplete/inline.js
+++ b/src/autocomplete/inline.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var snippetManager = require("../snippets").snippetManager;
+var AceInlineScreenReader = require("./inline_screenreader").AceInlineScreenReader;
 
 /**
  * This object is used to manage inline code completions rendered into an editor with ghost text.
@@ -21,10 +22,14 @@ class AceInline {
      * @returns {boolean} True if the completion could be rendered to the editor, false otherwise
      */
     show(editor, completion, prefix) {
+        if (!this.inlineScreenReader)
+            this.inlineScreenReader = new AceInlineScreenReader(editor);
+
         prefix = prefix || "";
         if (editor && this.editor && this.editor !== editor) {
             this.hide();
             this.editor = null;
+            this.inlineScreenReader = null;
         }
         if (!editor || !completion) {
             return false;
@@ -34,6 +39,9 @@ class AceInline {
             return false;
         }
         this.editor = editor;
+
+        this.inlineScreenReader.setScreenReaderContent(displayText);
+
         displayText = displayText.slice(prefix.length);
         if (displayText === "") {
             editor.removeGhostText();
@@ -61,6 +69,8 @@ class AceInline {
     destroy() {
         this.hide();
         this.editor = null;
+        this.inlineScreenReader.destroy();
+        this.inlineScreenReader = null;
     }
 }
 

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -9,7 +9,7 @@ class AceInlineScreenReader {
 
     setScreenReaderContent(content) {
         // Path for when inline preview is used with 'normal' completion popup.
-        if (!this.popup && this.editor.completer && this.editor.completer.popup) {
+        if (!this.popup && this.editor.completer?.popup) {
             this.popup = this.editor.completer.popup;
 
             this.popup.renderer.on("afterRender", function() {

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -8,7 +8,8 @@ class AceInlineScreenReader {
     }
 
     setScreenReaderContent(content) {
-        if (!this.popup) {
+        // Path for when inline preview is used with 'normal' completion popup.
+        if (!this.popup && this.editor.completer && this.editor.completer.popup) {
             this.popup = this.editor.completer.popup;
 
             this.popup.renderer.on("afterRender", function() {
@@ -24,6 +25,8 @@ class AceInlineScreenReader {
                 };
             }.bind(this));
         };
+
+        // TODO: Path for when special inline completion popup is used.
 
         // Remove all children of the div
         while (this.screenReaderDiv.firstChild) {

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -51,11 +51,6 @@ class AceInlineScreenReader {
     }
 
     destroy() {
-        // Remove all children of the div
-        while (this.screenReaderDiv.firstChild) {
-            this.screenReaderDiv.removeChild(this.screenReaderDiv.firstChild);
-        }
-
         this.screenReaderDiv.remove();
     }
 

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -4,25 +4,34 @@ class AceInlineScreenReader {
 
         this.screenReaderDiv = document.createElement("div");
         this.screenReaderDiv.classList.add("ace_screenreader_only");
-        this.screenReaderDiv.setAttribute("id", "ace-inline-screenreader");
         this.editor.container.appendChild(this.screenReaderDiv);
     }
 
     setScreenReaderContent(content) {
+        if (!this.popup) {
+            this.popup = this.editor.completer.popup;
+
+            this.popup.renderer.on("afterRender", function() {
+                let row = this.popup.getRow();
+                let t = this.popup.renderer.$textLayer;
+                let selected = t.element.childNodes[row - t.config.firstRow];
+                if (selected) {
+                    let idString = "";
+                    for (let lineIndex = 0; lineIndex < this._lines.length; lineIndex++) {
+                        idString += `ace-inline-screenreader-line-${lineIndex} `
+                    }
+                    selected.setAttribute("aria-details", idString);      
+                };
+            }.bind(this));
+        };
+
         // Remove all children of the div
         while (this.screenReaderDiv.firstChild) {
             this.screenReaderDiv.removeChild(this.screenReaderDiv.firstChild);
         }
-
-        const codeElement = AceInlineScreenReader.createCodeBlock(content);
+        this._lines = content.split(/\r\n|\r|\n/);
+        const codeElement = this.createCodeBlock();
         this.screenReaderDiv.appendChild(codeElement);
-
-        const popup = editor.completer.popup;
-
-        var popupTextLayer = popup.renderer.$textLayer;
-        var row = popup.getRow();
-        var selectedPopupElement = popupTextLayer.element.childNodes[row - popupTextLayer.config.firstRow];
-        selectedPopupElement.setAttribute("aria-describedby", "ace-inline-screenreader");
     }
 
     destroy() {
@@ -34,15 +43,13 @@ class AceInlineScreenReader {
         this.screenReaderDiv.remove();
     }
 
-    static createCodeBlock(content) {
+    createCodeBlock() {
         const container = document.createElement("pre");
-        this._lines = content.split(/\r\n|\r|\n/);
+        container.setAttribute("id", "ace-inline-screenreader");
 
         for (let lineIndex = 0; lineIndex < this._lines.length; lineIndex++) {
-            const lineElement = document.createElement("div");
-            lineElement.className = "ace_line";
-            
             const codeElement = document.createElement("code");
+            codeElement.setAttribute("id", `ace-inline-screenreader-line-${lineIndex}`);
             const line = document.createTextNode(this._lines[lineIndex]);
 
             codeElement.appendChild(line);

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -1,4 +1,12 @@
+"use strict";
+
+/**
+ * This object is used to communicate inline code completions rendered into an editor with ghost text to screen reader users.
+ */
 class AceInlineScreenReader {
+    /**
+     * Creates the off-screen div in which the ghost text content in redered and which the screen reader reads.
+     */
     constructor(editor) {
         this.editor = editor;
 
@@ -7,6 +15,10 @@ class AceInlineScreenReader {
         this.editor.container.appendChild(this.screenReaderDiv);
     }
 
+    /**
+     * Set the ghost text content to the screen reader div
+     * @param {string} content
+     */
     setScreenReaderContent(content) {
         // Path for when inline preview is used with 'normal' completion popup.
         if (!this.popup && this.editor.completer && this.editor.completer.popup) {
@@ -46,6 +58,9 @@ class AceInlineScreenReader {
         this.screenReaderDiv.remove();
     }
 
+    /**
+     * Take this._lines, render it as <code> blocks and add those to the screen reader div.
+     */
     createCodeBlock() {
         const container = document.createElement("pre");
         container.setAttribute("id", "ace-inline-screenreader");
@@ -61,7 +76,6 @@ class AceInlineScreenReader {
 
         return container;
     }
-    
 }
 
 exports.AceInlineScreenReader = AceInlineScreenReader;

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -6,6 +6,7 @@
 class AceInlineScreenReader {
     /**
      * Creates the off-screen div in which the ghost text content in redered and which the screen reader reads.
+     * @param {import("../editor").Editor} editor
      */
     constructor(editor) {
         this.editor = editor;

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -40,6 +40,7 @@ class AceInlineScreenReader {
         }
 
         // TODO: Path for when special inline completion popup is used.
+        // https://github.com/ajaxorg/ace/issues/5348
 
         // Remove all children of the div
         while (this.screenReaderDiv.firstChild) {

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -9,7 +9,7 @@ class AceInlineScreenReader {
 
     setScreenReaderContent(content) {
         // Path for when inline preview is used with 'normal' completion popup.
-        if (!this.popup && this.editor.completer?.popup) {
+        if (!this.popup && this.editor.completer && this.editor.completer.popup) {
             this.popup = this.editor.completer.popup;
 
             this.popup.renderer.on("afterRender", function() {

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -19,12 +19,12 @@ class AceInlineScreenReader {
                 if (selected) {
                     let idString = "";
                     for (let lineIndex = 0; lineIndex < this._lines.length; lineIndex++) {
-                        idString += `ace-inline-screenreader-line-${lineIndex} `
+                        idString += `ace-inline-screenreader-line-${lineIndex} `;
                     }
                     selected.setAttribute("aria-details", idString);      
-                };
+                }
             }.bind(this));
-        };
+        }
 
         // TODO: Path for when special inline completion popup is used.
 
@@ -60,7 +60,7 @@ class AceInlineScreenReader {
         }
 
         return container;
-    };
+    }
     
 }
 

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -30,11 +30,11 @@ class AceInlineScreenReader {
                 let t = this.popup.renderer.$textLayer;
                 let selected = t.element.childNodes[row - t.config.firstRow];
                 if (selected) {
-                    let idString = "";
+                    let idString = "doc-tooltip ";
                     for (let lineIndex = 0; lineIndex < this._lines.length; lineIndex++) {
                         idString += `ace-inline-screenreader-line-${lineIndex} `;
                     }
-                    selected.setAttribute("aria-details", idString);      
+                    selected.setAttribute("aria-describedby", idString);      
                 }
             }.bind(this));
         }

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -1,0 +1,57 @@
+class AceInlineScreenReader {
+    constructor(editor) {
+        this.editor = editor;
+
+        this.screenReaderDiv = document.createElement("div");
+        this.screenReaderDiv.classList.add("ace_screenreader_only");
+        this.screenReaderDiv.setAttribute("id", "ace-inline-screenreader");
+        this.editor.container.appendChild(this.screenReaderDiv);
+    }
+
+    setScreenReaderContent(content) {
+        // Remove all children of the div
+        while (this.screenReaderDiv.firstChild) {
+            this.screenReaderDiv.removeChild(this.screenReaderDiv.firstChild);
+        }
+
+        const codeElement = AceInlineScreenReader.createCodeBlock(content);
+        this.screenReaderDiv.appendChild(codeElement);
+
+        const popup = editor.completer.popup;
+
+        var popupTextLayer = popup.renderer.$textLayer;
+        var row = popup.getRow();
+        var selectedPopupElement = popupTextLayer.element.childNodes[row - popupTextLayer.config.firstRow];
+        selectedPopupElement.setAttribute("aria-describedby", "ace-inline-screenreader");
+    }
+
+    destroy() {
+        // Remove all children of the div
+        while (this.screenReaderDiv.firstChild) {
+            this.screenReaderDiv.removeChild(this.screenReaderDiv.firstChild);
+        }
+
+        this.screenReaderDiv.remove();
+    }
+
+    static createCodeBlock(content) {
+        const container = document.createElement("pre");
+        this._lines = content.split(/\r\n|\r|\n/);
+
+        for (let lineIndex = 0; lineIndex < this._lines.length; lineIndex++) {
+            const lineElement = document.createElement("div");
+            lineElement.className = "ace_line";
+            
+            const codeElement = document.createElement("code");
+            const line = document.createTextNode(this._lines[lineIndex]);
+
+            codeElement.appendChild(line);
+            container.appendChild(codeElement);
+        }
+
+        return container;
+    };
+    
+}
+
+exports.AceInlineScreenReader = AceInlineScreenReader;

--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -3,7 +3,7 @@ class AceInlineScreenReader {
         this.editor = editor;
 
         this.screenReaderDiv = document.createElement("div");
-        this.screenReaderDiv.classList.add("ace_screenreader_only");
+        this.screenReaderDiv.classList.add("ace_screenreader-only");
         this.editor.container.appendChild(this.screenReaderDiv);
     }
 

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -788,12 +788,12 @@ module.exports = {
                     var completions = [
                         {
                             caption: "function",
-                            value: "function\nthat does something\ncool",
+                            value: "function\nthat does something\ncool"
                         }
                     ];
                     callback(null, completions);
-                },
-            }, 
+                }
+            }
         ];
         
         var completer = Autocomplete.for(editor);

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -779,7 +779,7 @@ module.exports = {
         user.type(" value");
         assert.equal(completer.popup.isOpen, true);   
     },
-    "test: should set inline preview content as aria-details": function(done) {
+    "test: should add inline preview content to aria-describedby": function(done) {
         var editor = initEditor("fun");
         
         editor.completers = [
@@ -812,7 +812,7 @@ module.exports = {
         var popupTextLayer = completer.popup.renderer.$textLayer;
 
         // aria-details of selected popup item should have aria-details set to the offscreen inline screen reader div.
-        assert.strictEqual(popupTextLayer.selectedNode.getAttribute("aria-details"), "ace-inline-screenreader-line-0 ace-inline-screenreader-line-1 ace-inline-screenreader-line-2 ");
+        assert.strictEqual(popupTextLayer.selectedNode.getAttribute("aria-describedby"), "doc-tooltip ace-inline-screenreader-line-0 ace-inline-screenreader-line-1 ace-inline-screenreader-line-2 ");
 
         // The elements with these IDs should have the correct content.
         assert.strictEqual(document.getElementById("ace-inline-screenreader-line-0").textContent,"function");

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -811,7 +811,7 @@ module.exports = {
         editor.completer.popup.renderer.$loop._flush();
         var popupTextLayer = completer.popup.renderer.$textLayer;
 
-        // aria-details of selected popup item should have aria-details set to the offscreen inline screen reader div.
+        // aria-describedby of selected popup item should have aria-describedby set to the offscreen inline screen reader div and doc-tooltip.
         assert.strictEqual(popupTextLayer.selectedNode.getAttribute("aria-describedby"), "doc-tooltip ace-inline-screenreader-line-0 ace-inline-screenreader-line-1 ace-inline-screenreader-line-2 ");
 
         // The elements with these IDs should have the correct content.

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -778,6 +778,48 @@ module.exports = {
         // Should filter using the value instead.
         user.type(" value");
         assert.equal(completer.popup.isOpen, true);   
+    },
+    "test: should set inline preview content as aria-details": function(done) {
+        var editor = initEditor("fun");
+        
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "function",
+                            value: "function\nthat does something\ncool",
+                        }
+                    ];
+                    callback(null, completions);
+                },
+            }, 
+        ];
+        
+        var completer = Autocomplete.for(editor);
+        completer.inlineEnabled = true;
+
+        user.type("Ctrl-Space");
+        var inline = completer.inlineRenderer;
+
+        // Popup should be open, with inline text renderered.
+        assert.equal(editor.completer.popup.isOpen, true);  
+        assert.equal(completer.popup.getRow(), 0);
+        assert.strictEqual(inline.isOpen(), true);
+        assert.strictEqual(editor.renderer.$ghostText.text, "function\nthat does something\ncool");
+
+        editor.completer.popup.renderer.$loop._flush();
+        var popupTextLayer = completer.popup.renderer.$textLayer;
+
+        // aria-details of selected popup item should have aria-details set to the offscreen inline screen reader div.
+        assert.strictEqual(popupTextLayer.selectedNode.getAttribute("aria-details"), "ace-inline-screenreader-line-0 ace-inline-screenreader-line-1 ace-inline-screenreader-line-2 ");
+
+        // The elements with these IDs should have the correct content.
+        assert.strictEqual(document.getElementById("ace-inline-screenreader-line-0").textContent,"function");
+        assert.strictEqual(document.getElementById("ace-inline-screenreader-line-1").textContent,"that does something");
+        assert.strictEqual(document.getElementById("ace-inline-screenreader-line-2").textContent,"cool");
+
+        done();
     }
 };
 

--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -651,4 +651,13 @@ module.exports = `
     opacity: 0.5;
     font-style: italic;
     white-space: pre;
+}
+
+.ace_screenreader_only {
+    position:absolute;
+    left:-10000px;
+    top:auto;
+    width:1px;
+    height:1px;
+    overflow:hidden;
 }`;

--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -653,7 +653,7 @@ module.exports = `
     white-space: pre;
 }
 
-.ace_screenreader_only {
+.ace_screenreader-only {
     position:absolute;
     left:-10000px;
     top:auto;


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Currently, there is no way for screen reader users to learn the contents of the ghost text inline preview. This adds an `aria-describedby` to the completion item with inline preview which points to a screen reader only div displaying the contents of the ghost test. This allows the screen reader to read the content of the inline preview using the `aria-describedby` UX of their screen reader.



https://github.com/ajaxorg/ace/assets/34573235/d95f53dc-0aad-448e-84c1-3c4c2ec279da


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
