### PR TITLE
fix doc type of AceInlineScreenReader to enable API generation

### DIFF
--- a/src/autocomplete/inline_screenreader.js
+++ b/src/autocomplete/inline_screenreader.js
@@ -6,7 +6,7 @@
 class AceInlineScreenReader {
     /**
      * Creates the off-screen div in which the ghost text content in redered and which the screen reader reads.
-     * @param {import("../editor").Editor} editor
+     * @param {Editor} editor
      */
     constructor(editor) {
         this.editor = editor;


### PR DESCRIPTION
API generation failed during 1.30.0 release due to `import("../editor")` statement, removing it to enable API generation for next releases. API docs were generated already with this statement removed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
