### PR TITLE
feat: spinner in gutter when autoShown completion

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -1071,6 +1071,7 @@ export namespace Ace {
     setSelectOnHover?: Boolean;
     stickySelectionDelay?: Number;
     ignoreCaption?: Boolean;
+    showLoadingState?: Boolean;
     emptyMessage?(prefix: String): String;
     getPopup(): AcePopup;
     showPopup(editor: Editor, options: CompletionOptions): void;

--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -316,6 +316,45 @@ env.editor.commands.addCommands([{
     }
 }]);
 
+var slowCompleter = {
+    getCompletions: function (editor, session, pos, prefix, callback) {
+        var completions = [
+            {
+                caption: "slow option 1",
+                value: "s1",
+                score: 1
+            }, {
+                caption: "slow option 2",
+                value: "s2",
+                score: 0
+            }
+        ];
+        setTimeout(() => {
+            callback(null,  completions);
+        }, 80000);
+    }
+};
+
+var fastCompleter = {
+    getCompletions: function (editor, session, pos, prefix, callback) {
+        var completions = [
+            {
+                caption: "fast option 1",
+                value: "f1",
+                score: 3
+            }, {
+                caption: "fast option 2",
+                value: "f2",
+                score: 2
+            }
+        ];
+        setTimeout(() => {
+            callback(null,  completions);
+        }, 40000);
+    }
+};
+
+env.editor.completers = [slowCompleter, fastCompleter];
 
 env.editor.commands.addCommands(whitespace.commands);
 

--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -33,7 +33,7 @@ var Range = require("ace/range").Range;
 
 var whitespace = require("ace/ext/whitespace");
 
-var Autocomplete = require("ace/autocomplete").Autocomplete;
+
 
 var doclist = require("./doclist");
 var layout = require("./layout");
@@ -316,48 +316,6 @@ env.editor.commands.addCommands([{
     }
 }]);
 
-var slowCompleter = {
-    getCompletions: function (editor, session, pos, prefix, callback) {
-        var completions = [
-            {
-                caption: "slow option 1",
-                value: "s1",
-                score: 1
-            }, {
-                caption: "slow option 2",
-                value: "s2",
-                score: 0
-            }
-        ];
-        setTimeout(() => {
-            callback(null,  completions);
-        }, 80000);
-    }
-};
-
-var fastCompleter = {
-    getCompletions: function (editor, session, pos, prefix, callback) {
-        var completions = [
-            {
-                caption: "fast option 1",
-                value: "f1",
-                score: 3
-            }, {
-                caption: "fast option 2",
-                value: "f2",
-                score: 2
-            }
-        ];
-        setTimeout(() => {
-            callback(null,  completions);
-        }, 40000);
-    }
-};
-
-env.editor.completers = [slowCompleter, fastCompleter];
-
-var completer = Autocomplete.for(env.editor);
-completer.showLoadingState = true;
 
 env.editor.commands.addCommands(whitespace.commands);
 

--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -33,7 +33,7 @@ var Range = require("ace/range").Range;
 
 var whitespace = require("ace/ext/whitespace");
 
-
+var Autocomplete = require("ace/autocomplete").Autocomplete;
 
 var doclist = require("./doclist");
 var layout = require("./layout");
@@ -355,6 +355,9 @@ var fastCompleter = {
 };
 
 env.editor.completers = [slowCompleter, fastCompleter];
