### PR TITLE
fix: doc tooltip not filtering properly

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -464,7 +464,7 @@ class Autocomplete {
 
     updateDocTooltip() {
         var popup = this.popup;
-        var all = popup.data;
+        var all = this.completions.filtered;
         var selected = all && (all[popup.getHoveredRow()] || all[popup.getRow()]);
         var doc = null;
         if (!selected || !this.editor || !this.popup.isOpen)

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -297,6 +297,62 @@ module.exports = {
             }, 10);
         }
     },
+    "test: completers tooltip filtering": function (done) {
+        var editor = initEditor("");
+        var firstDoc = "First tooltip";
+        var secondDoc = "Second tooltip";
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "case",
+                            value: "case",
+                        }, {
+                            caption: "catch",
+                            value: "catch",
+                        }
+                    ];
+                    callback(null, completions);
+                },
+                getDocTooltip: function (item) {
+                    console.log(item)
+                    
+                    if (item.value === 'case') {
+                        item.docHTML = firstDoc;
+                    } 
+                    if (item.value === 'catch') {
+                        item.docHTML = secondDoc;
+                    }
+                },
+            }
+        ];
+        
+        sendKey("ca");
+        var popup = editor.completer.popup;
+
+        check(function() {
+            assert.equal(popup.data.length, 2);
+            assert.equal(popup.container.lastChild.innerHTML, firstDoc);
+
+            sendKey("t");
+
+            check(function() {
+                assert.equal(popup.data.length, 1);
+                assert.equal(popup.container.lastChild.innerHTML, secondDoc);
+
+                editor.destroy();
+                editor.container.remove();
+                done();
+            })
+        })
+    
+        function check(callback) {
+            setTimeout(function wait() {
+                callback();
+            }, 10);
+        }
+    },
     "test: slow and fast completers": function(done) {
         var syncCompleter={
             getCompletions: function(editor, session, pos, prefix, callback) {

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -307,24 +307,22 @@ module.exports = {
                     var completions = [
                         {
                             caption: "case",
-                            value: "case",
+                            value: "case"
                         }, {
                             caption: "catch",
-                            value: "catch",
+                            value: "catch"
                         }
                     ];
                     callback(null, completions);
                 },
                 getDocTooltip: function (item) {
-                    console.log(item)
-                    
                     if (item.value === 'case') {
                         item.docHTML = firstDoc;
                     } 
                     if (item.value === 'catch') {
                         item.docHTML = secondDoc;
                     }
-                },
+                }
             }
         ];
         
@@ -344,8 +342,8 @@ module.exports = {
                 editor.destroy();
                 editor.container.remove();
                 done();
-            })
-        })
+            });
+        });
     
         function check(callback) {
             setTimeout(function wait() {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Fixes bug where the completion doc tooltip would not be filtered properly because it would get the data from the popup before it was updated:


https://github.com/ajaxorg/ace/assets/34573235/bdfa250e-1b27-44d4-8f7b-f802deda470e




after this change:



https://github.com/ajaxorg/ace/assets/34573235/fcbb1afe-42ac-4a0b-90dc-38a7f9b37adb




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
