### PR TITLE
fix: updated red color in cloud-editor dark theme

### DIFF
--- a/src/theme/cloud_editor_dark-css.js
+++ b/src/theme/cloud_editor_dark-css.js
@@ -101,7 +101,7 @@ module.exports = `
 
 .ace-cloud_editor_dark .ace_invalid.ace_illegal {
     color: #dcdfe4;
-    background-color: #e76a71;
+    background-color: #e96a71;
 }
 
 .ace-cloud_editor_dark .ace_invalid.ace_deprecated {
@@ -124,7 +124,7 @@ module.exports = `
 }
 
 .ace-cloud_editor_dark .ace_variable {
-    color: #e76a71;
+    color: #e96a71;
 }
 
 .ace-cloud_editor_dark .ace_meta.ace_selector {
@@ -140,7 +140,7 @@ module.exports = `
 }
 
 .ace-cloud_editor_dark .ace_entity.ace_name.ace_tag {
-    color: #e76a71;
+    color: #e96a71;
 }
 .ace-cloud_editor_dark .ace_heading {
     color: #66b2f0;
@@ -150,7 +150,7 @@ module.exports = `
     color: #e5c383;
 }
 .ace-cloud_editor_dark .ace_doctype {
-    color: #e76a71;
+    color: #e96a71;
 }
 
 .ace-cloud_editor_dark .ace_entity.ace_name.ace_tag,
@@ -158,7 +158,7 @@ module.exports = `
 .ace-cloud_editor_dark .ace_meta.ace_tag,
 .ace-cloud_editor_dark .ace_string.ace_regexp,
 .ace-cloud_editor_dark .ace_variable {
-    color: #e76a71;
+    color: #e96a71;
 }
 
 .ace-cloud_editor_dark .ace_tooltip {


### PR DESCRIPTION

*Description of changes:*

The new color meets the 4.5:1 contrast ratio, while the previous color didn't.   

<img width="803" alt="Screenshot 2023-12-19 at 14 15 23" src="https://github.com/ajaxorg/ace/assets/30181549/125af8e5-576c-4394-a598-d3f55a40d095">

Versus previous:  

<img width="773" alt="Screenshot 2023-12-19 at 14 16 08" src="https://github.com/ajaxorg/ace/assets/30181549/e537557a-ed37-4853-83d0-919e6e9ccb69">
