### PR TITLE
Fix empty search match before surrogate pair causing infinite loop

### DIFF
--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -167,6 +167,7 @@ class SearchBox {
     updateCounter() {
         var editor = this.editor;
         var regex = editor.$search.$options.re;
+        var supportsUnicodeFlag = editor.$search.$options.$supportsUnicodeFlag;
         var all = 0;
         var before = 0;
         if (regex) {
@@ -188,7 +189,8 @@ class SearchBox {
                 if (all > MAX_COUNT)
                     break;
                 if (!m[0]) {
-                    regex.lastIndex = last += 1;
+                    regex.lastIndex = last +=
+                        supportsUnicodeFlag && (value.charCodeAt(last) ^ 0xd800) < 1024 ? 2 : 1;
                     if (last >= value.length)
                         break;
                 }

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -167,7 +167,7 @@ class SearchBox {
     updateCounter() {
         var editor = this.editor;
         var regex = editor.$search.$options.re;
-        var supportsUnicodeFlag = editor.$search.$options.$supportsUnicodeFlag;
+        var supportsUnicodeFlag = regex.unicode;
         var all = 0;
         var before = 0;
         if (regex) {

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -189,8 +189,7 @@ class SearchBox {
                 if (all > MAX_COUNT)
                     break;
                 if (!m[0]) {
-                    regex.lastIndex = last +=
-                        supportsUnicodeFlag && (value.charCodeAt(last) ^ 0xd800) < 1024 ? 2 : 1;
+                    regex.lastIndex = last += lang.skipEmptyMatch(value, last, supportsUnicodeFlag);
                     if (last >= value.length)
                         break;
                 }

--- a/src/lib/lang.js
+++ b/src/lib/lang.js
@@ -182,5 +182,5 @@ exports.supportsLookbehind = function () {
 };
 
 exports.skipEmptyMatch = function(line, last, supportsUnicodeFlag) {
-    return supportsUnicodeFlag && line.codePointAt(last) > 0xffff ? 2 : 1
-}
+    return supportsUnicodeFlag && line.codePointAt(last) > 0xffff ? 2 : 1;
+};

--- a/src/lib/lang.js
+++ b/src/lib/lang.js
@@ -180,3 +180,7 @@ exports.supportsLookbehind = function () {
     }
     return true;
 };
+
+exports.skipEmptyMatch = function(line, last, supportsUnicodeFlag) {
+    return supportsUnicodeFlag && line.codePointAt(last) > 0xffff ? 2 : 1
+}

--- a/src/lib/lang.js
+++ b/src/lib/lang.js
@@ -180,12 +180,3 @@ exports.supportsLookbehind = function () {
     }
     return true;
 };
-
-exports.supportsUnicodeFlag = function () {
-    try {
-        new RegExp('^.$', 'u');
-    } catch (error) {
-        return false;
-    }
-    return true;
-};

--- a/src/search.js
+++ b/src/search.js
@@ -24,6 +24,7 @@ class Search {
      * @property {boolean} [$isMultiLine] - true, if needle has \n or \r\n
      * @property {boolean} [preserveCase]
      * @property {boolean} [preventScroll]
+     * @property {boolean} [$supportsUnicodeFlag] - internal property, determine if browser supports unicode flag
      * @property {any} [re]
      **/
     
@@ -225,9 +226,10 @@ class Search {
 
         try {
             new RegExp(needle, "u");
+            options.$supportsUnicodeFlag = true;
             modifier += "u";
         } catch (e) {
-            // left for backward compatibility with previous versions for cases like /ab\{2}/gu
+            options.$supportsUnicodeFlag = false; //left for backward compatibility with previous versions for cases like /ab\{2}/gu
         }
 
         if (options.wholeWord)
@@ -385,10 +387,10 @@ function addWordBoundary(needle, options) {
     let supportsLookbehind = lang.supportsLookbehind();
 
     function wordBoundary(c, firstChar = true) {
-        let wordRegExp = supportsLookbehind && options.regExp.unicode ? new RegExp("[\\p{L}\\p{N}_]","u") : new RegExp("\\w");
+        let wordRegExp = supportsLookbehind && options.$supportsUnicodeFlag ? new RegExp("[\\p{L}\\p{N}_]","u") : new RegExp("\\w");
 
         if (wordRegExp.test(c) || options.regExp) {
-            if (supportsLookbehind && options.regExp.unicode) {
+            if (supportsLookbehind && options.$supportsUnicodeFlag) {
                 if (firstChar) return "(?<=^|[^\\p{L}\\p{N}_])";
                 return "(?=[^\\p{L}\\p{N}_]|$)";
             }

--- a/src/search.js
+++ b/src/search.js
@@ -218,28 +218,22 @@ class Search {
 
         if (!options.needle)
             return options.re = false;
-        
-        if (options.$supportsUnicodeFlag === undefined) {
-            options.$supportsUnicodeFlag = lang.supportsUnicodeFlag();
-        }
 
-        try {
-            new RegExp(needle, "u");
-        } catch (e) {
-            options.$supportsUnicodeFlag = false; //left for backward compatibility with previous versions for cases like /ab\{2}/gu
-        }
-        
         if (!options.regExp)
             needle = lang.escapeRegExp(needle);
 
-        if (options.wholeWord)
-            needle = addWordBoundary(needle, options);
-
         var modifier = options.caseSensitive ? "gm" : "gmi";
 
-        if (options.$supportsUnicodeFlag) {
+        try {
+            new RegExp(needle, "u");
+            options.$supportsUnicodeFlag = true;
             modifier += "u";
+        } catch (e) {
+            options.$supportsUnicodeFlag = false; //left for backward compatibility with previous versions for cases like /ab\{2}/gu
         }
+
+        if (options.wholeWord)
+            needle = addWordBoundary(needle, options);
         
         options.$isMultiLine = !$disableFakeMultiline && /[\n\r]/.test(needle);
         if (options.$isMultiLine)

--- a/src/search.js
+++ b/src/search.js
@@ -24,7 +24,6 @@ class Search {
      * @property {boolean} [$isMultiLine] - true, if needle has \n or \r\n
      * @property {boolean} [preserveCase]
      * @property {boolean} [preventScroll]
-     * @property {boolean} [$supportsUnicodeFlag] - internal property, determine if browser supports unicode flag
      * @property {any} [re]
      **/
     
@@ -226,10 +225,9 @@ class Search {
 
         try {
             new RegExp(needle, "u");
-            options.$supportsUnicodeFlag = true;
             modifier += "u";
         } catch (e) {
-            options.$supportsUnicodeFlag = false; //left for backward compatibility with previous versions for cases like /ab\{2}/gu
+            // left for backward compatibility with previous versions for cases like /ab\{2}/gu
         }
 
         if (options.wholeWord)
@@ -264,7 +262,7 @@ class Search {
             return false;
         var backwards = options.backwards == true;
         var skipCurrent = options.skipCurrent != false;
-        var supportsUnicodeFlag = options.$supportsUnicodeFlag
+        var supportsUnicodeFlag = re.unicode;
 
         var range = options.range;
         var start = options.start;

--- a/src/search.js
+++ b/src/search.js
@@ -338,8 +338,7 @@ class Search {
                     last = m.index;
                     if (!length) {
                         if (last >= line.length) break;
-                        re.lastIndex = last +=
-                            supportsUnicodeFlag && (line.charCodeAt(last) ^ 0xd800) < 1024 ? 2 : 1;
+                        re.lastIndex = last += lang.skipEmptyMatch(line, last, supportsUnicodeFlag);
                     }
                     if (m.index + length > endIndex)
                         break;
@@ -365,8 +364,7 @@ class Search {
                     if (callback(row, last, row,last + length))
                         return true;
                     if (!length) {
-                        re.lastIndex = last +=
-                            supportsUnicodeFlag && (line.charCodeAt(last) ^ 0xd800) < 1024 ? 2 : 1;
+                        re.lastIndex = last += lang.skipEmptyMatch(line, last, supportsUnicodeFlag);
                         if (last >= line.length) return false;
                     }
                 }

--- a/src/search.js
+++ b/src/search.js
@@ -270,6 +270,7 @@ class Search {
             return false;
         var backwards = options.backwards == true;
         var skipCurrent = options.skipCurrent != false;
+        var supportsUnicodeFlag = options.$supportsUnicodeFlag
 
         var range = options.range;
         var start = options.start;
@@ -343,7 +344,8 @@ class Search {
                     last = m.index;
                     if (!length) {
                         if (last >= line.length) break;
-                        re.lastIndex = last += 1;
+                        re.lastIndex = last +=
+                            supportsUnicodeFlag && (line.charCodeAt(last) ^ 0xd800) < 1024 ? 2 : 1;
                     }
                     if (m.index + length > endIndex)
                         break;
@@ -369,7 +371,8 @@ class Search {
                     if (callback(row, last, row,last + length))
                         return true;
                     if (!length) {
-                        re.lastIndex = last += 1;
+                        re.lastIndex = last +=
+                            supportsUnicodeFlag && (line.charCodeAt(last) ^ 0xd800) < 1024 ? 2 : 1;
                         if (last >= line.length) return false;
                     }
                 }

--- a/src/search.js
+++ b/src/search.js
@@ -385,10 +385,10 @@ function addWordBoundary(needle, options) {
     let supportsLookbehind = lang.supportsLookbehind();
 
     function wordBoundary(c, firstChar = true) {
-        let wordRegExp = supportsLookbehind && options.$supportsUnicodeFlag ? new RegExp("[\\p{L}\\p{N}_]","u") : new RegExp("\\w");
+        let wordRegExp = supportsLookbehind && options.regExp.unicode ? new RegExp("[\\p{L}\\p{N}_]","u") : new RegExp("\\w");
 
         if (wordRegExp.test(c) || options.regExp) {
-            if (supportsLookbehind && options.$supportsUnicodeFlag) {
+            if (supportsLookbehind && options.regExp.unicode) {
                 if (firstChar) return "(?<=^|[^\\p{L}\\p{N}_])";
                 return "(?=[^\\p{L}\\p{N}_]|$)";
             }

--- a/src/search_test.js
+++ b/src/search_test.js
@@ -9,6 +9,7 @@ var MockRenderer = require("./test/mockrenderer").MockRenderer;
 var Editor = require("./editor").Editor;
 var Search = require("./search").Search;
 var assert = require("./test/assertions");
+var Range = require("./range").Range;
 
 module.exports = {
     "test: configure the search object" : function() {
@@ -170,6 +171,38 @@ module.exports = {
         var range = search.find(session);
         assert.position(range.start, 1, 0);
         assert.position(range.end, 1, 6);
+    },
+
+    "test: return to unicode mode when possible": function() {
+        var session = new EditSession(["𝓕oo"]);
+
+        var search = new Search().set({
+            needle: "}",
+            regExp: true
+        });
+
+        search.find(session);
+        search.set({
+            needle: "."
+        });
+
+        var range = search.find(session);
+        assert.position(range.start, 0, 0);
+        assert.position(range.end, 0, 2);
+    },
+
+    "test: empty match before surrogate pair": function() {
+        var session = new EditSession(["𝓕oo"]);
+
+        var search = new Search().set({
+            needle: "()",
+            regExp: true,
+            start: new Range(0, 0, 0, 0)
+        });
+
+        var range = search.find(session);
+        assert.position(range.start, 0, 2);
+        assert.position(range.end, 0, 2);
     },
 
     "test: find backwards": function() {


### PR DESCRIPTION
*Issue #, if available: NA*

*Description of changes:*
This PR fixes 2 issues relating to Ace's search.

The first fix is for an infinite loop. If the `u` flag is present and the regex returns an empty match before a surrogate pair, the `lastIndex` must be increased by 2 instead of 1.

The second fix relates to the `u` flag feature detection. Currently `$supportsUnicodeFlag` is set to `false` if the user types something that's an invalid regular expression. Once it's set to `false`, it can't be set to `true` again, effectively disabling the `u` flag even in browsers supporting it. This PR fixes these issues and removes the `supportsUnicodeFlag` method from `lang` since it's no longer needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
