### PR TITLE
fix: prevent browser scroll while scrolling over the tooltip

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -586,7 +586,13 @@ class Autocomplete {
             this.tooltipNode.id = "doc-tooltip";
             this.tooltipNode.setAttribute("role", "tooltip");
             // prevent editor scroll if tooltip is inside an editor
-            this.tooltipNode.addEventListener("wheel", event.stopPropagation);
+            this.tooltipNode.addEventListener("wheel", function(event) {
+                event.stopPropagation();
+                var contentOverflows = this.tooltipNode.scrollHeight > this.tooltipNode.clientHeight;
+                if (!contentOverflows) {
+                    event.preventDefault();
+                }
+            }.bind(this));
         }
         var theme = this.editor.renderer.theme;
         this.tooltipNode.className = "ace_tooltip ace_doc-tooltip " +

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -10,6 +10,7 @@ var dom = require("./lib/dom");
 var snippetManager = require("./snippets").snippetManager;
 var config = require("./config");
 var event = require("./lib/event");
+var preventParentScroll = require("./lib/scroll").preventParentScroll;
 
 /**
  * @typedef BaseCompletion
@@ -587,13 +588,7 @@ class Autocomplete {
             this.tooltipNode.id = "doc-tooltip";
             this.tooltipNode.setAttribute("role", "tooltip");
             // prevent editor scroll if tooltip is inside an editor
-            this.tooltipNode.addEventListener("wheel", function(event) {
-                event.stopPropagation();
-                var contentOverflows = this.tooltipNode.scrollHeight > this.tooltipNode.clientHeight;
-                if (!contentOverflows) {
-                    event.preventDefault();
-                }
-            }.bind(this));
+            this.tooltipNode.addEventListener("wheel", preventParentScroll);
         }
         var theme = this.editor.renderer.theme;
         this.tooltipNode.className = "ace_tooltip ace_doc-tooltip " +

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -580,6 +580,7 @@ class Autocomplete {
             this.tooltipNode = dom.createElement("div");
             this.tooltipNode.style.margin = 0;
             this.tooltipNode.style.pointerEvents = "auto";
+            this.tooltipNode.style.overscrollBehavior = "contain";
             this.tooltipNode.tabIndex = -1;
             this.tooltipNode.onblur = this.blurListener.bind(this);
             this.tooltipNode.onclick = this.onTooltipClick.bind(this);

--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -457,6 +457,7 @@ module.exports = `
     pointer-events: none;
     overflow: auto;
     max-width: min(60em, 66vw);
+    overscroll-behavior: contain;
 }
 .ace_tooltip pre {
     white-space: pre-wrap;

--- a/src/lib/scroll.js
+++ b/src/lib/scroll.js
@@ -1,0 +1,8 @@
+exports.preventParentScroll = function preventParentScroll(event) {
+    event.stopPropagation();
+    var target = event.currentTarget;
+    var contentOverflows = target.scrollHeight > target.clientHeight;
+    if (!contentOverflows) {
+        event.preventDefault();
+    }
+};

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -197,7 +197,7 @@ class HoverTooltip extends Tooltip {
             if (!contentOverflows) {
                 event.preventDefault();
             }
-        }.bind(this));
+        });
     }
     
     addToEditor(editor) {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -190,8 +190,14 @@ class HoverTooltip extends Tooltip {
         el.addEventListener("blur", function() {
             if (!el.contains(document.activeElement)) this.hide();
         }.bind(this));
-        
-        el.addEventListener("wheel", event.stopPropagation);
+
+        el.addEventListener("wheel", function(event) {
+            event.stopPropagation();
+            var contentOverflows = el.scrollHeight > el.clientHeight;
+            if (!contentOverflows) {
+                event.preventDefault();
+            }
+        }.bind(this));
     }
     
     addToEditor(editor) {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -3,6 +3,7 @@
 var dom = require("./lib/dom");
 var event = require("./lib/event");
 var Range = require("./range").Range;
+var preventParentScroll = require("./lib/scroll").preventParentScroll;
 
 var CLASSNAME = "ace_tooltip";
 
@@ -191,13 +192,7 @@ class HoverTooltip extends Tooltip {
             if (!el.contains(document.activeElement)) this.hide();
         }.bind(this));
 
-        el.addEventListener("wheel", function(event) {
-            event.stopPropagation();
-            var contentOverflows = el.scrollHeight > el.clientHeight;
-            if (!contentOverflows) {
-                event.preventDefault();
-            }
-        });
+        el.addEventListener("wheel", preventParentScroll);
     }
     
     addToEditor(editor) {


### PR DESCRIPTION
*Description of changes:*
Prevents browser scroll when a non-scrollable tooltip is open and you scroll on the tooltip.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
