### PR TITLE
(Theme): (Solarized Dark uses wrong text color) #5130

### DIFF
--- a/src/theme/solarized_dark-css.js
+++ b/src/theme/solarized_dark-css.js
@@ -10,12 +10,12 @@ module.exports = `.ace-solarized-dark .ace_gutter {
 
 .ace-solarized-dark {
   background-color: #002B36;
-  color: #93A1A1
+  color: #839496
 }
 
 .ace-solarized-dark .ace_entity.ace_other.ace_attribute-name,
 .ace-solarized-dark .ace_storage {
-  color: #93A1A1
+  color: #839496
 }
 
 .ace-solarized-dark .ace_cursor,


### PR DESCRIPTION
*Issue #5130:*
- #5130 

*Description of changes:*
- changed the solarized theme primary color from `#93A1A1` to `#839496`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
