### PR TITLE
fix: Improve contrast of completion popup in CloudEditor theme

### DIFF
--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -414,53 +414,57 @@ class AcePopup {
 
 dom.importCssString(`
 .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
-    background-color: #CAD6FA;
-    z-index: 1;
-}
-.ace_dark.ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
-    background-color: #3a674e;
-}
-.ace_editor.ace_autocomplete .ace_line-hover {
-    border: 1px solid #abbffe;
-    margin-top: -1px;
-    background: rgba(233,233,253,0.4);
-    position: absolute;
+    background-color: #f2f3f3;
+    border: #0F68AE 1.5px solid;
     z-index: 2;
 }
+.ace_dark.ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
+    background-color: #272A30;
+    border-color: #299FBC;
+}
+.ace_editor.ace_autocomplete .ace_line-hover {
+    border: 1px solid #16191f;
+    margin-top: -1px;
+    background: #f2f3f3;
+    position: absolute;
+    z-index: 1;
+}
 .ace_dark.ace_editor.ace_autocomplete .ace_line-hover {
-    border: 1px solid rgba(109, 150, 13, 0.8);
-    background: rgba(58, 103, 78, 0.62);
+    border: 1px solid #d5dbdb;;
+    background: #272A30;
 }
 .ace_completion-meta {
-    opacity: 0.5;
+    color: #545b64;
     margin-left: 0.9em;
+}
+.ace_dark.ace_editor.ace_autocomplete .ace_completion-meta {
+    color: #ACB8B9;
 }
 .ace_completion-message {
     margin-left: 0.9em;
     color: blue;
 }
 .ace_editor.ace_autocomplete .ace_completion-highlight{
-    color: #2d69c7;
+    color: #0F68AE;
 }
 .ace_dark.ace_editor.ace_autocomplete .ace_completion-highlight{
-    color: #93ca12;
+    color: #2AA0BC;
 }
 .ace_editor.ace_autocomplete {
     width: 300px;
     z-index: 200000;
     border: 1px lightgray solid;
     position: fixed;
-    box-shadow: 2px 3px 5px rgba(0,0,0,.2);
-    line-height: 1.4;
-    background: #fefefe;
-    color: #111;
+    box-shadow: 0 1px 1px 0 #001c244d, 1px 1px 1px 0 #001c2426, -1px 1px 1px 0 #001c2426;
+    line-height: 1.5;
+    border: 1px solid #eaeded;
+    background: #ffffff;
+    color: #16191f;
 }
 .ace_dark.ace_editor.ace_autocomplete {
-    border: 1px #484747 solid;
-    box-shadow: 2px 3px 5px rgba(0, 0, 0, 0.51);
-    line-height: 1.4;
-    background: #25282c;
-    color: #c1c1c1;
+    border: 1px solid #2a2e33;
+    background: #050506;
+    color: #ffffff;
 }
 .ace_autocomplete .ace_text-layer  {
     width: calc(100% - 8px);

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -414,57 +414,53 @@ class AcePopup {
 
 dom.importCssString(`
 .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
-    background-color: #f2f3f3;
-    border: #0F68AE 1.5px solid;
-    z-index: 2;
-}
-.ace_dark.ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
-    background-color: #272A30;
-    border-color: #299FBC;
-}
-.ace_editor.ace_autocomplete .ace_line-hover {
-    border: 1px solid #16191f;
-    margin-top: -1px;
-    background: #f2f3f3;
-    position: absolute;
+    background-color: #CAD6FA;
     z-index: 1;
 }
