### PR TITLE
chore: add config file for Jekyll to exclude kitchen-sink demo files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
+# Config file for Jekyll, which is used by GH pages to build the Ace website.
+# Some files in the docs folder can cause Jekyll to trip up so we ignore those.
 exclude:
   - "demo/kitchen-sink/docs"

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 # Config file for Jekyll, which is used by GH pages to build the Ace website.
 # Some files in the docs folder can cause Jekyll to trip up so we ignore those.
+# https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll
 exclude:
   - "demo/kitchen-sink/docs"

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+exclude:
+  - "demo/kitchen-sink/docs"


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Adds a Jekyll to config file to exclude our kitchen-sink demo files from the Jekyll build process used by GH pages. The `astro.astro` file in there is currently being picked up and causing our GH pages to fail: 

<img width="1055" alt="Screenshot 2023-10-24 at 11 56 28" src="https://github.com/ajaxorg/ace/assets/34573235/c7b67651-e45d-4f64-be5c-aae00533e466">

For more context, see: https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
