### PR TITLE
Add record, yield, and sealed to the list of java keywords

### DIFF
--- a/src/mode/java_highlight_rules.js
+++ b/src/mode/java_highlight_rules.js
@@ -18,7 +18,7 @@ var JavaHighlightRules = function() {
     "char|final|interface|static|void|" +
     "class|finally|long|strictfp|volatile|" +
     "const|float|native|super|while|" +
-    "var"
+    "var|record|yield|sealed"
     );
 
     var buildinConstants = ("null|Infinity|NaN|undefined");


### PR DESCRIPTION
A start to addressing #5338


Adds record, yield, and sealed to the list of Java keywords

```java
sealed interface A {}
record B() implements A {}

void main() {
    int x = Math.random() > 0.5 ? 1 : 0;
    int y = switch (x) {
       case 1 -> {
           System.out.println("A");
           yield 5;
       }
       default -> 9;
    };
    System.out.println(x + y);
}
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
