### PR TITLE
Add "enableDoubleFindToReplace" option

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -2794,6 +2794,7 @@ config.defineOptions(Editor.prototype, "editor", {
     behavioursEnabled: {initialValue: true},
     wrapBehavioursEnabled: {initialValue: true},
     enableAutoIndent: {initialValue: true},
+    enableDoubleFindToReplace: {initalValue: false},
     autoScrollEditorIntoView: {
         set: function(val) {this.setAutoScrollEditorIntoView(val);}
     },

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -265,11 +265,9 @@ class SearchBox {
 var $searchBarKb = new HashHandler();
 $searchBarKb.bindKeys({
     "Ctrl-f|Command-f": function(sb) {
-        var isReplace = sb.isReplace = !sb.isReplace;
-        sb.replaceBox.style.display = isReplace ? "" : "none";
-        sb.replaceOption.checked = false;
+        sb.replaceOption.checked = sb.editor.getOption('enableDoubleFindToReplace') && !sb.replaceOption.checked;
         sb.$syncOptions();
-        sb.searchInput.focus();
+        sb[sb.replaceOption.checked ? "replaceInput" : "searchInput"].focus();
     },
     "Ctrl-H|Command-Option-F": function(sb) {
         if (sb.editor.getReadOnly())


### PR DESCRIPTION
*Issue #, if available:*
Brings back the behavior that #2653 complained about behind an option.

*Description of changes:*
Add "enableDoubleFindToReplace" option. This allows you to press Ctrl-F while the find window is open to toggle the replace option. I'm used to it, and so are the people at my company.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
