### PR TITLE
fix: don't show loading state when empty completer array is provided

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -111,7 +111,7 @@ class Autocomplete {
 
         this.$firstOpenTimer = lang.delayedCall(/**@this{Autocomplete}*/function() {
             var initialPosition = this.completionProvider && this.completionProvider.initialPosition;
-            if (this.autoShown || (this.popup && this.popup.isOpen) || !initialPosition) return;
+            if (this.autoShown || (this.popup && this.popup.isOpen) || !initialPosition || this.editor.completers.length === 0) return;
 
             this.completions = new FilteredList(Autocomplete.completionsForLoading);
             this.openPopup(this.editor, initialPosition.prefix, false);

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1328,6 +1328,19 @@ module.exports = {
 
             done();
         }, 100);
+    },
+    "test: should not show loading state when empty completer array is provided": function(done) {
+        var editor = initEditor("");
+        editor.completers = [];
+        var completer = Autocomplete.for(editor);
+        completer.showLoadingState = true;
+
+        user.type("Ctrl-Space");
+
+        // Tooltip should not be open
+        assert.ok(!(completer.popup && completer.popup.isOpen));
+
+        done();
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Currently, when providing an empty completer array, we show the popup with the completion loading state indefinitely:


https://github.com/ajaxorg/ace/assets/34573235/a41c86e4-6ea5-4858-b235-8eade3429f9d



This adds a check for the completer length in the showing of the loading popup. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
