### PR TITLE
fix: small fixes for completion loading state

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -1071,6 +1071,7 @@ export namespace Ace {
     setSelectOnHover?: Boolean;
     stickySelectionDelay?: Number;
     ignoreCaption?: Boolean;
+    showLoadingState?: Boolean;
     emptyMessage?(prefix: String): String;
     getPopup(): AcePopup;
     showPopup(editor: Editor, options: CompletionOptions): void;

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -105,10 +105,11 @@ class Autocomplete {
         }.bind(this), this.stickySelectionDelay);
     }
 
-    static completionsForLoading = [{
-        caption: config.nls("Loading..."),
-        value: ""
-    }];
+    static get completionsForLoading() { return [{
+            caption: config.nls("Loading..."),
+            value: ""
+        }];
+    };
 
     $init() {
         this.popup = new AcePopup(this.parentNode || document.body || document.documentElement); 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -63,6 +63,7 @@ class Autocomplete {
         this.keyboardHandler.bindKeys(this.commands);
         this.parentNode = null;
         this.setSelectOnHover = false;
+        this.showLoadingState = false;
 
         /**
          *  @property {number} stickySelectionDelay - a numerical value that determines after how many ms the popup selection will become 'sticky'.
@@ -479,18 +480,18 @@ class Autocomplete {
                 if (this.autoInsert && !this.autoShown && filtered.length == 1)
                     return this.insertMatch(filtered[0]);
             }
-            this.completions = finished ? 
-                completions : 
+            this.completions = !finished && this.showLoadingState ? 
                 new FilteredList(
                     Autocomplete.completionsForLoading.concat(filtered), completions.filterText
-                );
+                ) :
+                completions;
 
             this.openPopup(this.editor, prefix, keepPopupPosition);
 
             this.popup.renderer.setStyle("ace_loading", !finished);
         }.bind(this));
 
-        if (!this.autoShown && !(this.popup && this.popup.isOpen)) {
+        if (this.showLoadingState && !this.autoShown && !(this.popup && this.popup.isOpen)) {
             this.$firstOpenTimer.delay(this.stickySelectionDelay/2);
         }
     }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -63,6 +63,13 @@ class Autocomplete {
         this.keyboardHandler.bindKeys(this.commands);
         this.parentNode = null;
         this.setSelectOnHover = false;
+
+        /**
+         *  @property {Boolean} showLoadingState - A boolean indicating whether the loading states of the Autocompletion should be shown to the end-user. If enabled 
+         * it shows a loading indicator on the popup while autocomplete is loading.
+         * 
+         * Experimental: This visualisation is not yet considered stable and might change in the future.
+         */
         this.showLoadingState = false;
 
         /**
@@ -480,6 +487,8 @@ class Autocomplete {
                 if (this.autoInsert && !this.autoShown && filtered.length == 1)
                     return this.insertMatch(filtered[0]);
             }
+            // If showLoadingState is true and there is still a completer loading, show 'Loading...'
+            // in the top row of the completer popup.
             this.completions = !finished && this.showLoadingState ? 
                 new FilteredList(
                     Autocomplete.completionsForLoading.concat(filtered), completions.filterText

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -109,7 +109,7 @@ class Autocomplete {
             caption: config.nls("Loading..."),
             value: ""
         }];
-    };
+    }
 
     $init() {
         this.popup = new AcePopup(this.parentNode || document.body || document.documentElement); 

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1007,7 +1007,10 @@ module.exports = {
                 editor.completers = [fastCompleter, slowCompleter];
                 user.type("Ctrl-Space");
                 assert.equal(completer.popup.data.length, 4); 
+
+                // Should have to row saying 'Loading...' together with results.
                 assert.ok(isLoading());
+                assert.equal(completer.popup.data[0].caption, "Loading..."); 
                 setTimeout(() => {
                     completer.popup.renderer.$loop._flush();
                     assert.equal(completer.popup.data.length, 5);

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1008,7 +1008,7 @@ module.exports = {
                 user.type("Ctrl-Space");
                 assert.equal(completer.popup.data.length, 4); 
 
-                // Should have to row saying 'Loading...' together with results.
+                // Should have top row saying 'Loading...' together with results.
                 assert.ok(isLoading());
                 assert.equal(completer.popup.data[0].caption, "Loading..."); 
                 setTimeout(() => {

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -714,8 +714,9 @@ module.exports = {
         completer.stickySelectionDelay = 100;
         user.type("Ctrl-Space");
         assert.equal(completer.popup.isOpen, true);
-        assert.equal(completer.popup.data.length, 2); 
-        assert.equal(completer.popup.getRow(), 0);
+        assert.equal(completer.popup.data.length, 3); 
+        sendKey("Down");
+        assert.equal(completer.popup.getRow(), 1);
 
         setTimeout(() => {
             completer.popup.renderer.$loop._flush();
@@ -770,7 +771,7 @@ module.exports = {
         completer.stickySelectionDelay = -1;
         user.type("Ctrl-Space");
         assert.equal(completer.popup.isOpen, true);    
-        assert.equal(completer.popup.data.length, 2); 
+        assert.equal(completer.popup.data.length, 3); 
         assert.equal(completer.popup.getRow(), 0);
 
         setTimeout(() => {
@@ -1005,7 +1006,7 @@ module.exports = {
 
                 editor.completers = [fastCompleter, slowCompleter];
                 user.type("Ctrl-Space");
-                assert.equal(completer.popup.data.length, 3); 
+                assert.equal(completer.popup.data.length, 4); 
                 assert.ok(isLoading());
                 setTimeout(() => {
                     completer.popup.renderer.$loop._flush();

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -714,9 +714,8 @@ module.exports = {
         completer.stickySelectionDelay = 100;
         user.type("Ctrl-Space");
         assert.equal(completer.popup.isOpen, true);
-        assert.equal(completer.popup.data.length, 3); 
-        sendKey("Down");
-        assert.equal(completer.popup.getRow(), 1);
+        assert.equal(completer.popup.data.length, 2); 
+        assert.equal(completer.popup.getRow(), 0);
 
         setTimeout(() => {
             completer.popup.renderer.$loop._flush();
@@ -771,7 +770,7 @@ module.exports = {
         completer.stickySelectionDelay = -1;
         user.type("Ctrl-Space");
         assert.equal(completer.popup.isOpen, true);    
-        assert.equal(completer.popup.data.length, 3); 
+        assert.equal(completer.popup.data.length, 2); 
         assert.equal(completer.popup.getRow(), 0);
 
         setTimeout(() => {
@@ -990,6 +989,7 @@ module.exports = {
         
         var completer = Autocomplete.for(editor);
         completer.stickySelectionDelay = 100;
+        completer.showLoadingState = true;
         user.type("Ctrl-Space");
         assert.ok(!(completer.popup && completer.popup.isOpen));
 
@@ -1051,6 +1051,7 @@ module.exports = {
         var completer = Autocomplete.for(editor);
         completer.stickySelectionDelay = 100;
         completer.emptyMessage = "no completions";
+        completer.showLoadingState = true;
 
         user.type("doesntmatchanything");
         user.type("Ctrl-Space");
@@ -1101,6 +1102,7 @@ module.exports = {
         var completer = Autocomplete.for(editor);
         completer.stickySelectionDelay = 100;
         completer.inlineEnabled = true;
+        completer.showLoadingState = true;
 
         user.type("Ctrl-Space");
         assert.ok(!(completer.popup && completer.popup.isOpen));

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1020,6 +1020,104 @@ module.exports = {
         function isLoading() {
             return completer.popup.renderer.container.classList.contains("ace_loading");
         }
+    },
+    "test: should not display loading state on no suggestion state": function(done) {
+        var editor = initEditor("hello world\n");
+        
+        var slowCompleter = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        caption: "slow option 1",
+                        value: "s1",
+                        score: 3
+                    }, {
+                        caption: "slow option 2",
+                        value: "s2",
+                        score: 0
+                    }
+                ];
+                setTimeout(() => {
+                    callback(null,  completions);
+                }, 200);
+            }
+        };
+
+        editor.completers = [slowCompleter];
+        
+        var completer = Autocomplete.for(editor);
+        completer.stickySelectionDelay = 100;
+        completer.emptyMessage = "no completions";
+
+        user.type("doesntmatchanything");
+        user.type("Ctrl-Space");
+        assert.ok(!(completer.popup && completer.popup.isOpen));
+
+        setTimeout(() => {
+            completer.popup.renderer.$loop._flush();
+            assert.equal(completer.popup.data.length, 1);
+            assert.ok(isLoading());
+            setTimeout(() => {
+                // Should show no suggestions state without loading indicator
+                assert.equal(completer.popup.data.length, 1); 
+                assert.equal(completer.popup.data[0].caption, "no completions");
+                assert.ok(!isLoading());
+    
+                done();
+            }, 150);
+        }, 100);
+        
+        function isLoading() {
+            return completer.popup.renderer.container.classList.contains("ace_loading");
+        }
+    },
+    "test: should display ghost text after loading state if inline preview enabled": function(done) {
+        var editor = initEditor("hello world\n");
+        
+        var slowCompleter = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        caption: "slow option 1",
+                        value: "s1",
+                        score: 3
+                    }, {
+                        caption: "slow option 2",
+                        value: "s2",
+                        score: 0
+                    }
+                ];
+                setTimeout(() => {
+                    callback(null,  completions);
+                }, 200);
+            }
+        };
+
+        editor.completers = [slowCompleter];
+        
+        var completer = Autocomplete.for(editor);
+        completer.stickySelectionDelay = 100;
+        completer.inlineEnabled = true;
+
+        user.type("Ctrl-Space");
+        assert.ok(!(completer.popup && completer.popup.isOpen));
+
+        setTimeout(() => {
+            completer.popup.renderer.$loop._flush();
+            assert.equal(completer.popup.data.length, 1);
+            assert.ok(isLoading());
+            setTimeout(() => {
+                assert.equal(completer.popup.data.length, 2); 
+                assert.ok(!isLoading());
+                
+                assert.strictEqual(editor.renderer.$ghostText.text, "s1");
+                done();
+            }, 150);
+        }, 100);
+        
+        function isLoading() {
+            return completer.popup.renderer.container.classList.contains("ace_loading");
+        }
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Fixes three small issues with the completion loading state we recently added (#5368):
- When showing the 'no suggestions' state after the loading state the loading animation should not be rendered on the 'no suggestions state'.
- With inline preview enabled, the result that is selected after the loading state disappears should show inline preview.
-  Keeps the `Loading...` item in the popup as long as not all completers are finished, this allows screen reader users to find out when/if the loading has finished.

Additionally puts the completion loading state behind an option flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
