### PR TITLE
Add all ANSI Keywords to sql_highlight_rules.js

### DIFF
--- a/src/mode/sql_highlight_rules.js
+++ b/src/mode/sql_highlight_rules.js
@@ -8,7 +8,13 @@ var SqlHighlightRules = function() {
     var keywords = (
         "select|insert|update|delete|from|where|and|or|group|by|order|limit|offset|having|as|case|" +
         "when|then|else|end|type|left|right|join|on|outer|desc|asc|union|create|table|primary|key|if|" +
-        "foreign|not|references|default|null|inner|cross|natural|database|drop|grant|distinct|is|in"
+        "foreign|not|references|default|null|inner|cross|natural|database|drop|grant|distinct|is|in|" + 
+        "all|alter|any|array|at|authorization|between|both|cast|check|collate|column|commit|constraint|"+
+        "cube|current|current_date|current_time|current_timestamp|current_user|describe|escape|except|" +
+        "exists|external|extract|fetch|filter|for|full|function|global|grouping|intersect|interval|" + 
+        "into|leading|like|local|no|of|only|out|overlaps|partition|position|range|revoke|rollback|rollup|" +
+        "row|rows|session_user|set|some|start|tablesample|time|to|trailing|truncate|unique|unknown|" + 
+        "user|using|values|window|with"
     );
 
     var builtinConstants = (
@@ -22,7 +28,7 @@ var SqlHighlightRules = function() {
 
     var dataTypes = (
         "int|numeric|decimal|date|varchar|char|bigint|float|double|bit|binary|text|set|timestamp|" +
-        "money|real|number|integer"
+        "money|real|number|integer|string"
     );
 
     var keywordMapper = this.createKeywordMapper({


### PR DESCRIPTION
*Issue #, if available:*
Fixes #5446 

*Description of changes:*
Adds all ANSI Keywords and also adds string as datatype which is common in Spark and some other newer systems like DuckDB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
