### PR TITLE
fix: yaml worker errors at undefined row/column

### DIFF
--- a/lib/ace/mode/yaml_worker.js
+++ b/lib/ace/mode/yaml_worker.js
@@ -34,9 +34,11 @@ oop.inherits(YamlWorker, Mirror);
                 return;
             }
 
+            // error.mark is not always defined, if undefined we default to displaying the error at the top row of the document.
+            var markDefined = !!error.mark;
             errors.push({
-                row: error.mark.line,
-                column: error.mark.column,
+                row: markDefined ? error.mark.line : 0,
+                column: markDefined ? error.mark.column : 0,
                 text: error.reason,
                 type: 'error',
                 raw: error


### PR DESCRIPTION
*Issue #, if available:* #5408

*Description of changes:* When the yaml worker gives errors at an undefined position, we now default to showing them at the top of the doc and not thrown an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
