### PR TITLE
fix #5424: support highlighting of console.debug in JavaScript

### DIFF
--- a/src/mode/javascript_highlight_rules.js
+++ b/src/mode/javascript_highlight_rules.js
@@ -136,7 +136,7 @@ var JavaScriptHighlightRules = function(options) {
                 regex : /that\b/
             }, {
                 token : ["storage.type", "punctuation.operator", "support.function.firebug"],
-                regex : /(console)(\.)(warn|info|log|error|time|trace|timeEnd|assert)\b/
+                regex : /(console)(\.)(warn|info|log|error|debug|time|trace|timeEnd|assert)\b/
             }, {
                 token : keywordMapper,
                 regex : identifierRe


### PR DESCRIPTION
*Issue #, if available: #5424

*Just adding `debug` to the list of properties of `console` in Syntax Highlighting of JavaScript*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
