### PR TITLE
Change release shell script for new version of doc generator

### DIFF
--- a/tool/release-api-docs.sh
+++ b/tool/release-api-docs.sh
@@ -19,8 +19,6 @@ rm -rf ./doc
 
 npm i
 export ACE_VERSION="v$(node -p 'require("../package.json").version')"
-node generateAnnotations.js ../src
-node generateNewDts.js ace.d.ts
 node generateDoc.js ./doc
 
 rm -rf ./doc-repo


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This should be merged only after [Change generator to work with new JSDoc-based Type System](https://github.com/ajaxorg/ace-api-docs/pull/6)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
