### PR TITLE
Don't move popup with inline preview if setSelectOnHover true

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -319,8 +319,10 @@ class Autocomplete {
     }
 
     mouseOutListener(e) {
-        this.$updatePopupPosition();
-        this.tooltipTimer.call(null, null);
+        // Check whether the popup is still open after the mouseout event,
+        // if so, attempt to move it to its desired position.
+        if (this.popup.isOpen)
+            this.$updatePopupPosition();
     }
 
    goTo(where) {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -62,7 +62,7 @@ class Autocomplete {
         this.keyboardHandler = new HashHandler();
         this.keyboardHandler.bindKeys(this.commands);
         this.parentNode = null;
-        this.setSelectOnHover = false;
+        this.setSelectOnHover = true;
 
         /**
          *  @property {number} stickySelectionDelay - a numerical value that determines after how many ms the popup selection will become 'sticky'.
@@ -315,7 +315,8 @@ class Autocomplete {
     }
 
     mousewheelListener(e) {
-        this.detach();
+        if (!this.popup.isMouseOver)
+            this.detach();
     }
 
     mouseOutListener(e) {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -9,6 +9,7 @@ var lang = require("./lib/lang");
 var dom = require("./lib/dom");
 var snippetManager = require("./snippets").snippetManager;
 var config = require("./config");
+var event = require("./lib/event");
 
 /**
  * @typedef BaseCompletion
@@ -97,6 +98,7 @@ class Autocomplete {
         this.popup.on("show", this.$onPopupShow.bind(this));
         this.popup.on("hide", this.$onHidePopup.bind(this));
         this.popup.on("select", this.$onPopupChange.bind(this));
+        event.addListener(this.popup.container, "mouseout", this.$updatePopupPosition.bind(this));
         this.popup.on("changeHoverMarker", this.tooltipTimer.bind(null, null));
         return this.popup;
     }
@@ -127,6 +129,12 @@ class Autocomplete {
             var prefix = util.getCompletionPrefix(this.editor);
             if (!this.inlineRenderer.show(this.editor, completion, prefix)) {
                 this.inlineRenderer.hide();
+            }
+
+            // If the mouse is over the tooltip, and we're changing selection on hover don't
+            // move the tooltip while hovering over the popup.
+            if (this.popup.isMouseOver && this.setSelectOnHover) { 
+                return;
             }
             this.$updatePopupPosition();
         }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -62,7 +62,7 @@ class Autocomplete {
         this.keyboardHandler = new HashHandler();
         this.keyboardHandler.bindKeys(this.commands);
         this.parentNode = null;
-        this.setSelectOnHover = true;
+        this.setSelectOnHover = false;
 
         /**
          *  @property {number} stickySelectionDelay - a numerical value that determines after how many ms the popup selection will become 'sticky'.

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -320,6 +320,7 @@ class Autocomplete {
 
     mouseOutListener(e) {
         this.$updatePopupPosition();
+        this.tooltipTimer.call(null, null);
     }
 
    goTo(where) {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -98,7 +98,7 @@ class Autocomplete {
         this.popup.on("show", this.$onPopupShow.bind(this));
         this.popup.on("hide", this.$onHidePopup.bind(this));
         this.popup.on("select", this.$onPopupChange.bind(this));
-        event.addListener(this.popup.container, "mouseout", this.$updatePopupPosition.bind(this));
+        event.addListener(this.popup.container, "mouseout", this.mouseOutListener.bind(this));
         this.popup.on("changeHoverMarker", this.tooltipTimer.bind(null, null));
         return this.popup;
     }
@@ -134,10 +134,11 @@ class Autocomplete {
             // If the mouse is over the tooltip, and we're changing selection on hover don't
             // move the tooltip while hovering over the popup.
             if (this.popup.isMouseOver && this.setSelectOnHover) { 
+                this.tooltipTimer.call(null, null);
                 return;
             }
-            this.$updatePopupPosition();
         }
+        this.$updatePopupPosition();
         this.tooltipTimer.call(null, null);
     }
 
@@ -315,6 +316,10 @@ class Autocomplete {
 
     mousewheelListener(e) {
         this.detach();
+    }
+
+    mouseOutListener(e) {
+        this.$updatePopupPosition();
     }
 
    goTo(where) {

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -158,8 +158,8 @@ class AcePopup {
         };
 
         event.addListener(popup.container, "mouseout", function() {
-            hideHoverMarker();
             popup.isMouseOver = false;
+            hideHoverMarker();
         });
         popup.on("hide", hideHoverMarker);
         popup.on("changeSelection", hideHoverMarker);

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -103,6 +103,7 @@ class AcePopup {
             }
             lastMouseEvent = e;
             lastMouseEvent.scrollTop = popup.renderer.scrollTop;
+            popup.isMouseOver = true;
             var row = lastMouseEvent.getDocumentPosition().row;
             if (hoverMarker.start.row != row) {
                 if (!hoverMarker.id)
@@ -156,7 +157,10 @@ class AcePopup {
             return hoverMarker.start.row;
         };
 
-        event.addListener(popup.container, "mouseout", hideHoverMarker);
+        event.addListener(popup.container, "mouseout", function() {
+            hideHoverMarker();
+            popup.isMouseOver = false;
+        });
         popup.on("hide", hideHoverMarker);
         popup.on("changeSelection", hideHoverMarker);
 
@@ -224,6 +228,7 @@ class AcePopup {
         popup.isTopdown = false;
         popup.autoSelect = true;
         popup.filterText = "";
+        popup.isMouseOver = false;
 
         popup.data = [];
         popup.setData = function(list, filterText) {

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -161,10 +161,7 @@ class AcePopup {
             hideHoverMarker();
             popup.isMouseOver = false;
         });
-        popup.on("hide", function() {
-            hideHoverMarker();
-            popup.isMouseOver = false;
-        });
+        popup.on("hide", hideHoverMarker);
         popup.on("changeSelection", hideHoverMarker);
 
         popup.session.doc.getLength = function() {

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -161,7 +161,10 @@ class AcePopup {
             hideHoverMarker();
             popup.isMouseOver = false;
         });
-        popup.on("hide", hideHoverMarker);
+        popup.on("hide", function() {
+            hideHoverMarker();
+            popup.isMouseOver = false;
+        });
         popup.on("changeSelection", hideHoverMarker);
 
         popup.session.doc.getLength = function() {

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -865,8 +865,6 @@ module.exports = {
         var text = completer.popup.renderer.content.childNodes[2];
         var rect = text.getBoundingClientRect();
 
-        console.log(rect)
-
         // We need two mouse events to trigger the updating of the hover marker.
         text.dispatchEvent(new MouseEvent("move", {x: rect.left, y: rect.top}));
         // Hover over the second row.
@@ -885,12 +883,8 @@ module.exports = {
         text.dispatchEvent(new MouseEvent("out", {x: rect.left, y: rect.top}));
         editor.completer.popup.renderer.$loop._flush();
 
-        console.log(rect)
-
         // Check that position update of popup is called after the mouseout.
         assert.ok(called)
-
-        //assert.ok(false)
 
         editor.destroy();
         editor.container.remove();

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -820,7 +820,81 @@ module.exports = {
         assert.strictEqual(document.getElementById("ace-inline-screenreader-line-2").textContent,"cool");
 
         done();
-    }
+    },
+    "test: update popup position only on mouse out when inline enabled and setSelectOnHover true": function() {
+        var editor = initEditor("fun");
+
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "functionshort",
+                            value: "function that does something uncool",
+                            score: 1
+                        },
+                        {
+                            caption: "functionlong",
+                            value: "function\nthat does something\ncool",
+                            score: 0
+                        }
+                    ];
+                    callback(null, completions);
+                }
+            }
+        ];
+
+        var completer = Autocomplete.for(editor);
+        completer.setSelectOnHover = true;
+        completer.inlineEnabled = true;
+
+        user.type("Ctrl-Space");
+        assert.equal(editor.completer.popup.isOpen, true);
+        var called = false;
+        editor.completer.$updatePopupPosition = function() {
+            console.log("function called")
+            called = true;
+        };
+
+        var inline = completer.inlineRenderer;
+
+        assert.equal(completer.popup.getRow(), 0);
+        assert.strictEqual(inline.isOpen(), true);
+        assert.strictEqual(editor.renderer.$ghostText.text, "function that does something uncool");
+ 
+        var text = completer.popup.renderer.content.childNodes[2];
+        var rect = text.getBoundingClientRect();
+
+        console.log(rect)
+
+        // We need two mouse events to trigger the updating of the hover marker.
+        text.dispatchEvent(new MouseEvent("move", {x: rect.left, y: rect.top}));
+        // Hover over the second row.
+        text.dispatchEvent(new MouseEvent("move", {x: rect.left + 1, y: rect.top + 20}));
+    
+        editor.completer.popup.renderer.$loop._flush();
+
+        // Check that the completion item changed to the longer item.
+        assert.equal(completer.popup.getRow(), 1);
+        assert.strictEqual(inline.isOpen(), true);
+        assert.strictEqual(editor.renderer.$ghostText.text, "function\nthat does something\ncool");
+
+        // Check that position update of popup is not called.
+        assert.ok(!called)
+
+        text.dispatchEvent(new MouseEvent("out", {x: rect.left, y: rect.top}));
+        editor.completer.popup.renderer.$loop._flush();
+
+        console.log(rect)
+
+        // Check that position update of popup is called after the mouseout.
+        assert.ok(called)
+
+        //assert.ok(false)
+
+        editor.destroy();
+        editor.container.remove();
+    },
 };
 
 if (typeof module !== "undefined" && module === require.main) {

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -852,7 +852,6 @@ module.exports = {
         assert.equal(editor.completer.popup.isOpen, true);
         var called = false;
         editor.completer.$updatePopupPosition = function() {
-            console.log("function called")
             called = true;
         };
 
@@ -878,17 +877,17 @@ module.exports = {
         assert.strictEqual(editor.renderer.$ghostText.text, "function\nthat does something\ncool");
 
         // Check that position update of popup is not called.
-        assert.ok(!called)
+        assert.ok(!called);
 
         text.dispatchEvent(new MouseEvent("out", {x: rect.left, y: rect.top}));
         editor.completer.popup.renderer.$loop._flush();
 
         // Check that position update of popup is called after the mouseout.
-        assert.ok(called)
+        assert.ok(called);
 
         editor.destroy();
         editor.container.remove();
-    },
+    }
 };
 
 if (typeof module !== "undefined" && module === require.main) {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* When `setSelectOnHover` is set to `True`, we select the item in the popup tooltip that's being hovered on. This can cause the height of the inline preview to change, resulting in moving the popup, after which the mouse can be hovering over a new item and selecting that. Leading to a cycle of moving popup:

https://github.com/ajaxorg/ace/assets/34573235/72e521e4-fcc1-403b-bbe2-1fc1845a533b

This aims to improve the situation by only moving the popup if it's not being moused over, and moving it to the desired position on `mouseout`:

https://github.com/ajaxorg/ace/assets/34573235/d9e1cb30-18c6-40a1-b3e2-46af59b7f247


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
