### PR TITLE
fix: improve prefixing for inline preview

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -197,7 +197,14 @@ class Autocomplete {
     }
 
     $updateGhostText(completion) {
-        var prefix = util.getCompletionPrefix(this.editor);
+        // Ghost text can include characters normally not part of the prefix (e.g. whitespace).
+        // When typing ahead with ghost text however, we want to simply prefix with respect to the
+        // base of the completion.
+        var row = this.base.row;
+        var column = this.base.column;
+        var cursorColumn = this.editor.getCursorPosition().column;
+        var prefix = this.editor.session.getLine(row).slice(column, cursorColumn);
+
         if (!this.inlineRenderer.show(this.editor, completion, prefix)) {
             this.inlineRenderer.hide();
         } else {

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1386,6 +1386,51 @@ module.exports = {
                 done();
             }, 100);
         }, 100);
+    },
+    "test: should keep shwoing ghost text when typing ahead with whitespace": function(done) {
+        var editor = initEditor("");
+        
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            value: "function that does something cool"
+                        }
+                    ];
+                    callback(null, completions);
+                }
+            }
+        ];
+        
+        var completer = Autocomplete.for(editor);
+        completer.inlineEnabled = true;
+
+        user.type("f");
+        var inline = completer.inlineRenderer;
+
+        // Popup should be open, with inline text renderered.
+        assert.equal(completer.popup.isOpen, true);  
+        assert.equal(completer.popup.getRow(), 0);
+        assert.strictEqual(inline.isOpen(), true);
+        assert.strictEqual(editor.renderer.$ghostText.text, "unction that does something cool");
+
+        // when you keep typing, the ghost text should update accordingly
+        user.type("unction th");
+
+        setTimeout(() => {
+            assert.strictEqual(inline.isOpen(), true);
+            assert.strictEqual(editor.renderer.$ghostText.text, "at does something cool");
+
+            user.type("at do");
+
+            setTimeout(() => {
+                assert.strictEqual(inline.isOpen(), true);
+                assert.strictEqual(editor.renderer.$ghostText.text, "es something cool");
+    
+                done();
+            }, 100);
+        }, 100);
     }
 };
 

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1387,7 +1387,7 @@ module.exports = {
             }, 100);
         }, 100);
     },
-    "test: should keep shwoing ghost text when typing ahead with whitespace": function(done) {
+    "test: should keep showing ghost text when typing ahead with whitespace": function(done) {
         var editor = initEditor("");
         
         editor.completers = [


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Use the string of text between the start of the autocomplete prefix and the current cursor position, regardless of the characters in between, to determine whether inline preview should be rendered. This allows inline preview to stay visible when typing ahead with whitespace.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
