### PR TITLE
build: pin typescript version to fix typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "eslint": "^8.20.0",
         "istanbul": "^0.4.5",
         "standard-version": "^9.3.2",
-        "typescript": "^5.2.2"
+        "typescript": "~5.2.2"
     },
     "mappings": {
         "ace": "."


### PR DESCRIPTION
*Issue #, if available:*
#5505 

*Description of changes:*
Pin Typescript version to only allow `5.2.x`. Using `5.4.x` causes `npm run typecheck` to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
