### PR TITLE
Fix typecheck error with typescript >= 5.4.0

### DIFF
--- a/src/multi_select.js
+++ b/src/multi_select.js
@@ -480,9 +480,9 @@ var Editor = require("./editor").Editor;
 
     /** 
      * Executes a command for each selection range.
-     * @param {Object} cmd The command to execute
+     * @param {any} cmd The command to execute
      * @param {String} [args] Any arguments for the command
-     * @param {Object} [options]
+     * @param {Object|true} [options]
      * @this {Editor}
      **/ 
     this.forEachSelection = function(cmd, args, options) {


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
This change will fix a strange bug that occurs when leaving `@param {Object} [options]`. This causes the newer versions of TypeScript to ignore the type in the `@this` directive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
