### PR TITLE
add DataCap logo to users on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1150,6 +1150,10 @@ if (match) {
                                     <img lazy-src="https://tool.next2d.app/assets/img/logo.svg" style="width: 85px; left: 7px; top: -7px;">
                                     <a href="https://next2d.app/">Next2D</a>
                                 </li>
+                                <li>
+                                    <img lazy-src="https://raw.githubusercontent.com/devlive-community/datacap/dev/core/datacap-web/public/static/images/logo.png" style="width: 85px; left: 7px; top: -7px;">
+                                    <a href="https://github.com/devlive-community/datacap">DataCap</a>
+                                </li>
                                 <li id="add_your_site">
                                     <p>+</p>
                                     <a href="https://github.com/ajaxorg/ace/issues/new?assignees=&labels=website%2Cneeds-triage&projects=&template=add-to-website.yml&title=Add+project+%28project+name%29+to+the+list+of+projects+using+Ace+on+its+website">Your Site Here</a>


### PR DESCRIPTION
*Issue #, if available:* closes #5359

*Description of changes:* Adds logo of DataCap to users section on website. 

<img width="553" alt="Screenshot 2023-10-23 at 16 44 35" src="https://github.com/ajaxorg/ace/assets/34573235/44093006-2677-4672-b8a9-db1d9f9c010a">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
