### PR TITLE
Only show snippet markers for the current snippet on edit

### DIFF
--- a/src/snippets.js
+++ b/src/snippets.js
@@ -892,9 +892,10 @@ class TabstopManager {
         if (index == max)
             index = 0;
         this.selectTabstop(index);
-        if (index === 0)
-            this.detach();
         this.updateTabstopMarkers();
+        if (index === 0) {
+            this.detach();
+        }
     }
     selectTabstop(index) {
         this.$openTabstops = null;
@@ -1000,11 +1001,16 @@ class TabstopManager {
         });
     }
     updateTabstopMarkers() {
-        var currentId =  this.selectedTabstop ? this.selectedTabstop.snippetId : 0;
+        if (!this.selectedTabstop) return;
+        var currentSnippetId =  this.selectedTabstop.snippetId;
+        // back to the parent snippet tabstops if $0
+        if ( this.selectedTabstop.index === 0) {
+            currentSnippetId--;
+        }
         this.tabstops.forEach(function(ts) {
-            // Show the selected tabstop markers
-            if (ts.snippetId === currentId || currentId === 0) this.addTabstopMarkers(ts);
-            else this.removeTabstopMarkers(ts)
+            // show marker only for the tabstops of the currently active snippet
+            if (ts.snippetId === currentSnippetId) this.addTabstopMarkers(ts);
+            else this.removeTabstopMarkers(ts);
         }, this);
     }
     removeRange(range) {

--- a/src/snippets.js
+++ b/src/snippets.js
@@ -379,6 +379,9 @@ class SnippetManager {
         var range = editor.getSelectionRange();
         var end = editor.session.replace(range, processedSnippet.text);
 
+        if (editor.tabstopManager) {
+            editor.tabstopManager.detach();
+        }
         var tabstopManager = new TabstopManager(editor);
         var selectionId = editor.inVirtualSelectionMode && editor.selection.index;
         //@ts-expect-error TODO: potential wrong arguments

--- a/src/snippets_test.js
+++ b/src/snippets_test.js
@@ -324,16 +324,16 @@ module.exports = {
         editor.insertSnippet("{$1}");
 
         // check first snippet's marker
-        assert.equal(JSON.stringify(editor.session.$backMarkers[3].range.start), JSON.stringify({row: 0, column: 2}));
-        assert.equal(JSON.stringify(editor.session.$backMarkers[4].range.start), JSON.stringify({row: 0, column: 1}));
-
-        editor.insertSnippet("\"examples\": [$1]");
+        var snippetMarkers = Object.values(editor.session.$backMarkers).filter(function(i) {return i.clazz == "ace_snippet-marker";});
+        assert.jsonEquals(snippetMarkers[0].range.start, {row: 0, column: 2});
+        assert.jsonEquals(snippetMarkers[1].range.start, {row: 0, column: 1});
 
         // check markers after insertion of the second snippet
-        assert.equal(editor.session.$backMarkers[3], undefined);
-        assert.equal(editor.session.$backMarkers[4], undefined);
-        assert.equal(JSON.stringify(editor.session.$backMarkers[5].range.start), JSON.stringify({row: 0, column: 15}));
-        assert.equal(JSON.stringify(editor.session.$backMarkers[6].range.start), JSON.stringify({row: 0, column: 14}));
+        editor.insertSnippet("\"examples\": [$1]");
+        snippetMarkers = Object.values(editor.session.$backMarkers).filter(function(i) {return i.clazz == "ace_snippet-marker";});
+        assert.equal(snippetMarkers.length, 2);
+        assert.jsonEquals(snippetMarkers[0].range.start, {row: 0, column: 15});
+        assert.jsonEquals(snippetMarkers[1].range.start, {row: 0, column: 14});
     },
     "test: linking": function() {
         var editor = this.editor;

--- a/src/snippets_test.js
+++ b/src/snippets_test.js
@@ -318,6 +318,23 @@ module.exports = {
         testTabstop(tabstops[4], "[5/3]> [5/3],[2/3]> [2/3]");
         testTabstop(tabstops[5], "[6/2]> [6/5]");
     },
+    "test: insert snippet inside snippet and check markers": function() {
+        var editor = this.editor;
+        editor.session.setValue("");
+        editor.insertSnippet("{$1}");
+
+        // check first snippet's marker
+        assert.equal(JSON.stringify(editor.session.$backMarkers[3].range.start), JSON.stringify({row: 0, column: 2}));
+        assert.equal(JSON.stringify(editor.session.$backMarkers[4].range.start), JSON.stringify({row: 0, column: 1}));
+
+        editor.insertSnippet("\"examples\": [$1]");
+
+        // check markers after insertion of the second snippet
+        assert.equal(editor.session.$backMarkers[3], undefined);
+        assert.equal(editor.session.$backMarkers[4], undefined);
+        assert.equal(JSON.stringify(editor.session.$backMarkers[5].range.start), JSON.stringify({row: 0, column: 15}));
+        assert.equal(JSON.stringify(editor.session.$backMarkers[6].range.start), JSON.stringify({row: 0, column: 14}));
+    },
     "test: linking": function() {
         var editor = this.editor;
         editor.setOption("enableMultiselect", false);


### PR DESCRIPTION
*Issue #, if available:*
Snippet markers continue as cascading:



https://github.com/ajaxorg/ace/assets/12100596/dadc9c50-2175-464b-99a6-952d9c0ae817




*Description of changes:*

In every tab next, adds markers only to the current snippet's tabstops.




https://github.com/ajaxorg/ace/assets/12100596/1d69051f-934a-48e0-84a3-abb367e99c18




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
