### PR TITLE
Popup anchor

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -224,8 +224,15 @@ class Autocomplete {
             }
         }
 
+        // posGhostText can be below the editor rendering the popup away from the editor.
+        // In this case, we want to render the popup such that the top aligns with the bottom of the editor.
+        var editorContainerBottom = editor.container.getBoundingClientRect().bottom - lineHeight;
+        var lowestPosition = editorContainerBottom < posGhostText.top ?
+            {top: editorContainerBottom, left: posGhostText.left} :
+            posGhostText;
+
         // Try to render below ghost text, then above ghost text, then over ghost text
-        if (this.popup.tryShow(posGhostText, lineHeight, "bottom")) {
+        if (this.popup.tryShow(lowestPosition, lineHeight, "bottom")) {
             return;
         }
 

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1123,6 +1123,46 @@ module.exports = {
         function isLoading() {
             return completer.popup.renderer.container.classList.contains("ace_loading");
         }
+    },
+    "test: if there is very long ghost text, popup should be rendered at the bottom of the editor container": function(done) {
+        var editor = initEditor("hello world\n");
+
+        // Give enough space for the popup to appear below the editor
+        var initialEditorHeight = editor.container.style.height;
+        var initialDocumentHeight = document.body.style.height;
+        editor.container.style.height = "200px";
+        document.body.style.height = editor.container.getBoundingClientRect().height + 200 + "px";
+
+        var longCompleter = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        caption: "loooooong",
+                        value: "line\n".repeat(30),
+                        score: 0
+                    }
+                ];
+                callback(null,  completions);
+            }
+        };
+
+        editor.completers = [longCompleter];
+        
+        var completer = Autocomplete.for(editor);
+        completer.inlineEnabled = true;
+
+        user.type("Ctrl-Space");
+        assert.ok(completer.popup && completer.popup.isOpen);
+        completer.popup.renderer.$loop._flush();
+
+        // Popup should start one pixel below the bottom of the editor container
+        assert.equal(completer.popup.container.getBoundingClientRect().top, editor.container.getBoundingClientRect().bottom + 1);
+
+        // Reset back to initial values
+        editor.container.style.height = initialEditorHeight;
+        document.body.style.height = initialDocumentHeight;
+
+        done();
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Currently, when ghost text extends beyond the border of the editor, the autocomplete popup can be rendered disconnected from the editor:


https://github.com/ajaxorg/ace/assets/34573235/8863711a-f212-4fd1-9229-337a3b01d2ca



This changes this so that it will be rendered below, but still connected to, the editor at the lowest:



https://github.com/ajaxorg/ace/assets/34573235/c9b80240-05f2-4213-9a68-3614226d89b1



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
