### PR TITLE
Change default font-size to 14

### DIFF
--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -31,7 +31,7 @@ module.exports = `
     position: relative;
     overflow: hidden;
     padding: 0;
-    font: 12px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace;
+    font: 14px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace;
     direction: ltr;
     text-align: left;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);


### PR DESCRIPTION
Changes the default font-size from 12px to a more modern 14px used by other editors such as CodeMirror and Monaco.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