+.ace_dark.ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
+    background-color: #3a674e;
+}
+.ace_editor.ace_autocomplete .ace_line-hover {
+    border: 1px solid #abbffe;
+    margin-top: -1px;
+    background: rgba(233,233,253,0.4);
+    position: absolute;
+    z-index: 2;
+}
 .ace_dark.ace_editor.ace_autocomplete .ace_line-hover {
-    border: 1px solid #d5dbdb;
-    background: #272A30;
+    border: 1px solid rgba(109, 150, 13, 0.8);
+    background: rgba(58, 103, 78, 0.62);
 }
 .ace_completion-meta {
-    color: #545b64;
+    opacity: 0.5;
     margin-left: 0.9em;
-}
-.ace_dark.ace_editor.ace_autocomplete .ace_completion-meta {
-    color: #ACB8B9;
 }
 .ace_completion-message {
     margin-left: 0.9em;
     color: blue;
 }
 .ace_editor.ace_autocomplete .ace_completion-highlight{
-    color: #0F68AE;
+    color: #2d69c7;
 }
 .ace_dark.ace_editor.ace_autocomplete .ace_completion-highlight{
-    color: #2AA0BC;
+    color: #93ca12;
 }
 .ace_editor.ace_autocomplete {
     width: 300px;
     z-index: 200000;
     border: 1px lightgray solid;
     position: fixed;
-    box-shadow: 0 1px 1px 0 #001c244d, 1px 1px 1px 0 #001c2426, -1px 1px 1px 0 #001c2426;
-    line-height: 1.5;
-    border: 1px solid #eaeded;
-    background: #ffffff;
-    color: #16191f;
+    box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+    line-height: 1.4;
+    background: #fefefe;
+    color: #111;
 }
 .ace_dark.ace_editor.ace_autocomplete {
-    border: 1px solid #2a2e33;
-    background: #050506;
-    color: #ffffff;
+    border: 1px #484747 solid;
+    box-shadow: 2px 3px 5px rgba(0, 0, 0, 0.51);
+    line-height: 1.4;
+    background: #25282c;
+    color: #c1c1c1;
 }
 .ace_autocomplete .ace_text-layer  {
     width: calc(100% - 8px);

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -430,7 +430,7 @@ dom.importCssString(`
     z-index: 1;
 }
 .ace_dark.ace_editor.ace_autocomplete .ace_line-hover {
-    border: 1px solid #d5dbdb;;
+    border: 1px solid #d5dbdb;
     background: #272A30;
 }
 .ace_completion-meta {

--- a/src/theme/cloud_editor-css.js
+++ b/src/theme/cloud_editor-css.js
@@ -182,4 +182,26 @@ module.exports = `
     outline: 1px solid #0073bb;
 }
 
+.ace-cloud_editor.ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
+    background-color: #f2f3f3;
+    border: #0F68AE 1.5px solid;
+}
+.ace-cloud_editor.ace_editor.ace_autocomplete .ace_line-hover {
+    border: 1px solid #16191f;
+    background: #f2f3f3;
+}
+.ace-cloud_editor.ace_editor.ace_autocomplete .ace_completion-meta {
+    color: #545b64;
+}
+.ace-cloud_editor.ace_editor.ace_autocomplete .ace_completion-highlight{
+    color: #0F68AE;
+}
+.ace-cloud_editor.ace_editor.ace_autocomplete {
+    box-shadow: 0 1px 1px 0 #001c244d, 1px 1px 1px 0 #001c2426, -1px 1px 1px 0 #001c2426;
+    line-height: 1.5;
+    border: 1px solid #eaeded;
+    background: #ffffff;
+    color: #16191f;
+}
+
 `;

--- a/src/theme/cloud_editor_dark-css.js
+++ b/src/theme/cloud_editor_dark-css.js
@@ -185,4 +185,26 @@ module.exports = `
     outline: 1px solid #44b9d6;
 }
 
+.ace-cloud_editor_dark.ace_dark.ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
+    background-color: #272A30;
+    border: #299FBC 1.5px solid;
+}
+.ace-cloud_editor_dark.ace_dark.ace_editor.ace_autocomplete .ace_line-hover {
+    border: 1px solid #d5dbdb;
+    background: #272A30;
+}
+.ace-cloud_editor_dark.ace_dark.ace_editor.ace_autocomplete .ace_completion-meta {
+    color: #ACB8B9;
+}
+.ace-cloud_editor_dark.ace_dark.ace_editor.ace_autocomplete .ace_completion-highlight{
+    color: #2AA0BC;
+}
+.ace-cloud_editor_dark.ace_dark.ace_editor.ace_autocomplete {
+    box-shadow: 0 1px 1px 0 #001c244d, 1px 1px 1px 0 #001c2426, -1px 1px 1px 0 #001c2426;
+    line-height: 1.5;
+    border: 1px solid #2a2e33;
+    background: #050506;
+    color: #ffffff;
+}
+
 `;


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Some parts of the default autocomplete popup did not meet accessibility contrast requirements, the gaps were:

- The blue completion highlight text has insufficient contrast with the selected and non-selected background, it should be 4.5:1.
- The blue completion highlight text  has insufficient contrast with the 'normal' text, it should be 3:1.
- The light grey meta text on does not contrast 4.5:1 with the selected and non-selected background colors.

This improves the styling in our CloudEditor themes, which we use as our de-facto accessible themes.

<img width="576" alt="Screenshot 2024-01-26 at 14 22 13" src="https://github.com/ajaxorg/ace/assets/34573235/2871b46a-84b2-4326-8880-65779dffa2ff">

<img width="510" alt="Screenshot 2024-01-26 at 14 21 49" src="https://github.com/ajaxorg/ace/assets/34573235/3a69ad20-e2e0-4f28-8c9c-55051238005a">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
