### PR TITLE
fix: switch aria-selected to aria-current for webkit

### DIFF
--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -130,7 +130,10 @@ class AcePopup {
             if (selected !== t.selectedNode && t.selectedNode) {
                 dom.removeCssClass(t.selectedNode, "ace_selected");
                 el.removeAttribute("aria-activedescendant");
-                selected.removeAttribute("aria-selected");
+                if (userAgent.isSafari)
+                    selected.removeAttribute("aria-current");
+                else 
+                    selected.removeAttribute("aria-selected");
                 t.selectedNode.removeAttribute("id");
             }
             t.selectedNode = selected;
@@ -146,7 +149,10 @@ class AcePopup {
                 selected.setAttribute("aria-setsize", popup.data.length);
                 selected.setAttribute("aria-posinset", row+1);
                 selected.setAttribute("aria-describedby", "doc-tooltip");
-                selected.setAttribute("aria-selected", "true");
+                if (userAgent.isSafari)
+                    selected.setAttribute("aria-current", "true");
+                else 
+                    selected.setAttribute("aria-selected", "true");
             }
         });
         var hideHoverMarker = function() { setHoverMarker(-1); };


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* follow-up to #5403, we set the role to `menuitem` for items in the completer popup on webkit browsers but `aria-selected` is not allowed for `menuitem` roles triggering customers who run automated a11y tests. This changes it to [aria-current](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) which is allowed for this role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
