### PR TITLE
fix: switch red/blue in cloudeditor themes

### DIFF
--- a/src/theme/cloud_editor-css.js
+++ b/src/theme/cloud_editor-css.js
@@ -76,7 +76,7 @@ module.exports = `
 }
 
 .ace-cloud_editor .ace_meta.ace_tag {
-    color: #d1000a;
+    color: #2963d6;
 }
 
 .ace-cloud_editor .ace_constant {
@@ -92,7 +92,7 @@ module.exports = `
 }
 
 .ace-cloud_editor .ace_support.ace_function {
-    color: #2963d6;
+    color: #d1000a;
 }
 
 .ace-cloud_editor .ace_support.ace_class {
@@ -105,7 +105,7 @@ module.exports = `
 
 .ace-cloud_editor .ace_invalid.ace_illegal {
     color: #ffffff;
-    background-color: #d1000a;
+    background-color: #2963d6;
 }
 
 .ace-cloud_editor .ace_invalid.ace_deprecated {
@@ -128,7 +128,7 @@ module.exports = `
 }
 
 .ace-cloud_editor .ace_variable {
-    color: #d1000a;
+    color: #2963d6;
 }
 
 .ace-cloud_editor .ace_meta.ace_selector {
@@ -140,22 +140,22 @@ module.exports = `
 }
 
 .ace-cloud_editor .ace_entity.ace_name.ace_function {
-    color: #2963d6;
-}
-
-.ace-cloud_editor .ace_entity.ace_name.ace_tag {
     color: #d1000a;
 }
 
-.ace-cloud_editor .ace_heading {
+.ace-cloud_editor .ace_entity.ace_name.ace_tag {
     color: #2963d6;
+}
+
+.ace-cloud_editor .ace_heading {
+    color: #d1000a;
 }
 
 .ace-cloud_editor .ace_xml-pe {
     color: #a26202;
 }
 .ace-cloud_editor .ace_doctype {
-    color: #d1000a;
+    color: #2963d6;
 }
 
 .ace-cloud_editor .ace_tooltip {

--- a/src/theme/cloud_editor_dark-css.js
+++ b/src/theme/cloud_editor_dark-css.js
@@ -88,7 +88,7 @@ module.exports = `
 }
 
 .ace-cloud_editor_dark .ace_support.ace_function {
-    color: #66b2f0;
+    color: #e96a71;
 }
 
 .ace-cloud_editor_dark .ace_support.ace_class {
@@ -101,7 +101,7 @@ module.exports = `
 
 .ace-cloud_editor_dark .ace_invalid.ace_illegal {
     color: #dcdfe4;
-    background-color: #e96a71;
+    background-color:#66b2f0;
 }
 
 .ace-cloud_editor_dark .ace_invalid.ace_deprecated {
@@ -124,7 +124,7 @@ module.exports = `
 }
 
 .ace-cloud_editor_dark .ace_variable {
-    color: #e96a71;
+    color:#66b2f0;
 }
 
 .ace-cloud_editor_dark .ace_meta.ace_selector {
@@ -136,21 +136,21 @@ module.exports = `
 }
 
 .ace-cloud_editor_dark .ace_entity.ace_name.ace_function {
-    color: #66b2f0;
+    color: #e96a71;
 }
 
 .ace-cloud_editor_dark .ace_entity.ace_name.ace_tag {
-    color: #e96a71;
+    color:#66b2f0;
 }
 .ace-cloud_editor_dark .ace_heading {
-    color: #66b2f0;
+    color: #e96a71;
 }
 
 .ace-cloud_editor_dark .ace_xml-pe {
     color: #e5c383;
 }
 .ace-cloud_editor_dark .ace_doctype {
-    color: #e96a71;
+    color:#66b2f0;
 }
 
 .ace-cloud_editor_dark .ace_entity.ace_name.ace_tag,
@@ -158,7 +158,7 @@ module.exports = `
 .ace-cloud_editor_dark .ace_meta.ace_tag,
 .ace-cloud_editor_dark .ace_string.ace_regexp,
 .ace-cloud_editor_dark .ace_variable {
-    color: #e96a71;
+    color:#66b2f0;
 }
 
 .ace-cloud_editor_dark .ace_tooltip {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Some users reported that the usage of red for variables could be confusing because users associate red with errors in their code. This swaps blue and red in the themes to reduce the usage of red. As a follow-up we could reduces the bright red-ness of our red to reduce the association with errors.


<img width="659" alt="Screenshot 2024-03-01 at 10 51 17" src="https://github.com/ajaxorg/ace/assets/34573235/8cbab326-dc09-4df7-9754-5198b5ac3ff5">
<img width="463" alt="Screenshot 2024-03-01 at 10 51 11" src="https://github.com/ajaxorg/ace/assets/34573235/52bfdd48-2d1d-4ee9-9354-7d190bd459e3">
<img width="652" alt="Screenshot 2024-03-01 at 10 51 01" src="https://github.com/ajaxorg/ace/assets/34573235/a63793e3-dc2a-41c2-92a6-897fc9022d41">
<img width="606" alt="Screenshot 2024-03-01 at 10 40 51" src="https://github.com/ajaxorg/ace/assets/34573235/1206ff0f-fa2d-4539-b536-62d7adc27a90">
<img width="686" alt="Screenshot 2024-03-01 at 10 39 32" src="https://github.com/ajaxorg/ace/assets/34573235/15df4af6-8d96-42ab-a1b1-b063a9598603">
<img width="651" alt="Screenshot 2024-03-01 at 10 38 29" src="https://github.com/ajaxorg/ace/assets/34573235/cca1dc0d-fdd8-4e7c-810d-dc805049222e">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
