### PR TITLE
fix: update ghost text if on same line popup

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -331,8 +331,8 @@ class Autocomplete {
         
         this.popup.setRow(this.autoSelect ? newRow : -1);
      
-        // If we stay on the same row, but the content is different, we want to update the popup.
-        if (newRow === oldRow && previousSelectedItem !== this.completions.filtered[newRow]) 
+        // If we stay on the same row, but the content is different or we have inline preview enabled, we want to update the popup.
+        if (newRow === oldRow && (previousSelectedItem !== this.completions.filtered[newRow] || this.inlineRenderer)) 
             this.$onPopupChange();
 
         if (!keepPopupPosition) {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -335,10 +335,12 @@ class Autocomplete {
         
         this.popup.setRow(this.autoSelect ? newRow : -1);
      
-        // If we stay on the same row, but the content is different or we have inline preview enabled, we want to update the popup.
+        // If we stay on the same row, but the content is different, we want to update the popup.
         if (newRow === oldRow && previousSelectedItem !== this.completions.filtered[newRow]) 
             this.$onPopupChange();
 
+        // If we stay on the same line and have inlinePreview enabled, we want to make sure the
+        // ghost text remains up-to-date.
         const inlineEnabled = this.inlineRenderer && this.inlineEnabled;
         if (newRow === oldRow && inlineEnabled) {
             var completion = this.popup.getData(this.popup.getRow());

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -176,12 +176,7 @@ class Autocomplete {
     $onPopupChange(hide) {
         if (this.inlineRenderer && this.inlineEnabled) {
             var completion = hide ? null : this.popup.getData(this.popup.getRow());
-            var prefix = util.getCompletionPrefix(this.editor);
-            if (!this.inlineRenderer.show(this.editor, completion, prefix)) {
-                this.inlineRenderer.hide();
-            } else {
-                this.$seen(completion);
-            }
+            this.$updateGhostText(completion);
             // If the mouse is over the tooltip, and we're changing selection on hover don't
             // move the tooltip while hovering over the popup.
             if (this.popup.isMouseOver && this.setSelectOnHover) {
@@ -198,6 +193,15 @@ class Autocomplete {
             this.popupTimer.call(null, null);
             // @ts-expect-error TODO: potential wrong arguments
             this.tooltipTimer.call(null, null);
+        }
+    }
+
+    $updateGhostText(completion) {
+        var prefix = util.getCompletionPrefix(this.editor);
+        if (!this.inlineRenderer.show(this.editor, completion, prefix)) {
+            this.inlineRenderer.hide();
+        } else {
+            this.$seen(completion);
         }
     }
 
@@ -332,8 +336,14 @@ class Autocomplete {
         this.popup.setRow(this.autoSelect ? newRow : -1);
      
         // If we stay on the same row, but the content is different or we have inline preview enabled, we want to update the popup.
-        if (newRow === oldRow && (previousSelectedItem !== this.completions.filtered[newRow] || this.inlineRenderer)) 
+        if (newRow === oldRow && previousSelectedItem !== this.completions.filtered[newRow]) 
             this.$onPopupChange();
+
+        const inlineEnabled = this.inlineRenderer && this.inlineEnabled;
+        if (newRow === oldRow && inlineEnabled) {
+            var completion = this.popup.getData(this.popup.getRow());
+            this.$updateGhostText(completion);
+        }
 
         if (!keepPopupPosition) {
             this.popup.setTheme(editor.getTheme());

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1340,6 +1340,52 @@ module.exports = {
         assert.ok(!(completer.popup && completer.popup.isOpen));
 
         done();
+    },
+    "test: should update inline preview when typing when it's the only item in the popup": function(done) {
+        var editor = initEditor("");
+        
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            caption: "function",
+                            value: "function\nthat does something\ncool"
+                        }
+                    ];
+                    callback(null, completions);
+                }
+            }
+        ];
+        
+        var completer = Autocomplete.for(editor);
+        completer.inlineEnabled = true;
+
+        user.type("f");
+        var inline = completer.inlineRenderer;
+
+        // Popup should be open, with inline text renderered.
+        assert.equal(completer.popup.isOpen, true);  
+        assert.equal(completer.popup.getRow(), 0);
+        assert.strictEqual(inline.isOpen(), true);
+        assert.strictEqual(editor.renderer.$ghostText.text, "unction\nthat does something\ncool");
+
+        // when you keep typing, the ghost text should update accordingly
+        user.type("unc");
+
+        setTimeout(() => {
+            assert.strictEqual(inline.isOpen(), true);
+            assert.strictEqual(editor.renderer.$ghostText.text, "tion\nthat does something\ncool");
+
+            user.type("tio");
+
+            setTimeout(() => {
+                assert.strictEqual(inline.isOpen(), true);
+                assert.strictEqual(editor.renderer.$ghostText.text, "n\nthat does something\ncool");
+    
+                done();
+            }, 100);
+        }, 100);
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* We only update the inline preview in the completer if the selection changes, when typing ahead though, this doesn't have to be the case. This changes it so that we also update the ghost text when typing ahead which doesn't cause selection changes.

Before:


https://github.com/ajaxorg/ace/assets/34573235/579aa70a-a17c-4442-8ac4-d21a8092f8d1

After:


https://github.com/ajaxorg/ace/assets/34573235/e98da0e1-7925-4ab0-a778-30ae1533de19



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