+
+var completer = Autocomplete.for(env.editor);
+completer.showLoadingState = true;
 
 env.editor.commands.addCommands(whitespace.commands);
 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -63,6 +63,7 @@ class Autocomplete {
         this.keyboardHandler.bindKeys(this.commands);
         this.parentNode = null;
         this.setSelectOnHover = false;
+        this.showLoadingState = false;
 
         /**
          *  @property {number} stickySelectionDelay - a numerical value that determines after how many ms the popup selection will become 'sticky'.
@@ -488,7 +489,7 @@ class Autocomplete {
             }
         }.bind(this));
 
-        if (!(this.popup && this.popup.isOpen)) {
+        if (!(this.popup && this.popup.isOpen) && this.showLoadingState) {
             this.$firstOpenTimer.delay(this.stickySelectionDelay/2);
         }
     }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -63,6 +63,13 @@ class Autocomplete {
         this.keyboardHandler.bindKeys(this.commands);
         this.parentNode = null;
         this.setSelectOnHover = false;
+
+        /**
+         *  @property {Boolean} showLoadingState - A boolean indicating whether the loading states of the Autocompletion should be shown to the end-user. If enabled 
+         * if shows a spinner in the gutter and a loading indicator on the popup while autocomplete is loading.
+         * 
+         * Experimental: This visualisation is not yet considered stable and might change in the future.
+         */
         this.showLoadingState = false;
 
         /**
@@ -94,7 +101,7 @@ class Autocomplete {
             if ((this.popup && this.popup.isOpen) || !initialPosition) return;
 
             if (this.autoShown) {
-                this.editor.renderer.$gutterLayer.showSpinner(this.base.row);
+                this.editor.renderer.showGutterSpinner(this.base.row);
                 return;
             }
 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -89,7 +89,13 @@ class Autocomplete {
 
         this.$firstOpenTimer = lang.delayedCall(function() {
             var initialPosition = this.completionProvider && this.completionProvider.initialPosition;
-            if (this.autoShown || (this.popup && this.popup.isOpen) || !initialPosition) return;
+
+            if ((this.popup && this.popup.isOpen) || !initialPosition) return;
+
+            if (this.autoShown) {
+                this.editor.renderer.$gutterLayer.showSpinner(this.base.row);
+                return;
+            }
 
             var completionsForEmpty = [{
                 caption: config.nls("Loading..."),
@@ -227,6 +233,7 @@ class Autocomplete {
     }
 
     openPopup(editor, prefix, keepPopupPosition) {
+        this.editor.renderer.$gutterLayer.hideSpinner();
         this.$firstOpenTimer.cancel();
 
         if (!this.popup)
@@ -282,6 +289,7 @@ class Autocomplete {
             this.editor.off("blur", this.blurListener);
             this.editor.off("mousedown", this.mousedownListener);
             this.editor.off("mousewheel", this.mousewheelListener);
+            this.editor.renderer.$gutterLayer.hideSpinner();
         }
         this.$firstOpenTimer.cancel();
 
@@ -475,9 +483,12 @@ class Autocomplete {
             this.openPopup(this.editor, prefix, keepPopupPosition);
 
             this.popup.renderer.setStyle("ace_loading", !finished);
+            if (finished) {
+                this.editor.renderer.$gutterLayer.hideSpinner();
+            }
         }.bind(this));
 
-        if (!this.autoShown && !(this.popup && this.popup.isOpen)) {
+        if (!(this.popup && this.popup.isOpen)) {
             this.$firstOpenTimer.delay(this.stickySelectionDelay/2);
         }
     }

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1028,10 +1028,10 @@ module.exports = {
                 var completions = [
                     {
                         caption: "slow option 1",
-                        value: "s1",
+                        value: "s1"
                     }, {
                         caption: "slow option 2",
-                        value: "s2",
+                        value: "s2"
                     }
                 ];
                 setTimeout(() => {

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -942,7 +942,7 @@ module.exports = {
         editor.destroy();
         editor.container.remove();
     },
-    "test: should display loading state when keyboard invoking autocomplete": function(done) {
+    "test: should display loading state when keyboard invoking autocomplete when showLoadingState true": function(done) {
         var editor = initEditor("hello world\n");
         
         var slowCompleter = {
@@ -989,10 +989,12 @@ module.exports = {
         
         var completer = Autocomplete.for(editor);
         completer.stickySelectionDelay = 100;
+        completer.showLoadingState = true;
         user.type("Ctrl-Space");
         assert.ok(!(completer.popup && completer.popup.isOpen));
 
         setTimeout(() => {
+            assert.ok(completer.popup && completer.popup.isOpen);
             completer.popup.renderer.$loop._flush();
             assert.equal(completer.popup.data.length, 1);
             assert.ok(isLoading());
@@ -1020,7 +1022,7 @@ module.exports = {
             return completer.popup.renderer.container.classList.contains("ace_loading");
         }
     },
-    "test: should display loading state when automatically invoking autocomplete": function(done) {
+    "test: should display loading state when automatically invoking autocomplete when showLoadingState true": function(done) {
         var editor = initEditor("");
         
         var slowCompleter = {
@@ -1044,6 +1046,7 @@ module.exports = {
         
         var completer = Autocomplete.for(editor);
         completer.stickySelectionDelay = 100;
+        completer.showLoadingState = true;
         user.type("s");
         assert.ok(!(completer.popup && completer.popup.isOpen));
 

--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -660,4 +660,92 @@ module.exports = `
     width:1px;
     height:1px;
     overflow:hidden;
-}`;
+}
+
+.ace_spinner {
+    box-sizing: border-box;
+    display: inline;
+    line-height: 0;
+    float: left;
+    position: relative;
+    margin-left: -14px;
+    top: 50%;
+
+    margin-top: -5px;
+    width: 10px;
+    height: 10px;
+    color: black;
+
+    animation-duration: 0.7s;
+    animation-timing-function: linear;
+    animation-delay: 0s;
+    animation-iteration-count: infinite;
+    animation-direction: normal;
+    animation-fill-mode: none;
+    animation-play-state: running;
+    animation-name: ace_spinner;
+}
+
+@keyframes ace_spinner {
+    0% { transform: rotate(0deg) }
+    100% { transform: rotate(1turn) } 
+}
+
+.ace_spinner_left, .ace_spinner_right {
+    display: inline-block;
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+    width: 50%;
+}
+
+.ace_spinner_left:after, .ace_spinner_right:after {
+    border-color: inherit;
+    animation: 1.5s ease-in-out infinite;
+    border-color: currentColor #0000 #0000 currentColor;
+    border-radius: 50%;
+    border-style: solid;
+    border-width: 2px;
+    box-sizing: border-box;
+    content: "";
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 200%;
+}
+
+.ace_spinner_left:after {
+    animation-name: ace_spinner_left;
+    left: 0;
+}
+
+@keyframes ace_spinner_left {
+    0% { transform: rotate(0deg) }
+    50% { transform: rotate(120deg) } 
+    100% { transform: rotate(0deg) } 
+}
+
+.ace_spinner_right:after {
+    animation-name: ace_spinner_right;
+    left: -100%;
+}
+
+@keyframes ace_spinner_right {
+    0% { transform: rotate(90deg) }
+    50% { transform: rotate(-30deg) } 
+    100% { transform: rotate(90deg) } 
+}
+
+@media (prefers-reduced-motion) {
+    .ace_spinner {
+        animation: none;
+    }
+    .ace_spinner_left:after {
+        animation: none;
+    }
+    .ace_spinner_right:after {
+        animation: none;
+    }
+}
+`;

--- a/src/layer/gutter.js
+++ b/src/layer/gutter.js
@@ -473,7 +473,7 @@ class Gutter{
             dom.setStyle(annotationNode.style, "display", "none");
 
             // Show the spinner in the gutter
-            if (!annotationNode.contains(this.spinner)) {
+            if (!element.contains(this.spinner)) {
                 cell.element.appendChild(this.spinner);
             } 
             dom.setStyle(this.spinner.style, "display", "block" );

--- a/src/layer/gutter.js
+++ b/src/layer/gutter.js
@@ -21,6 +21,24 @@ class Gutter{
 
         this.$lines = new Lines(this.element);
         this.$lines.$offsetCoefficient = 1;
+
+        this.spinnerRow = -1;
+        this.spinner = this.createSpinner();
+    }
+
+    createSpinner() {
+        var spinner = dom.createElement("span");
+        spinner.className = "ace_spinner";
+
+        var spinnerLeft = dom.createElement("span");
+        spinnerLeft.className = "ace_spinner_left";
+        spinner.appendChild(spinnerLeft);
+
+        var spinnerRight = dom.createElement("span");
+        spinnerRight.className = "ace_spinner_right";
+        spinner.appendChild(spinnerRight);
+
+        return spinner;
     }
 
     setSession(session) {
@@ -272,6 +290,19 @@ class Gutter{
         return fragment;
     }
     
+    showSpinner(row) {
+        this.spinnerRow = row;
+        if (this.config)
+            this.update(this.config);
+    }
+
+    hideSpinner() {
+        dom.setStyle(this.spinner.style, "display", "none" );    
+        this.spinnerRow = -1;
+        if (this.config)
+            this.update(this.config);
+    }
+
     $renderCell(cell, config, fold, row) {
         var element = cell.element;
         
@@ -434,6 +465,19 @@ class Gutter{
         dom.setStyle(cell.element.style, "top", this.$lines.computeLineTop(row, config, session) + "px");
         
         cell.text = rowText;
+
+        // Override the gutter annotation with a spinner animation if needed
+        if (row === this.spinnerRow) {
+            // Hide the annotation
+            element.classList.remove("ace_info", "ace_warning", "ace_error", "ace_error_fold", "ace_warning_fold");
+            dom.setStyle(annotationNode.style, "display", "none");
+
+            // Show the spinner in the gutter
+            if (!annotationNode.contains(this.spinner)) {
+                cell.element.appendChild(this.spinner);
+            } 
+            dom.setStyle(this.spinner.style, "display", "block" );
+        }
 
         // If there are no annotations or fold widgets in the gutter cell, hide it from assistive tech.
         if (annotationNode.style.display === "none" && foldWidget.style.display === "none")

--- a/src/layer/gutter.js
+++ b/src/layer/gutter.js
@@ -22,7 +22,7 @@ class Gutter{
         this.$lines = new Lines(this.element);
         this.$lines.$offsetCoefficient = 1;
 
-        this.spinnerRow = -1;
+        this.spinnerRow = null;
         this.spinner = this.createSpinner();
     }
 
@@ -298,7 +298,7 @@ class Gutter{
 
     hideSpinner() {
         dom.setStyle(this.spinner.style, "display", "none" );    
-        this.spinnerRow = -1;
+        this.spinnerRow = null;
         if (this.config)
             this.update(this.config);
     }

--- a/src/mouse/default_gutter_handler.js
+++ b/src/mouse/default_gutter_handler.js
@@ -61,6 +61,9 @@ function GutterHandler(mouseHandler) {
             var gutterCell = gutter.$lines.get(gutterRow);
             if (gutterCell) {
                 var gutterElement = gutterCell.element.querySelector(".ace_gutter_annotation");
+                if (gutterElement.style.display === "none"){
+                     return hideTooltip();
+                }
                 var rect = gutterElement.getBoundingClientRect();
                 var style = tooltip.getElement().style;
                 style.left = rect.right + "px";

--- a/src/mouse/default_gutter_handler.js
+++ b/src/mouse/default_gutter_handler.js
@@ -47,6 +47,9 @@ function GutterHandler(mouseHandler) {
                 return hideTooltip();
         }
 
+        if (gutter.spinnerRow === row)
+            return hideTooltip();
+
         tooltip.showTooltip(row);
 
         if (!tooltip.isOpen)
@@ -61,9 +64,6 @@ function GutterHandler(mouseHandler) {
             var gutterCell = gutter.$lines.get(gutterRow);
             if (gutterCell) {
                 var gutterElement = gutterCell.element.querySelector(".ace_gutter_annotation");
-                if (gutterElement.style.display === "none"){
-                     return hideTooltip();
-                }
                 var rect = gutterElement.getBoundingClientRect();
                 var style = tooltip.getElement().style;
                 style.left = rect.right + "px";

--- a/src/virtual_renderer.js
+++ b/src/virtual_renderer.js
@@ -420,6 +420,14 @@ class VirtualRenderer {
     }
 
     /**
+     * Show an animated spinner in the gutter at the given row. This overrides the annotation at that row.
+     **/
+    showGutterSpinner(row) {
+        if (this.$gutterLayer)
+            this.$gutterLayer.showSpinner(row);
+    }
+
+    /**
      * Adjusts the wrap limit, which is the number of characters that can fit within the width of the edit area on screen.
      **/
     adjustWrapLimit() {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* we recently (#5368) added a loading indicator for autocompleters for all situations except when auto shown. This PR is adds a spinner in the gutter the illustrate this situation. 

Additionally, the hides both of the mechanisms to show the loading state behind an option parameter.

https://github.com/ajaxorg/ace/assets/34573235/6c7375a3-2da5-4113-879c-0b7a55a0b69e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
