### PR TITLE
fix backspace handling during composition on firefox

### DIFF
--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -37,7 +37,7 @@ TextInput= function(parentNode, host) {
 
     var copied = false;
     var pasted = false;
-    /**@type {false | {[key: string]: any}}} */
+    /**@type {(boolean|Object) & {context?: any, useTextareaForIME?: boolean, selectionStart?: number, markerRange?: any}}} */
     var inComposition = false;
     var sendingText = false;
     var tempStyle = '';
@@ -223,7 +223,7 @@ TextInput= function(parentNode, host) {
         if (!isFocused && !afterContextMenu)
             return;
         // see https://github.com/ajaxorg/ace/issues/2114
-        // @ts-expect-error this prevents infinite recursion on safari 8 
+        // this prevents infinite recursion on safari 8
         inComposition = true;
         
         var selectionStart = 0;
@@ -512,7 +512,12 @@ TextInput= function(parentNode, host) {
         }
     };
 
-    event.addCommandKeyListener(text, host.onCommandKey.bind(host), host);
+    event.addCommandKeyListener(text, function(e, hashId, keyCode) {
+        // ignore command events during composition as they will 
+        // either be handled by ime itself or fired again after ime end
+        if (inComposition) return;
+        return host.onCommandKey(e, hashId, keyCode);
+    }, host);
 
     event.addListener(text, "select", onSelect, host);
     event.addListener(text, "input", onInput, host);

--- a/src/keyboard/textinput_test.js
+++ b/src/keyboard/textinput_test.js
@@ -621,6 +621,64 @@ module.exports = {
         assert.equal(editor.getValue(), "开iird");
     },
     
+    "test: backspace during composition": function() {
+        editor.setValue("lxx\n", 1);
+        editor.execCommand("golineup");
+        editor.selection.moveTo(0, 1);
+        editor.setOption("useTextareaForIME", true);
+
+        [
+            { _: "keydown", range: [0,0], value: "xx\n\n", key: { code: "Backspace", key: "Backspace", keyCode: 8}},
+            function() {
+                assert.equal(editor.getValue(), "xx\n");
+            },
+            { _: "keydown", range: [0,0], value: "xx\n\n", key: { code: "KeyA", key: "a", keyCode: 65}},
+            { _: "keypress", range: [0,0], value: "xx\n\n", key: { code: "KeyA", key: "a", keyCode: 97}},
+            { _: "input", data: "a", inputType: "insertText", range: [1,1], value: "axx\n\n"},
+            { _: "keyup", range: [1,1], value: "axx\n\n", key: { code: "KeyA", key: "a", keyCode: 65}},
+            { _: "keydown", range: [1,1], value: "axx\n\n", key: { code: "KeyA", key: "a", keyCode: 65}},
+            { _: "keypress", range: [1,1], value: "axx\n\n", key: { code: "KeyA", key: "a", keyCode: 97}},
+            { _: "input", data: "a", inputType: "insertText", range: [2,2], value: "aaxx\n\n"},
+            { _: "keyup", range: [2,2], value: "aaxx\n\n", key: { code: "KeyA", key: "a", keyCode: 65}},
+            { _: "keydown", range: [2,2], value: "aaxx\n\n", key: { code: "AltRight", key: "Alt", keyCode: 18}, modifier: "alt-"},
+            { _: "keydown", range: [2,2], value: "aaxx\n\n", key: { code: "KeyI", key: "Dead", keyCode: 73}, modifier: "alt-"},
+            { _: "compositionstart", data: "", range: [0,0], value: ""},
+            function() {
+                editor.textInput.getElement().value = "ˆ";
+            },
+            { _: "compositionupdate", data: "ˆ", range: [0,0], value: ""},
+            { _: "input", data: "ˆ", inputType: "insertCompositionText", range: [1,1], value: "ˆ"},
+            { _: "keyup", range: [1,1], value: "ˆ", key: { code: "KeyI", key: "ˆ", keyCode: 73}, modifier: "alt-"},
+            { _: "keyup", range: [1,1], value: "ˆ", key: { code: "AltRight", key: "Alt", keyCode: 18}},
+            { _: "keydown", range: [1,1], value: "ˆ", key: { code: "Backspace", key: "Backspace", keyCode: 8}},
+            { _: "compositionend", data: "ˆ", range: [1,1], value: "ˆ"},
+            { _: "input", data: "ˆ", inputType: "insertCompositionText", range: [1,1], value: "ˆ"},
+            { _: "keydown", range: [2,2], value: "aaxx\n\n", key: { code: "Backspace", key: "Backspace", keyCode: 8}},
+            { _: "keyup", range: [2,2], value: "aaxx\n\n", key: { code: "Backspace", key: "Backspace", keyCode: 8}},
+            { _: "keydown", range: [2,2], value: "aaxx\n\n", key: { code: "AltRight", key: "Alt", keyCode: 18}, modifier: "alt-"},
+            { _: "keydown", range: [2,2], value: "aaxx\n\n", key: { code: "KeyI", key: "Dead", keyCode: 73}, modifier: "alt-"},
+            { _: "compositionstart", data: "", range: [0,0], value: ""},
+            { _: "compositionupdate", data: "ˆ", range: [0,0], value: ""},
+            function() {
+                editor.textInput.getElement().value = "ˆ";
+            },
+            { _: "input", data: "ˆ", inputType: "insertCompositionText", range: [1,1], value: "ˆ"},
+            { _: "keyup", range: [1,1], value: "ˆ", key: { code: "KeyI", key: "ˆ", keyCode: 73}, modifier: "alt-"},
+            { _: "keyup", range: [1,1], value: "ˆ", key: { code: "AltRight", key: "Alt", keyCode: 18}},
+            { _: "keydown", range: [1,1], value: "ˆ", key: { code: "ShiftLeft", key: "Shift", keyCode: 16}, modifier: "shift-"},
+            { _: "keyup", range: [1,1], value: "ˆ", key: { code: "ShiftLeft", key: "Shift", keyCode: 16}},
+            { _: "keydown", range: [1,1], value: "ˆ", key: { code: "Delete", key: "Delete", keyCode: 46}},
+            { _: "compositionend", data: "ˆ", range: [1,1], value: "ˆ"},
+            { _: "input", data: "ˆ", inputType: "insertCompositionText", range: [1,1], value: "ˆ"},
+            { _: "keydown", range: [3,3], value: "aaˆx\n\n", key: { code: "Delete", key: "Delete", keyCode: 46}},
+            { _: "select", range: [3,3], value: "aaˆx\n\n"},
+            { _: "keyup", range: [3,3], value: "aaˆx\n\n", key: { code: "Delete", key: "Delete", keyCode: 46}}
+        ].forEach(function(data, i) {
+            sendEvent(data._, data);
+        });
+        assert.equal(editor.getValue(), "aaˆx\n");
+    },
+
     "test: mac pressAndHold on firefox": function() {
         editor.setOption("useTextareaForIME", true);
         [

--- a/src/lib/event.js
+++ b/src/lib/event.js
@@ -182,14 +182,24 @@ exports.addMultiMouseDownListener = function(elements, timeouts, eventHandler, c
     });
 };
 
-var getModifierHash = function(e) {
+/** @param {KeyboardEvent|MouseEvent} e */
+function getModifierHash(e) {
     return 0 | (e.ctrlKey ? 1 : 0) | (e.altKey ? 2 : 0) | (e.shiftKey ? 4 : 0) | (e.metaKey ? 8 : 0);
-};
+}
 
+/**
+ * @param {KeyboardEvent|MouseEvent} e
+ * @returns string
+ */
 exports.getModifierString = function(e) {
     return keys.KEY_MODS[getModifierHash(e)];
 };
 
+/**
+ * @param {(e: KeyboardEvent, hashId: number, keyCode: number)=> void } callback
+ * @param {KeyboardEvent} e
+ * @param {number} keyCode
+ */
 function normalizeCommandKeys(callback, e, keyCode) {
     var hashId = getModifierHash(e);
 
@@ -203,7 +213,7 @@ function normalizeCommandKeys(callback, e, keyCode) {
                 return;
         }
         if (keyCode === 18 || keyCode === 17) {
-            var location = "location" in e ? e.location : e.keyLocation;
+            var location = e.location;
             if (keyCode === 17 && location === 1) {
                 if (pressedKeys[keyCode] == 1)
                     ts = e.timeStamp;
@@ -220,8 +230,7 @@ function normalizeCommandKeys(callback, e, keyCode) {
     }
     
     if (!hashId && keyCode === 13) {
-        var location = "location" in e ? e.location : e.keyLocation;
-        if (location === 3) {
+        if (e.location === 3) {
             callback(e, hashId, -keyCode);
             if (e.defaultPrevented)
                 return;
@@ -247,8 +256,8 @@ function normalizeCommandKeys(callback, e, keyCode) {
 }
 
 /**
- * @param el
- * @param callback
+ * @param {EventTarget} el
+ * @param {(e: KeyboardEvent, hashId: number, keyCode: number)=>void} callback
  * @param [destroyer]
  */
 exports.addCommandKeyListener = function(el, callback, destroyer) {


### PR DESCRIPTION
fixes https://github.com/ajaxorg/ace/issues/4999

Firefox was setting keyCode to 8 during composition while chrome is setting it to unknown key 229
Here i have added filtering based on key instead of keyCode, because all browsers are setting it to Backspace, which would cause us problems when implementing https://github.com/ajaxorg/ace/issues/4952



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
