### PR TITLE
fix: SwiftHighlightRules exports

### DIFF
--- a/src/mode/swift_highlight_rules.js
+++ b/src/mode/swift_highlight_rules.js
@@ -166,4 +166,5 @@ var SwiftHighlightRules = function() {
 
 oop.inherits(SwiftHighlightRules, TextHighlightRules);
 
+exports.HighlightRules = SwiftHighlightRules;
 exports.SwiftHighlightRules = SwiftHighlightRules;

--- a/src/mode/swift_highlight_rules.js
+++ b/src/mode/swift_highlight_rules.js
@@ -166,4 +166,4 @@ var SwiftHighlightRules = function() {
 
 oop.inherits(SwiftHighlightRules, TextHighlightRules);
 
-exports.HighlightRules = SwiftHighlightRules;
+exports.SwiftHighlightRules = SwiftHighlightRules;


### PR DESCRIPTION
*Issue #, if available:*

#5511 

*Description of changes:*

Exports `SwiftHighlightRules` according to how we typed it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [X] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

