### PR TITLE
change colors for ace_snippet-marker

### DIFF
--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -153,7 +153,7 @@ class AcePopup {
                 el.setAttribute("aria-activedescendant", ariaId);
                 selected.setAttribute("role", optionAriaRole);
                 selected.setAttribute("aria-roledescription", nls("item"));
-                selected.setAttribute("aria-label", popup.getData(row).caption);
+                selected.setAttribute("aria-label", popup.getData(row).caption || popup.getData(row).value);
                 selected.setAttribute("aria-setsize", popup.data.length);
                 selected.setAttribute("aria-posinset", row + 1);
                 selected.setAttribute("aria-describedby", "doc-tooltip");

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -153,7 +153,7 @@ class AcePopup {
                 el.setAttribute("aria-activedescendant", ariaId);
                 selected.setAttribute("role", optionAriaRole);
                 selected.setAttribute("aria-roledescription", nls("item"));
-                selected.setAttribute("aria-label", popup.getData(row).value);
+                selected.setAttribute("aria-label", popup.getData(row).caption);
                 selected.setAttribute("aria-setsize", popup.data.length);
                 selected.setAttribute("aria-posinset", row + 1);
                 selected.setAttribute("aria-describedby", "doc-tooltip");

--- a/src/theme/cloud_editor-css.js
+++ b/src/theme/cloud_editor-css.js
@@ -181,5 +181,12 @@ module.exports = `
 .ace-cloud_editor .ace_tooltip.ace_hover-tooltip:focus > div {
     outline: 1px solid #0073bb;
 }
+.ace-cloud_editor .ace_snippet-marker {
+    background-color: #CED6E0;
+    border-top: #C0C8D2 1px solid;
+    border-bottom: #C0C8D2 1px solid;
+    border-left: 0 solid;
+    border-right: 0 solid;
+}
 
 `;

--- a/src/theme/cloud_editor-css.js
+++ b/src/theme/cloud_editor-css.js
@@ -183,10 +183,7 @@ module.exports = `
 }
 .ace-cloud_editor .ace_snippet-marker {
     background-color: #CED6E0;
-    border-top: #C0C8D2 1px solid;
-    border-bottom: #C0C8D2 1px solid;
-    border-left: 0 solid;
-    border-right: 0 solid;
+    border: 0;
 }
 
 `;

--- a/src/theme/cloud_editor_dark-css.js
+++ b/src/theme/cloud_editor_dark-css.js
@@ -186,10 +186,7 @@ module.exports = `
 }
 .ace-cloud_editor_dark .ace_snippet-marker {
     background-color: #434650;
-    border-top: #4D4F5C 1px solid;
-    border-bottom: #4D4F5C 1px solid;
-    border-left: 0 solid;
-    border-right: 0 solid;
+    border: 0;
 }
 
 `;

--- a/src/theme/cloud_editor_dark-css.js
+++ b/src/theme/cloud_editor_dark-css.js
@@ -184,5 +184,12 @@ module.exports = `
 .ace-cloud_editor_dark .ace_tooltip.ace_hover-tooltip:focus > div {
     outline: 1px solid #44b9d6;
 }
+.ace-cloud_editor_dark .ace_snippet-marker {
+    background-color: #434650;
+    border-top: #4D4F5C 1px solid;
+    border-bottom: #4D4F5C 1px solid;
+    border-left: 0 solid;
+    border-right: 0 solid;
+}
 
 `;


### PR DESCRIPTION
Increase the contrast ratio of ace_snippet-marker colors in cloud editor theme:
</br>

![light](https://github.com/ajaxorg/ace/assets/12100596/9adfa5b1-6998-4253-b863-15483b1f1137)
</br>
![dark](https://github.com/ajaxorg/ace/assets/12100596/fbfc6f64-24eb-47e2-957b-a7d94f942afa)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
