### PR TITLE
feat: allow completers to set gutter decoration while loading

### DIFF
--- a/src/layer/gutter.js
+++ b/src/layer/gutter.js
@@ -18,6 +18,7 @@ class Gutter{
 
         this.$annotations = [];
         this.$updateAnnotations = this.$updateAnnotations.bind(this);
+        this.$hideAnnotationCursorRow = false;
 
         this.$lines = new Lines(this.element);
         this.$lines.$offsetCoefficient = 1;
@@ -434,6 +435,12 @@ class Gutter{
         dom.setStyle(cell.element.style, "top", this.$lines.computeLineTop(row, config, session) + "px");
         
         cell.text = rowText;
+
+        // hide the annotation for the cursor row if desired.
+        if (this.$hideAnnotationCursorRow && row == this.$cursorRow) {
+            element.classList.remove("ace_info", "ace_warning", "ace_error", "ace_error_fold", "ace_warning_fold");
+            dom.setStyle(annotationNode.style, "display", "none");
+        }
 
         // If there are no annotations or fold widgets in the gutter cell, hide it from assistive tech.
         if (annotationNode.style.display === "none" && foldWidget.style.display === "none")

--- a/src/mouse/default_gutter_handler.js
+++ b/src/mouse/default_gutter_handler.js
@@ -47,6 +47,10 @@ function GutterHandler(mouseHandler) {
                 return hideTooltip();
         }
 
+        // Don't show the tooltip if the gutter annotation is hidden.
+        if (gutter.$hideAnnotationCursorRow && row == gutter.$cursorRow)
+            return hideTooltip();
+
         tooltip.showTooltip(row);
 
         if (!tooltip.isOpen)


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* working on a feature where completers can provide a classname to decorate the gutter with while they're `autoShown` and loading.

To do:
- write tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
