### PR TITLE
fix regression in passing matches startAutocomplete

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -536,6 +536,7 @@ class Autocomplete {
             this.base = this.editor.session.doc.createAnchor(pos.row, pos.column);
             this.base.$insertRight = true;
             this.completions = new FilteredList(options.matches);
+            this.getCompletionProvider().completions = this.completions;
             return this.openPopup(this.editor, "", keepPopupPosition);
         }
 

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1431,6 +1431,24 @@ module.exports = {
                 done();
             }, 100);
         }, 100);
+    },
+    "test: passing matches from execCommand": function() {
+        var editor = initEditor("");
+        editor.execCommand('startAutocomplete', {
+            matches: [
+                { value: 'example value' }
+            ]
+        });
+        user.type("\n");
+        
+        assert.equal(editor.getValue(), "example value");
+        
+        editor.resize(true);
+        editor.insertSnippet("<$1-${1|a1,b2,c3|}>");
+        user.type("Down");
+        user.type("\n");
+        
+        assert.equal(editor.getValue(), "example value<b2-b2>");
     }
 };
 

--- a/src/test/all_browser.js
+++ b/src/test/all_browser.js
@@ -142,7 +142,7 @@ if (location.search) {
     else
         selectedTests = parts[0].split(",");
 }
-var filter = location.hash.substr(1);
+var filter = decodeURIComponent(location.hash.substr(1));
 window.onhashchange = function() { location.reload(); };
 
 require(selectedTests, function() {


### PR DESCRIPTION
fixes https://github.com/ajaxorg/ace/issues/5472
 which was broken by inline autocomplete refactoring

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
