### PR TITLE
feat: allow setting completion.ignoreCaption

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -1067,6 +1067,7 @@ export namespace Ace {
     parentNode?: HTMLElement;
     setSelectOnHover?: Boolean;
     stickySelectionDelay?: Number;
+    ignoreCaption?: Boolean;
     emptyMessage?(prefix: String): String;
     getPopup(): AcePopup;
     showPopup(editor: Editor, options: CompletionOptions): void;

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -399,7 +399,10 @@ class Autocomplete {
         var prefix = util.getCompletionPrefix(this.editor);
         this.base = session.doc.createAnchor(pos.row, pos.column - prefix.length);
         this.base.$insertRight = true;
-        var completionOptions = { exactMatch: this.exactMatch };
+        var completionOptions = {
+            exactMatch: this.exactMatch,
+            ignoreCaption: this.ignoreCaption
+        };
         this.getCompletionProvider({
             prefix,
             pos

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -726,6 +726,58 @@ module.exports = {
      
             done();
         }, 500);    
+    },
+    "test: should filter using caption if ignoreCaption false": function() {
+        var editor = initEditor("hello world\n");
+        
+        var completer = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        caption: "caption",
+                        value: "value",
+                    }
+                ];
+                callback(null,  completions);
+            }
+        };
+
+        editor.completers = [completer];
+        
+        var completer = Autocomplete.for(editor);
+
+        // Should filter using the caption if set to false.
+        completer.ignoreCaption = false;
+        user.type("cap");
+        assert.equal(completer.popup.isOpen, true);   
+    },
+    "test: should filter using value if ignoreCaption true": function() {
+        var editor = initEditor("hello world\n");
+        
+        var completer = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        caption: "caption",
+                        value: "value",
+                    }
+                ];
+                callback(null,  completions);
+            }
+        };
+
+        editor.completers = [completer];
+        
+        var completer = Autocomplete.for(editor);
+
+        // Should not filter using the caption if set to true.
+        completer.ignoreCaption = true;
+        user.type("cap");
+        assert.equal(completer.popup, undefined);   
+
+        // Should filter using the value instead.
+        user.type(" value");
+        assert.equal(completer.popup.isOpen, true);   
     }
 };
 

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -735,7 +735,7 @@ module.exports = {
                 var completions = [
                     {
                         caption: "caption",
-                        value: "value",
+                        value: "value"
                     }
                 ];
                 callback(null,  completions);
@@ -759,7 +759,7 @@ module.exports = {
                 var completions = [
                     {
                         caption: "caption",
-                        value: "value",
+                        value: "value"
                     }
                 ];
                 callback(null,  completions);


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* By default, we [use](https://github.com/ajaxorg/ace/blob/master/src/autocomplete.js#L832) the `caption` value of a completion result to filter results. This might cause issues for users who want to have a caption say something else than what's going to be inserted (e.g. when they are using inline preview). This allows setting `ignoreCaption` to true after which filtering will be done following the `value` or `snippet` parameters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
