### PR TITLE
Automate Generation of d.ts for Ace Editor Modes

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,6 +33,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm i
     - run: npm run cover
+    # run linter
     - run: |
         set -x;
         git status;
@@ -50,9 +51,11 @@ jobs:
                 node node_modules/eslint/bin/eslint $jsChanges;
             fi
         fi
-    # - run: npm run lint
+    # check types
+    - run: npm run update-types
     - run: node_modules/.bin/tsc --noImplicitAny --strict --noUnusedLocals --noImplicitReturns --noUnusedParameters --noImplicitThis ace.d.ts
     - run: npm run typecheck
+    - run: git diff --exit-code ./ace-modes.d.ts ./ace.d.ts
     - uses: codecov/codecov-action@v3
       with:
         token: d8edca4b-8e97-41e5-b54e-34c7cf3b2d47

--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -1384,6 +1384,7 @@ declare module "ace-code/src/mode/swift" {
 
 declare module "ace-code/src/mode/swift_highlight_rules" {
     export const HighlightRules: new () => import(".").Ace.HighlightRules;
+    export const SwiftHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
 declare module "ace-code/src/mode/tcl" {

--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -1,1149 +1,1683 @@
-declare module "ace-code/src/mode/matching_brace_outdent" {
-  export const MatchingBraceOutdent: new () => import(".").Ace.Outdent;
-}
-declare module "ace-code/src/mode/matching_parens_outdent" {
-  export const MatchingParensOutdent: new () => import(".").Ace.Outdent;
+declare module "ace-code/src/mode/abap" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
+declare module "ace-code/src/mode/abap_highlight_rules" {
+    export const AbapHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/abc" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/abc_highlight_rules" {
+    export const ABCHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/actionscript" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/actionscript_highlight_rules" {
+    export const ActionScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/ada" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/ada_highlight_rules" {
+    export const AdaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/alda" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/alda_highlight_rules" {
+    export const AldaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/apache_conf" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/apache_conf_highlight_rules" {
+    export const ApacheConfHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/apex" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/apex_highlight_rules" {
+    export const ApexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/applescript" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/applescript_highlight_rules" {
+    export const AppleScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/aql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/aql_highlight_rules" {
+    export const AqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/asciidoc" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/asciidoc_highlight_rules" {
+    export const AsciidocHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/asl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/asl_highlight_rules" {
+    export const ASLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/assembly_arm32" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/assembly_arm32_highlight_rules" {
+    export const AssemblyARM32HighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/assembly_x86" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/assembly_x86_highlight_rules" {
+    export const AssemblyX86HighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/astro" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/astro_highlight_rules" {
+    export const AstroHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/autohotkey" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/autohotkey_highlight_rules" {
+    export const AutoHotKeyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/batchfile" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/batchfile_highlight_rules" {
+    export const BatchFileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
 
 declare module "ace-code/src/mode/behaviour" {
-  export const Behaviour: new () => import(".").Ace.Behaviour;
-}
-declare module "ace-code/src/mode/behaviour/css" {
-  export const CssBehaviour: new () => import(".").Ace.Behaviour;
-}
-declare module "ace-code/src/mode/behaviour/cstyle" {
-  export const CstyleBehaviour: new () => import(".").Ace.Behaviour;
-}
-declare module "ace-code/src/mode/behaviour/html" {
-  export const HtmlBehaviour: new () => import(".").Ace.Behaviour;
-}
-declare module "ace-code/src/mode/behaviour/liquid" {
-  export const LiquidBehaviour: new () => import(".").Ace.Behaviour;
-}
-declare module "ace-code/src/mode/behaviour/xml" {
-  export const XmlBehaviour: new () => import(".").Ace.Behaviour;
-}
-declare module "ace-code/src/mode/behaviour/xquery" {
-  export const XQueryBehaviour: new () => import(".").Ace.Behaviour;
+    export const Behaviour: new () => import(".").Ace.Behaviour;
 }
 
+declare module "ace-code/src/mode/bibtex" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/bibtex_highlight_rules" {
+    export const BibTeXHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/c9search" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/c9search_highlight_rules" {
+    export const C9SearchHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/cirru" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/cirru_highlight_rules" {
+    export const CirruHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/clojure" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/clojure_highlight_rules" {
+    export const ClojureHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/cobol" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/cobol_highlight_rules" {
+    export const CobolHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/coffee" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/coffee_highlight_rules" {
+    export const CoffeeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/coldfusion" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/coldfusion_highlight_rules" {
+    export const ColdfusionHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/crystal" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/crystal_highlight_rules" {
+    export const CrystalHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/csharp" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/csharp_highlight_rules" {
+    export const CSharpHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/csound_document" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/csound_document_highlight_rules" {
+    export const CsoundDocumentHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/csound_orchestra" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/csound_orchestra_highlight_rules" {
+    export const CsoundOrchestraHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/csound_preprocessor_highlight_rules" {
+    export const CsoundPreprocessorHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/csound_score" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/csound_score_highlight_rules" {
+    export const CsoundScoreHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/csp" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/csp_highlight_rules" {
+    export const CspHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/css" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/css_completions" {
+    export const CssCompletions: new () => import(".").Ace.Completion;
+}
+
+declare module "ace-code/src/mode/css_highlight_rules" {
+    export const supportType: string;
+    export const supportFunction: string;
+    export const supportConstant: string;
+    export const supportConstantColor: string;
+    export const supportConstantFonts: string;
+    export const numRe: string;
+    export const pseudoElements: string;
+    export const pseudoClasses: string;
+    export const CssHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/curly" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/curly_highlight_rules" {
+    export const CurlyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/cuttlefish" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/cuttlefish_highlight_rules" {
+    export const CuttlefishHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/c_cpp" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/c_cpp_highlight_rules" {
+    export const cFunctions: string;
+    export const c_cppHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/d" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/dart" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/dart_highlight_rules" {
+    export const DartHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/diff" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/diff_highlight_rules" {
+    export const DiffHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/django" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/dockerfile" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/dockerfile_highlight_rules" {
+    export const DockerfileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/doc_comment_highlight_rules" {
+    export const DocCommentHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/dot" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/dot_highlight_rules" {
+    export const DotHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/drools" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/drools_highlight_rules" {
+    export const DroolsHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/d_highlight_rules" {
+    export const DHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/edifact" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/edifact_highlight_rules" {
+    export const EdifactHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/eiffel" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/eiffel_highlight_rules" {
+    export const EiffelHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/ejs" {
+    export const EjsHighlightRules: new () => import(".").Ace.HighlightRules;
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/elixir" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/elixir_highlight_rules" {
+    export const ElixirHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/elm" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/elm_highlight_rules" {
+    export const ElmHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/erlang" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/erlang_highlight_rules" {
+    export const ErlangHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/flix" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/flix_highlight_rules" {
+    export const FlixHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/forth" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/forth_highlight_rules" {
+    export const ForthHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/fortran" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/fortran_highlight_rules" {
+    export const FortranHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/fsharp" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/fsharp_highlight_rules" {
+    export const FSharpHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/fsl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/fsl_highlight_rules" {
+    export const FSLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/ftl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/ftl_highlight_rules" {
+    export const FtlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/gcode" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/gcode_highlight_rules" {
+    export const GcodeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/gherkin" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/gherkin_highlight_rules" {
+    export const GherkinHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/gitignore" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/gitignore_highlight_rules" {
+    export const GitignoreHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/glsl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/glsl_highlight_rules" {
+    export const glslHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/gobstones" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/gobstones_highlight_rules" {
+    export const GobstonesHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/golang" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/golang_highlight_rules" {
+    export const GolangHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/graphqlschema" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/graphqlschema_highlight_rules" {
+    export const GraphQLSchemaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/groovy" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/groovy_highlight_rules" {
+    export const GroovyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/haml" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/haml_highlight_rules" {
+    export const HamlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/handlebars" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/handlebars_highlight_rules" {
+    export const HandlebarsHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/haskell" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/haskell_cabal" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/haskell_cabal_highlight_rules" {
+    export const CabalHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/haskell_highlight_rules" {
+    export const HaskellHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/haxe" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/haxe_highlight_rules" {
+    export const HaxeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/hjson" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/hjson_highlight_rules" {
+    export const HjsonHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/html" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/html_completions" {
+    export const HtmlCompletions: new () => import(".").Ace.Completion;
+}
+
+declare module "ace-code/src/mode/html_elixir" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/html_elixir_highlight_rules" {
+    export const HtmlElixirHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/html_highlight_rules" {
+    export const HtmlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/html_ruby" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/html_ruby_highlight_rules" {
+    export const HtmlRubyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/ini" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/ini_highlight_rules" {
+    export const IniHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/io" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/ion" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/ion_highlight_rules" {
+    export const IonHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/io_highlight_rules" {
+    export const IoHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/jack" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/jack_highlight_rules" {
+    export const JackHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/jade" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/jade_highlight_rules" {
+    export const JadeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/java" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/javascript" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/javascript_highlight_rules" {
+    export const JavaScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/java_highlight_rules" {
+    export const JavaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/jexl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/jexl_highlight_rules" {
+    export const JexlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/jsdoc_comment_highlight_rules" {
+    export const JsDocCommentHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/json" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/json5" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/json5_highlight_rules" {
+    export const Json5HighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/json_highlight_rules" {
+    export const JsonHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/jsp" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/jsp_highlight_rules" {
+    export const JspHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/jssm" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/jssm_highlight_rules" {
+    export const JSSMHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/jsx" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/jsx_highlight_rules" {
+    export const JsxHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/js_regex_highlight_rules" {
+    export const JsRegexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/julia" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/julia_highlight_rules" {
+    export const JuliaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/kotlin" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/kotlin_highlight_rules" {
+    export const KotlinHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/latex" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/latex_highlight_rules" {
+    export const LatexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/latte" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/latte_highlight_rules" {
+    export const LatteHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/less" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/less_highlight_rules" {
+    export const LessHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/liquid" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/liquid_highlight_rules" {
+    export const LiquidHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/lisp" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/lisp_highlight_rules" {
+    export const LispHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/livescript" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/logiql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/logiql_highlight_rules" {
+    export const LogiQLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/logtalk" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/logtalk_highlight_rules" {
+    export const LogtalkHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/lsl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/lsl_highlight_rules" {
+    export const LSLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/lua" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/luapage" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/luapage_highlight_rules" {
+    export const LuaPageHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/lua_highlight_rules" {
+    export const LuaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/lucene" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/lucene_highlight_rules" {
+    export const LuceneHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/makefile" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/makefile_highlight_rules" {
+    export const MakefileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/markdown" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/markdown_highlight_rules" {
+    export const MarkdownHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/mask" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/mask_highlight_rules" {
+    export const MaskHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/matching_brace_outdent" {
+    export const MatchingBraceOutdent: new () => import(".").Ace.Outdent;
+}
+
+declare module "ace-code/src/mode/matching_parens_outdent" {
+    export const MatchingParensOutdent: new () => import(".").Ace.Outdent;
+}
+
+declare module "ace-code/src/mode/matlab" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/matlab_highlight_rules" {
+    export const MatlabHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/maze" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/maze_highlight_rules" {
+    export const MazeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/mediawiki" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/mediawiki_highlight_rules" {
+    export const MediaWikiHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/mel" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/mel_highlight_rules" {
+    export const MELHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/mips" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/mips_highlight_rules" {
+    export const MIPSHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/mixal" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/mixal_highlight_rules" {
+    export const MixalHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/mushcode" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/mushcode_highlight_rules" {
+    export const MushCodeRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/mysql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/mysql_highlight_rules" {
+    export const MysqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/nasal" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/nasal_highlight_rules" {
+    export const NasalHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/nginx" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/nginx_highlight_rules" {
+    export const NginxHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/nim" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/nim_highlight_rules" {
+    export const NimHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/nix" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/nix_highlight_rules" {
+    export const NixHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/nsis" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/nsis_highlight_rules" {
+    export const NSISHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/nunjucks" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/nunjucks_highlight_rules" {
+    export const NunjucksHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/objectivec" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/objectivec_highlight_rules" {
+    export const ObjectiveCHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/ocaml" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/ocaml_highlight_rules" {
+    export const OcamlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/odin" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/odin_highlight_rules" {
+    export const OdinHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/partiql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/partiql_highlight_rules" {
+    export const PartiqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/pascal" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/pascal_highlight_rules" {
+    export const PascalHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/perl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/perl_highlight_rules" {
+    export const PerlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/pgsql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/pgsql_highlight_rules" {
+    export const PgsqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/php" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/php_completions" {
+    export const PhpCompletions: new () => import(".").Ace.Completion;
+}
+
+declare module "ace-code/src/mode/php_highlight_rules" {
+    export const PhpHighlightRules: new () => import(".").Ace.HighlightRules;
+    export const PhpLangHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/php_laravel_blade" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/php_laravel_blade_highlight_rules" {
+    export const PHPLaravelBladeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/pig" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/pig_highlight_rules" {
+    export const PigHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/plain_text" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/plsql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/plsql_highlight_rules" {
+    export const plsqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/powershell" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/powershell_highlight_rules" {
+    export const PowershellHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/praat" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/praat_highlight_rules" {
+    export const PraatHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/prisma" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/prisma_highlight_rules" {
+    export const PrismaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/prolog" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/prolog_highlight_rules" {
+    export const PrologHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/properties" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/properties_highlight_rules" {
+    export const PropertiesHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/protobuf" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/protobuf_highlight_rules" {
+    export const ProtobufHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/prql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/prql_highlight_rules" {
+    export const PrqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/puppet" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/puppet_highlight_rules" {
+    export const PuppetHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/python" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/python_highlight_rules" {
+    export const PythonHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/qml" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/qml_highlight_rules" {
+    export const QmlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/r" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/raku" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/raku_highlight_rules" {
+    export const RakuHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/razor" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/razor_completions" {
+    export const RazorCompletions: new () => import(".").Ace.Completion;
+}
+
+declare module "ace-code/src/mode/razor_highlight_rules" {
+    export const RazorHighlightRules: new () => import(".").Ace.HighlightRules;
+    export const RazorLangHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/rdoc" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/rdoc_highlight_rules" {
+    export const RDocHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/red" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/redshift" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/redshift_highlight_rules" {
+    export const RedshiftHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/red_highlight_rules" {
+    export const RedHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/rhtml" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/rhtml_highlight_rules" {
+    export const RHtmlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/robot" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/robot_highlight_rules" {
+    export const RobotHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/rst" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/rst_highlight_rules" {
+    export const RSTHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/ruby" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/ruby_highlight_rules" {
+    export const constantOtherSymbol: { token: string; regex: string; };
+    export const qString: { token: string; regex: string; };
+    export const qqString: { token: string; regex: string; };
+    export const tString: { token: string; regex: string; };
+    export const constantNumericHex: { token: string; regex: string; };
+    export const constantNumericBinary: { token: string; regex: RegExp; };
+    export const constantNumericDecimal: { token: string; regex: RegExp; };
+    export const constantNumericDecimal: { token: string; regex: RegExp; };
+    export const constantNumericRational: { token: string; regex: RegExp; };
+    export const constantNumericComplex: { token: string; regex: RegExp; };
+    export const constantNumericFloat: { token: string; regex: string; };
+    export const instanceVariable: { token: string; regex: string; };
+    export const RubyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/rust" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/rust_highlight_rules" {
+    export const RustHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/r_highlight_rules" {
+    export const RHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/sac" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/sac_highlight_rules" {
+    export const sacHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/sass" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/sass_highlight_rules" {
+    export const SassHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/scad" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/scad_highlight_rules" {
+    export const scadHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/scala" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/scala_highlight_rules" {
+    export const ScalaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/scheme" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/scheme_highlight_rules" {
+    export const SchemeHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/scrypt" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/scrypt_highlight_rules" {
+    export const scryptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/scss" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/scss_highlight_rules" {
+    export const ScssHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/sh" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/sh_highlight_rules" {
+    export const reservedKeywords: string;
+    export const languageConstructs: string;
+    export const ShHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/sjs" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/sjs_highlight_rules" {
+    export const SJSHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/slim" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/slim_highlight_rules" {
+    export const SlimHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/smarty" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/smarty_highlight_rules" {
+    export const SmartyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/smithy" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/smithy_highlight_rules" {
+    export const SmithyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/snippets" {
+    export const SnippetHighlightRules: new () => import(".").Ace.HighlightRules;
+    export const SnippetGroupHighlightRules: new () => import(".").Ace.HighlightRules;
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/soy_template" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/soy_template_highlight_rules" {
+    export const SoyTemplateHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/space" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/space_highlight_rules" {
+    export const SpaceHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/sparql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/sparql_highlight_rules" {
+    export const SPARQLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/sql" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/sqlserver" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/sqlserver_highlight_rules" {
+    export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/sql_highlight_rules" {
+    export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/stylus" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/stylus_highlight_rules" {
+    export const StylusHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/svg" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/svg_highlight_rules" {
+    export const SvgHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/swift" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/swift_highlight_rules" {
+    export const HighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/tcl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/tcl_highlight_rules" {
+    export const TclHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/terraform" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/terraform_highlight_rules" {
+    export const TerraformHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/tex" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/text" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/textile" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/textile_highlight_rules" {
+    export const TextileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/text_highlight_rules" {
+    export const TextHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/tex_highlight_rules" {
+    export const TexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/toml" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/toml_highlight_rules" {
+    export const TomlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/tsx" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/tsx_highlight_rules" {
+    export const TsxHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/turtle" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/turtle_highlight_rules" {
+    export const TurtleHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/twig" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/twig_highlight_rules" {
+    export const TwigHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/typescript" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/typescript_highlight_rules" {
+    export const TypeScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/vala" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/vala_highlight_rules" {
+    export const ValaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/vbscript" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/vbscript_highlight_rules" {
+    export const VBScriptHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/velocity" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/velocity_highlight_rules" {
+    export const VelocityHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/verilog" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/verilog_highlight_rules" {
+    export const VerilogHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/vhdl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/vhdl_highlight_rules" {
+    export const VHDLHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/visualforce" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/visualforce_highlight_rules" {
+    export const VisualforceHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/vue" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/vue_highlight_rules" {
+    export const VueHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/wollok" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/wollok_highlight_rules" {
+    export const WollokHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/xml" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/xml_highlight_rules" {
+    export const XmlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/yaml" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/yaml_highlight_rules" {
+    export const YamlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/zeek" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/zeek_highlight_rules" {
+    export const ZeekHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/zig" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/zig_highlight_rules" {
+    export const ZigHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/behaviour/css" {
+    export const CssBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/cstyle" {
+    export const CstyleBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/html" {
+    export const HtmlBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/liquid" {
+    export const LiquidBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/xml" {
+    export const XmlBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/xquery" {
+    export const XQueryBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/folding/asciidoc" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/c9search" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/coffee" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/csharp" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/cstyle" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/diff" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/drools" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
 
 declare module "ace-code/src/mode/folding/fold_mode" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
-declare module "ace-code/src/mode/folding/asciidoc" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
-}
-declare module "ace-code/src/mode/folding/c9search" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
-}
-declare module "ace-code/src/mode/folding/coffee" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
-}
-declare module "ace-code/src/mode/folding/csharp" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
-}
-declare module "ace-code/src/mode/folding/cstyle" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
-}
-declare module "ace-code/src/mode/folding/diff" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
-}
-declare module "ace-code/src/mode/folding/drools" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
-}
+
 declare module "ace-code/src/mode/folding/haskell_cabal" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/html" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/ini" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/java" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/latex" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/lua" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/markdown" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/mixed" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/pythonic" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/ruby" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/sql" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/sqlserver" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/vbscript" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/velocity" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
+
 declare module "ace-code/src/mode/folding/xml" {
-  export const FoldMode: new () => import(".").Ace.FoldMode;
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
 
-
-declare module "ace-code/src/mode/abap" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/abap_highlight_rules" {
-  export const AbapHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/abc" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/abc_highlight_rules" {
-  export const ABCHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/actionscript" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/actionscript_highlight_rules" {
-  export const ActionScriptHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/ada" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/ada_highlight_rules" {
-  export const AdaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/alda" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/alda_highlight_rules" {
-  export const AldaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/apache_conf" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/apache_conf_highlight_rules" {
-  export const ApacheConfHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/apex" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/apex_highlight_rules" {
-  export const ApexHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/aql" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/aql_highlight_rules" {
-  export const AqlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/asciidoc" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/asciidoc_highlight_rules" {
-  export const AsciidocHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/asl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/asl_highlight_rules" {
-  export const ASLHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/assembly_x86" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/assembly_x86_highlight_rules" {
-  export const AssemblyX86HighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/autohotkey" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/autohotkey_highlight_rules" {
-  export const AutoHotKeyHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/batchfile" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/batchfile_highlight_rules" {
-  export const BatchFileHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/bibtex" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/bibtex_highlight_rules" {
-  export const BibTeXHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/c_cpp" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/c_cpp_highlight_rules" {
-  export const c_cppHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/c9search" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/c9search_highlight_rules" {
-  export const C9SearchHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/cirru" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/cirru_highlight_rules" {
-  export const CirruHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/clojure" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/clojure_highlight_rules" {
-  export const ClojureHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/cobol" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/cobol_highlight_rules" {
-  export const CobolHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/coffee" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/coffee_highlight_rules" {
-  export const CoffeeHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/coldfusion" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/coldfusion_highlight_rules" {
-  export const ColdfusionHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/crystal" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/crystal_highlight_rules" {
-  export const CrystalHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/csharp" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/csharp_highlight_rules" {
-  export const CSharpHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/csound_document" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/csound_document_highlight_rules" {
-  export const CsoundDocumentHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/csound_orchestra" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/csound_orchestra_highlight_rules" {
-  export const CsoundOrchestraHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/csound_score" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/csound_score_highlight_rules" {
-  export const CsoundScoreHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/css" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/css_highlight_rules" {
-  export const CssHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/curly" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/curly_highlight_rules" {
-  export const CurlyHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/d" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/d_highlight_rules" {
-  export const DHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/dart" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/dart_highlight_rules" {
-  export const DartHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/diff" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/diff_highlight_rules" {
-  export const DiffHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/dockerfile" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/dockerfile_highlight_rules" {
-  export const DockerfileHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/dot" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/dot_highlight_rules" {
-  export const DotHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/drools" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/drools_highlight_rules" {
-  export const DroolsHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/edifact" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/edifact_highlight_rules" {
-  export const EdifactHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/eiffel" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/eiffel_highlight_rules" {
-  export const EiffelHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/ejs" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/ejs_highlight_rules" {
-  export const EjsHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/elixir" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/elixir_highlight_rules" {
-  export const ElixirHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/elm" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/elm_highlight_rules" {
-  export const ElmHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/erlang" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/erlang_highlight_rules" {
-  export const ErlangHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/flix" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/flix_highlight_rules" {
-  export const FlixHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/forth" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/forth_highlight_rules" {
-  export const ForthHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/fortran" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/fortran_highlight_rules" {
-  export const FortranHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/fsharp" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/fsharp_highlight_rules" {
-  export const FSharpHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/fsl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/fsl_highlight_rules" {
-  export const FSLHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/ftl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/ftl_highlight_rules" {
-  export const FtlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/gcode" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/gcode_highlight_rules" {
-  export const GcodeHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/gherkin" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/gherkin_highlight_rules" {
-  export const GherkinHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/gitignore" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/gitignore_highlight_rules" {
-  export const GitignoreHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/glsl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/glsl_highlight_rules" {
-  export const glslHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/gobstones" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/gobstones_highlight_rules" {
-  export const GobstonesHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/golang" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/golang_highlight_rules" {
-  export const GolangHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/graphqlschema" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/graphqlschema_highlight_rules" {
-  export const GraphQLSchemaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/groovy" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/groovy_highlight_rules" {
-  export const GroovyHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/haml" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/haml_highlight_rules" {
-  export const HamlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/handlebars" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/handlebars_highlight_rules" {
-  export const HandlebarsHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/haskell" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/haskell_highlight_rules" {
-  export const HaskellHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/haskell_cabal" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/haskell_cabal_highlight_rules" {
-  export const CabalHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/haxe" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/haxe_highlight_rules" {
-  export const HaxeHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/hjson" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/hjson_highlight_rules" {
-  export const HjsonHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/html" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/html_highlight_rules" {
-  export const HtmlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/html_elixir" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/html_elixir_highlight_rules" {
-  export const HtmlElixirHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/html_ruby" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/html_ruby_highlight_rules" {
-  export const HtmlRubyHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/ini" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/ini_highlight_rules" {
-  export const IniHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/io" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/io_highlight_rules" {
-  export const IoHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/ion" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/ion_highlight_rules" {
-  export const IonHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/jack" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/jack_highlight_rules" {
-  export const JackHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/jade" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/jade_highlight_rules" {
-  export const JadeHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/java" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/java_highlight_rules" {
-  export const JavaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/javascript" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/javascript_highlight_rules" {
-  export const JavaScriptHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/jexl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/jexl_highlight_rules" {
-  export const JexlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/json" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/json_highlight_rules" {
-  export const JsonHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/json5" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/json5_highlight_rules" {
-  export const Json5HighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/jsp" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/jsp_highlight_rules" {
-  export const JspHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/jssm" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/jssm_highlight_rules" {
-  export const JSSMHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/jsx" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/julia" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/julia_highlight_rules" {
-  export const JuliaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/kotlin" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/kotlin_highlight_rules" {
-  export const KotlinHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/latex" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/latex_highlight_rules" {
-  export const LatexHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/latte" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/latte_highlight_rules" {
-  export const LatteHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/less" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/less_highlight_rules" {
-  export const LessHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/liquid" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/liquid_highlight_rules" {
-  export const LiquidHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/lisp" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/lisp_highlight_rules" {
-  export const LispHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/livescript" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/logiql" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/logiql_highlight_rules" {
-  export const LogiQLHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/logtalk" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/logtalk_highlight_rules" {
-  export const LogtalkHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/lsl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/lsl_highlight_rules" {
-  export const LSLHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/lua" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/lua_highlight_rules" {
-  export const LuaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/luapage" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/luapage_highlight_rules" {
-  export const LuaPageHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/lucene" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/lucene_highlight_rules" {
-  export const LuceneHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/makefile" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/makefile_highlight_rules" {
-  export const MakefileHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/markdown" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/markdown_highlight_rules" {
-  export const MarkdownHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/mask" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/mask_highlight_rules" {
-  export const MaskHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/matlab" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/matlab_highlight_rules" {
-  export const MatlabHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/maze" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/maze_highlight_rules" {
-  export const MazeHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/mediawiki" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/mediawiki_highlight_rules" {
-  export const MediaWikiHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/mel" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/mel_highlight_rules" {
-  export const MELHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/mips" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/mips_highlight_rules" {
-  export const MIPSHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/mixal" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/mixal_highlight_rules" {
-  export const MixalHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/mushcode" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/mushcode_highlight_rules" {
-  export const MushCodeRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/mysql" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/mysql_highlight_rules" {
-  export const MysqlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/nginx" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/nginx_highlight_rules" {
-  export const NginxHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/nim" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/nim_highlight_rules" {
-  export const NimHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/nix" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/nix_highlight_rules" {
-  export const NixHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/nsis" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/nsis_highlight_rules" {
-  export const NSISHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/nunjucks" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/nunjucks_highlight_rules" {
-  export const NunjucksHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/objectivec" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/objectivec_highlight_rules" {
-  export const ObjectiveCHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/ocaml" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/ocaml_highlight_rules" {
-  export const OcamlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/partiql" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/partiql_highlight_rules" {
-  export const PartiqlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/pascal" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/pascal_highlight_rules" {
-  export const PascalHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/perl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/perl_highlight_rules" {
-  export const PerlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/pgsql" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/pgsql_highlight_rules" {
-  export const PgsqlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/php" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/php_highlight_rules" {
-  export const PhpHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/php_laravel_blade" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/php_laravel_blade_highlight_rules" {
-  export const PHPLaravelBladeHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/pig" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/pig_highlight_rules" {
-  export const PigHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/plsql" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/plsql_highlight_rules" {
-  export const plsqlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/powershell" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/powershell_highlight_rules" {
-  export const PowershellHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/praat" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/praat_highlight_rules" {
-  export const PraatHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/prisma" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/prisma_highlight_rules" {
-  export const PrismaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/prolog" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/prolog_highlight_rules" {
-  export const PrologHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/properties" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/properties_highlight_rules" {
-  export const PropertiesHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/protobuf" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/protobuf_highlight_rules" {
-  export const ProtobufHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/puppet" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/puppet_highlight_rules" {
-  export const PuppetHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/python" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/python_highlight_rules" {
-  export const PythonHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/qml" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/qml_highlight_rules" {
-  export const QmlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/r" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/r_highlight_rules" {
-  export const RHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/raku" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/raku_highlight_rules" {
-  export const RakuHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/razor" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/razor_highlight_rules" {
-  export const RazorHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/rdoc" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/rdoc_highlight_rules" {
-  export const RDocHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/red" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/red_highlight_rules" {
-  export const RedHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/rhtml" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/rhtml_highlight_rules" {
-  export const RHtmlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/robot" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/robot_highlight_rules" {
-  export const RobotHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/rst" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/rst_highlight_rules" {
-  export const RSTHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/ruby" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/ruby_highlight_rules" {
-  export const RubyHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/rust" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/rust_highlight_rules" {
-  export const RustHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/sac" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/sac_highlight_rules" {
-  export const sacHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/sass" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/sass_highlight_rules" {
-  export const SassHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/scad" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/scad_highlight_rules" {
-  export const scadHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/scala" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/scala_highlight_rules" {
-  export const ScalaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/scheme" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/scheme_highlight_rules" {
-  export const SchemeHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/scrypt" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/scrypt_highlight_rules" {
-  export const scryptHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/scss" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/scss_highlight_rules" {
-  export const ScssHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/sh" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/sh_highlight_rules" {
-  export const ShHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/sjs" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/sjs_highlight_rules" {
-  export const SJSHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/slim" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/slim_highlight_rules" {
-  export const SlimHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/smarty" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/smarty_highlight_rules" {
-  export const SmartyHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/smithy" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/smithy_highlight_rules" {
-  export const SmithyHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/snippets" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/soy_template" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/soy_template_highlight_rules" {
-  export const SoyTemplateHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/space" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/space_highlight_rules" {
-  export const SpaceHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/sparql" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/sparql_highlight_rules" {
-  export const SPARQLHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/sql" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/sql_highlight_rules" {
-  export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/sqlserver" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/sqlserver_highlight_rules" {
-  export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/stylus" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/stylus_highlight_rules" {
-  export const StylusHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/svg" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/svg_highlight_rules" {
-  export const SvgHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/swift" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/swift_highlight_rules" {
-  export const SwiftHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/tcl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/tcl_highlight_rules" {
-  export const TclHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/terraform" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/terraform_highlight_rules" {
-  export const TerraformHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/tex" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/tex_highlight_rules" {
-  export const TexHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/text" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/text_highlight_rules" {
-  export const TextHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/textile" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/textile_highlight_rules" {
-  export const TextileHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/toml" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/toml_highlight_rules" {
-  export const TomlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/tsx" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/turtle" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/turtle_highlight_rules" {
-  export const TurtleHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/twig" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/twig_highlight_rules" {
-  export const TwigHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/typescript" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/typescript_highlight_rules" {
-  export const TypeScriptHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/vala" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/vala_highlight_rules" {
-  export const ValaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/vbscript" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/vbscript_highlight_rules" {
-  export const VBScriptHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/velocity" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/velocity_highlight_rules" {
-  export const VelocityHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/verilog" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/verilog_highlight_rules" {
-  export const VerilogHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/vhdl" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/vhdl_highlight_rules" {
-  export const VHDLHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/visualforce" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/visualforce_highlight_rules" {
-  export const VisualforceHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/wollok" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/wollok_highlight_rules" {
-  export const WollokHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/xml" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/xml_highlight_rules" {
-  export const XmlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/yaml" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/yaml_highlight_rules" {
-  export const YamlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/zeek" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-declare module "ace-code/src/mode/zeek_highlight_rules" {
-  export const ZeekHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-declare module "ace-code/src/mode/django" {
-  export const Mode: new () => import(".").Ace.SyntaxMode;
+declare module "ace-code/src/mode/folding/yaml" {
+    export const FoldMode: new () => import(".").Ace.Folding;
 }

--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -1198,7 +1198,7 @@ declare module "ace-code/src/mode/ruby_highlight_rules" {
     export const constantNumericHex: { token: string; regex: string; };
     export const constantNumericBinary: { token: string; regex: RegExp; };
     export const constantNumericDecimal: { token: string; regex: RegExp; };
-    export const constantNumericDecimal: { token: string; regex: RegExp; };
+    export const constantNumericOctal: { token: string; regex: RegExp; };
     export const constantNumericRational: { token: string; regex: RegExp; };
     export const constantNumericComplex: { token: string; regex: RegExp; };
     export const constantNumericFloat: { token: string; regex: string; };

--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -1,12 +1,8 @@
-declare module "ace-code/src/mode/abap" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
 declare module "ace-code/src/mode/abap_highlight_rules" {
     export const AbapHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/abc" {
+declare module "ace-code/src/mode/abap" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -14,7 +10,7 @@ declare module "ace-code/src/mode/abc_highlight_rules" {
     export const ABCHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/actionscript" {
+declare module "ace-code/src/mode/abc" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -22,7 +18,7 @@ declare module "ace-code/src/mode/actionscript_highlight_rules" {
     export const ActionScriptHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/ada" {
+declare module "ace-code/src/mode/actionscript" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -30,7 +26,7 @@ declare module "ace-code/src/mode/ada_highlight_rules" {
     export const AdaHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/alda" {
+declare module "ace-code/src/mode/ada" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -38,7 +34,7 @@ declare module "ace-code/src/mode/alda_highlight_rules" {
     export const AldaHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/apache_conf" {
+declare module "ace-code/src/mode/alda" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -46,7 +42,7 @@ declare module "ace-code/src/mode/apache_conf_highlight_rules" {
     export const ApacheConfHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/apex" {
+declare module "ace-code/src/mode/apache_conf" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -54,7 +50,7 @@ declare module "ace-code/src/mode/apex_highlight_rules" {
     export const ApexHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/applescript" {
+declare module "ace-code/src/mode/apex" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -62,7 +58,7 @@ declare module "ace-code/src/mode/applescript_highlight_rules" {
     export const AppleScriptHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/aql" {
+declare module "ace-code/src/mode/applescript" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -70,7 +66,7 @@ declare module "ace-code/src/mode/aql_highlight_rules" {
     export const AqlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/asciidoc" {
+declare module "ace-code/src/mode/aql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -78,7 +74,7 @@ declare module "ace-code/src/mode/asciidoc_highlight_rules" {
     export const AsciidocHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/asl" {
+declare module "ace-code/src/mode/asciidoc" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -86,7 +82,7 @@ declare module "ace-code/src/mode/asl_highlight_rules" {
     export const ASLHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/assembly_arm32" {
+declare module "ace-code/src/mode/asl" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -94,7 +90,7 @@ declare module "ace-code/src/mode/assembly_arm32_highlight_rules" {
     export const AssemblyARM32HighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/assembly_x86" {
+declare module "ace-code/src/mode/assembly_arm32" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -102,7 +98,7 @@ declare module "ace-code/src/mode/assembly_x86_highlight_rules" {
     export const AssemblyX86HighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/astro" {
+declare module "ace-code/src/mode/assembly_x86" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -110,7 +106,7 @@ declare module "ace-code/src/mode/astro_highlight_rules" {
     export const AstroHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/autohotkey" {
+declare module "ace-code/src/mode/astro" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -118,7 +114,7 @@ declare module "ace-code/src/mode/autohotkey_highlight_rules" {
     export const AutoHotKeyHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/batchfile" {
+declare module "ace-code/src/mode/autohotkey" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -126,19 +122,28 @@ declare module "ace-code/src/mode/batchfile_highlight_rules" {
     export const BatchFileHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/behaviour" {
-    export const Behaviour: new () => import(".").Ace.Behaviour;
+declare module "ace-code/src/mode/batchfile" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/bibtex" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
+declare module "ace-code/src/mode/behaviour" {
+    export const Behaviour: new () => import(".").Ace.Behaviour;
 }
 
 declare module "ace-code/src/mode/bibtex_highlight_rules" {
     export const BibTeXHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/c9search" {
+declare module "ace-code/src/mode/bibtex" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/c_cpp_highlight_rules" {
+    export const cFunctions: string;
+    export const c_cppHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/c_cpp" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -146,7 +151,7 @@ declare module "ace-code/src/mode/c9search_highlight_rules" {
     export const C9SearchHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/cirru" {
+declare module "ace-code/src/mode/c9search" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -154,7 +159,7 @@ declare module "ace-code/src/mode/cirru_highlight_rules" {
     export const CirruHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/clojure" {
+declare module "ace-code/src/mode/cirru" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -162,7 +167,7 @@ declare module "ace-code/src/mode/clojure_highlight_rules" {
     export const ClojureHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/cobol" {
+declare module "ace-code/src/mode/clojure" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -170,7 +175,7 @@ declare module "ace-code/src/mode/cobol_highlight_rules" {
     export const CobolHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/coffee" {
+declare module "ace-code/src/mode/cobol" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -178,7 +183,7 @@ declare module "ace-code/src/mode/coffee_highlight_rules" {
     export const CoffeeHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/coldfusion" {
+declare module "ace-code/src/mode/coffee" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -186,7 +191,7 @@ declare module "ace-code/src/mode/coldfusion_highlight_rules" {
     export const ColdfusionHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/crystal" {
+declare module "ace-code/src/mode/coldfusion" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -194,7 +199,7 @@ declare module "ace-code/src/mode/crystal_highlight_rules" {
     export const CrystalHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/csharp" {
+declare module "ace-code/src/mode/crystal" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -202,7 +207,7 @@ declare module "ace-code/src/mode/csharp_highlight_rules" {
     export const CSharpHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/csound_document" {
+declare module "ace-code/src/mode/csharp" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -210,7 +215,7 @@ declare module "ace-code/src/mode/csound_document_highlight_rules" {
     export const CsoundDocumentHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/csound_orchestra" {
+declare module "ace-code/src/mode/csound_document" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -218,19 +223,19 @@ declare module "ace-code/src/mode/csound_orchestra_highlight_rules" {
     export const CsoundOrchestraHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/csound_preprocessor_highlight_rules" {
-    export const CsoundPreprocessorHighlightRules: new () => import(".").Ace.HighlightRules;
+declare module "ace-code/src/mode/csound_orchestra" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/csound_score" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
+declare module "ace-code/src/mode/csound_preprocessor_highlight_rules" {
+    export const CsoundPreprocessorHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
 declare module "ace-code/src/mode/csound_score_highlight_rules" {
     export const CsoundScoreHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/csp" {
+declare module "ace-code/src/mode/csound_score" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -238,7 +243,7 @@ declare module "ace-code/src/mode/csp_highlight_rules" {
     export const CspHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/css" {
+declare module "ace-code/src/mode/csp" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -258,7 +263,7 @@ declare module "ace-code/src/mode/css_highlight_rules" {
     export const CssHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/curly" {
+declare module "ace-code/src/mode/css" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -266,7 +271,7 @@ declare module "ace-code/src/mode/curly_highlight_rules" {
     export const CurlyHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/cuttlefish" {
+declare module "ace-code/src/mode/curly" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -274,20 +279,15 @@ declare module "ace-code/src/mode/cuttlefish_highlight_rules" {
     export const CuttlefishHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/c_cpp" {
+declare module "ace-code/src/mode/cuttlefish" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/c_cpp_highlight_rules" {
-    export const cFunctions: string;
-    export const c_cppHighlightRules: new () => import(".").Ace.HighlightRules;
+declare module "ace-code/src/mode/d_highlight_rules" {
+    export const DHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
 declare module "ace-code/src/mode/d" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
-declare module "ace-code/src/mode/dart" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -295,7 +295,7 @@ declare module "ace-code/src/mode/dart_highlight_rules" {
     export const DartHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/diff" {
+declare module "ace-code/src/mode/dart" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -303,23 +303,23 @@ declare module "ace-code/src/mode/diff_highlight_rules" {
     export const DiffHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
+declare module "ace-code/src/mode/diff" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
 declare module "ace-code/src/mode/django" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
-declare module "ace-code/src/mode/dockerfile" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
-declare module "ace-code/src/mode/dockerfile_highlight_rules" {
-    export const DockerfileHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
 declare module "ace-code/src/mode/doc_comment_highlight_rules" {
     export const DocCommentHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/dot" {
+declare module "ace-code/src/mode/dockerfile_highlight_rules" {
+    export const DockerfileHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/dockerfile" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -327,7 +327,7 @@ declare module "ace-code/src/mode/dot_highlight_rules" {
     export const DotHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/drools" {
+declare module "ace-code/src/mode/dot" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -335,11 +335,7 @@ declare module "ace-code/src/mode/drools_highlight_rules" {
     export const DroolsHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/d_highlight_rules" {
-    export const DHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/edifact" {
+declare module "ace-code/src/mode/drools" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -347,7 +343,7 @@ declare module "ace-code/src/mode/edifact_highlight_rules" {
     export const EdifactHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/eiffel" {
+declare module "ace-code/src/mode/edifact" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -355,12 +351,12 @@ declare module "ace-code/src/mode/eiffel_highlight_rules" {
     export const EiffelHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/ejs" {
-    export const EjsHighlightRules: new () => import(".").Ace.HighlightRules;
+declare module "ace-code/src/mode/eiffel" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/elixir" {
+declare module "ace-code/src/mode/ejs" {
+    export const EjsHighlightRules: new () => import(".").Ace.HighlightRules;
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -368,7 +364,7 @@ declare module "ace-code/src/mode/elixir_highlight_rules" {
     export const ElixirHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/elm" {
+declare module "ace-code/src/mode/elixir" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -376,7 +372,7 @@ declare module "ace-code/src/mode/elm_highlight_rules" {
     export const ElmHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/erlang" {
+declare module "ace-code/src/mode/elm" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -384,7 +380,7 @@ declare module "ace-code/src/mode/erlang_highlight_rules" {
     export const ErlangHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/flix" {
+declare module "ace-code/src/mode/erlang" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -392,7 +388,7 @@ declare module "ace-code/src/mode/flix_highlight_rules" {
     export const FlixHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/forth" {
+declare module "ace-code/src/mode/flix" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -400,7 +396,7 @@ declare module "ace-code/src/mode/forth_highlight_rules" {
     export const ForthHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/fortran" {
+declare module "ace-code/src/mode/forth" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -408,7 +404,7 @@ declare module "ace-code/src/mode/fortran_highlight_rules" {
     export const FortranHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/fsharp" {
+declare module "ace-code/src/mode/fortran" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -416,7 +412,7 @@ declare module "ace-code/src/mode/fsharp_highlight_rules" {
     export const FSharpHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/fsl" {
+declare module "ace-code/src/mode/fsharp" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -424,7 +420,7 @@ declare module "ace-code/src/mode/fsl_highlight_rules" {
     export const FSLHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/ftl" {
+declare module "ace-code/src/mode/fsl" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -432,7 +428,7 @@ declare module "ace-code/src/mode/ftl_highlight_rules" {
     export const FtlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/gcode" {
+declare module "ace-code/src/mode/ftl" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -440,7 +436,7 @@ declare module "ace-code/src/mode/gcode_highlight_rules" {
     export const GcodeHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/gherkin" {
+declare module "ace-code/src/mode/gcode" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -448,7 +444,7 @@ declare module "ace-code/src/mode/gherkin_highlight_rules" {
     export const GherkinHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/gitignore" {
+declare module "ace-code/src/mode/gherkin" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -456,7 +452,7 @@ declare module "ace-code/src/mode/gitignore_highlight_rules" {
     export const GitignoreHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/glsl" {
+declare module "ace-code/src/mode/gitignore" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -464,7 +460,7 @@ declare module "ace-code/src/mode/glsl_highlight_rules" {
     export const glslHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/gobstones" {
+declare module "ace-code/src/mode/glsl" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -472,7 +468,7 @@ declare module "ace-code/src/mode/gobstones_highlight_rules" {
     export const GobstonesHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/golang" {
+declare module "ace-code/src/mode/gobstones" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -480,7 +476,7 @@ declare module "ace-code/src/mode/golang_highlight_rules" {
     export const GolangHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/graphqlschema" {
+declare module "ace-code/src/mode/golang" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -488,7 +484,7 @@ declare module "ace-code/src/mode/graphqlschema_highlight_rules" {
     export const GraphQLSchemaHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/groovy" {
+declare module "ace-code/src/mode/graphqlschema" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -496,7 +492,7 @@ declare module "ace-code/src/mode/groovy_highlight_rules" {
     export const GroovyHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/haml" {
+declare module "ace-code/src/mode/groovy" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -504,7 +500,7 @@ declare module "ace-code/src/mode/haml_highlight_rules" {
     export const HamlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/handlebars" {
+declare module "ace-code/src/mode/haml" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -512,11 +508,7 @@ declare module "ace-code/src/mode/handlebars_highlight_rules" {
     export const HandlebarsHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/haskell" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
-declare module "ace-code/src/mode/haskell_cabal" {
+declare module "ace-code/src/mode/handlebars" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -524,11 +516,15 @@ declare module "ace-code/src/mode/haskell_cabal_highlight_rules" {
     export const CabalHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
+declare module "ace-code/src/mode/haskell_cabal" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
 declare module "ace-code/src/mode/haskell_highlight_rules" {
     export const HaskellHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/haxe" {
+declare module "ace-code/src/mode/haskell" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -536,7 +532,7 @@ declare module "ace-code/src/mode/haxe_highlight_rules" {
     export const HaxeHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/hjson" {
+declare module "ace-code/src/mode/haxe" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -544,7 +540,7 @@ declare module "ace-code/src/mode/hjson_highlight_rules" {
     export const HjsonHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/html" {
+declare module "ace-code/src/mode/hjson" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -552,27 +548,27 @@ declare module "ace-code/src/mode/html_completions" {
     export const HtmlCompletions: new () => import(".").Ace.Completion;
 }
 
-declare module "ace-code/src/mode/html_elixir" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
 declare module "ace-code/src/mode/html_elixir_highlight_rules" {
     export const HtmlElixirHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/html_elixir" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
 declare module "ace-code/src/mode/html_highlight_rules" {
     export const HtmlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/html_ruby" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
 declare module "ace-code/src/mode/html_ruby_highlight_rules" {
     export const HtmlRubyHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/ini" {
+declare module "ace-code/src/mode/html_ruby" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/html" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -580,11 +576,15 @@ declare module "ace-code/src/mode/ini_highlight_rules" {
     export const IniHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/io" {
+declare module "ace-code/src/mode/ini" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/ion" {
+declare module "ace-code/src/mode/io_highlight_rules" {
+    export const IoHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/io" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -592,11 +592,7 @@ declare module "ace-code/src/mode/ion_highlight_rules" {
     export const IonHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/io_highlight_rules" {
-    export const IoHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/jack" {
+declare module "ace-code/src/mode/ion" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -604,7 +600,7 @@ declare module "ace-code/src/mode/jack_highlight_rules" {
     export const JackHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/jade" {
+declare module "ace-code/src/mode/jack" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -612,11 +608,15 @@ declare module "ace-code/src/mode/jade_highlight_rules" {
     export const JadeHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/java" {
+declare module "ace-code/src/mode/jade" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/javascript" {
+declare module "ace-code/src/mode/java_highlight_rules" {
+    export const JavaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/java" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -624,11 +624,7 @@ declare module "ace-code/src/mode/javascript_highlight_rules" {
     export const JavaScriptHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/java_highlight_rules" {
-    export const JavaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/jexl" {
+declare module "ace-code/src/mode/javascript" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -636,15 +632,23 @@ declare module "ace-code/src/mode/jexl_highlight_rules" {
     export const JexlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
+declare module "ace-code/src/mode/jexl" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/js_regex_highlight_rules" {
+    export const JsRegexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
 declare module "ace-code/src/mode/jsdoc_comment_highlight_rules" {
     export const JsDocCommentHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/json" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
+declare module "ace-code/src/mode/json_highlight_rules" {
+    export const JsonHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/json5" {
+declare module "ace-code/src/mode/json" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -652,11 +656,7 @@ declare module "ace-code/src/mode/json5_highlight_rules" {
     export const Json5HighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/json_highlight_rules" {
-    export const JsonHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/jsp" {
+declare module "ace-code/src/mode/json5" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -664,7 +664,7 @@ declare module "ace-code/src/mode/jsp_highlight_rules" {
     export const JspHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/jssm" {
+declare module "ace-code/src/mode/jsp" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -672,7 +672,7 @@ declare module "ace-code/src/mode/jssm_highlight_rules" {
     export const JSSMHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/jsx" {
+declare module "ace-code/src/mode/jssm" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -680,11 +680,7 @@ declare module "ace-code/src/mode/jsx_highlight_rules" {
     export const JsxHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/js_regex_highlight_rules" {
-    export const JsRegexHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/julia" {
+declare module "ace-code/src/mode/jsx" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -692,7 +688,7 @@ declare module "ace-code/src/mode/julia_highlight_rules" {
     export const JuliaHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/kotlin" {
+declare module "ace-code/src/mode/julia" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -700,7 +696,7 @@ declare module "ace-code/src/mode/kotlin_highlight_rules" {
     export const KotlinHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/latex" {
+declare module "ace-code/src/mode/kotlin" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -708,7 +704,7 @@ declare module "ace-code/src/mode/latex_highlight_rules" {
     export const LatexHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/latte" {
+declare module "ace-code/src/mode/latex" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -716,7 +712,7 @@ declare module "ace-code/src/mode/latte_highlight_rules" {
     export const LatteHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/less" {
+declare module "ace-code/src/mode/latte" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -724,7 +720,7 @@ declare module "ace-code/src/mode/less_highlight_rules" {
     export const LessHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/liquid" {
+declare module "ace-code/src/mode/less" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -732,7 +728,7 @@ declare module "ace-code/src/mode/liquid_highlight_rules" {
     export const LiquidHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/lisp" {
+declare module "ace-code/src/mode/liquid" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -740,11 +736,11 @@ declare module "ace-code/src/mode/lisp_highlight_rules" {
     export const LispHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/livescript" {
+declare module "ace-code/src/mode/lisp" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/logiql" {
+declare module "ace-code/src/mode/livescript" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -752,7 +748,7 @@ declare module "ace-code/src/mode/logiql_highlight_rules" {
     export const LogiQLHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/logtalk" {
+declare module "ace-code/src/mode/logiql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -760,7 +756,7 @@ declare module "ace-code/src/mode/logtalk_highlight_rules" {
     export const LogtalkHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/lsl" {
+declare module "ace-code/src/mode/logtalk" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -768,11 +764,15 @@ declare module "ace-code/src/mode/lsl_highlight_rules" {
     export const LSLHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/lua" {
+declare module "ace-code/src/mode/lsl" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/luapage" {
+declare module "ace-code/src/mode/lua_highlight_rules" {
+    export const LuaHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/lua" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -780,11 +780,7 @@ declare module "ace-code/src/mode/luapage_highlight_rules" {
     export const LuaPageHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/lua_highlight_rules" {
-    export const LuaHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/lucene" {
+declare module "ace-code/src/mode/luapage" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -792,7 +788,7 @@ declare module "ace-code/src/mode/lucene_highlight_rules" {
     export const LuceneHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/makefile" {
+declare module "ace-code/src/mode/lucene" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -800,7 +796,7 @@ declare module "ace-code/src/mode/makefile_highlight_rules" {
     export const MakefileHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/markdown" {
+declare module "ace-code/src/mode/makefile" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -808,12 +804,16 @@ declare module "ace-code/src/mode/markdown_highlight_rules" {
     export const MarkdownHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/mask" {
+declare module "ace-code/src/mode/markdown" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
 declare module "ace-code/src/mode/mask_highlight_rules" {
     export const MaskHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/mask" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
 declare module "ace-code/src/mode/matching_brace_outdent" {
@@ -824,15 +824,11 @@ declare module "ace-code/src/mode/matching_parens_outdent" {
     export const MatchingParensOutdent: new () => import(".").Ace.Outdent;
 }
 
-declare module "ace-code/src/mode/matlab" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
 declare module "ace-code/src/mode/matlab_highlight_rules" {
     export const MatlabHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/maze" {
+declare module "ace-code/src/mode/matlab" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -840,7 +836,7 @@ declare module "ace-code/src/mode/maze_highlight_rules" {
     export const MazeHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/mediawiki" {
+declare module "ace-code/src/mode/maze" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -848,7 +844,7 @@ declare module "ace-code/src/mode/mediawiki_highlight_rules" {
     export const MediaWikiHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/mel" {
+declare module "ace-code/src/mode/mediawiki" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -856,7 +852,7 @@ declare module "ace-code/src/mode/mel_highlight_rules" {
     export const MELHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/mips" {
+declare module "ace-code/src/mode/mel" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -864,7 +860,7 @@ declare module "ace-code/src/mode/mips_highlight_rules" {
     export const MIPSHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/mixal" {
+declare module "ace-code/src/mode/mips" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -872,7 +868,7 @@ declare module "ace-code/src/mode/mixal_highlight_rules" {
     export const MixalHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/mushcode" {
+declare module "ace-code/src/mode/mixal" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -880,7 +876,7 @@ declare module "ace-code/src/mode/mushcode_highlight_rules" {
     export const MushCodeRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/mysql" {
+declare module "ace-code/src/mode/mushcode" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -888,7 +884,7 @@ declare module "ace-code/src/mode/mysql_highlight_rules" {
     export const MysqlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/nasal" {
+declare module "ace-code/src/mode/mysql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -896,7 +892,7 @@ declare module "ace-code/src/mode/nasal_highlight_rules" {
     export const NasalHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/nginx" {
+declare module "ace-code/src/mode/nasal" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -904,7 +900,7 @@ declare module "ace-code/src/mode/nginx_highlight_rules" {
     export const NginxHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/nim" {
+declare module "ace-code/src/mode/nginx" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -912,7 +908,7 @@ declare module "ace-code/src/mode/nim_highlight_rules" {
     export const NimHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/nix" {
+declare module "ace-code/src/mode/nim" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -920,7 +916,7 @@ declare module "ace-code/src/mode/nix_highlight_rules" {
     export const NixHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/nsis" {
+declare module "ace-code/src/mode/nix" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -928,7 +924,7 @@ declare module "ace-code/src/mode/nsis_highlight_rules" {
     export const NSISHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/nunjucks" {
+declare module "ace-code/src/mode/nsis" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -936,7 +932,7 @@ declare module "ace-code/src/mode/nunjucks_highlight_rules" {
     export const NunjucksHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/objectivec" {
+declare module "ace-code/src/mode/nunjucks" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -944,7 +940,7 @@ declare module "ace-code/src/mode/objectivec_highlight_rules" {
     export const ObjectiveCHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/ocaml" {
+declare module "ace-code/src/mode/objectivec" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -952,7 +948,7 @@ declare module "ace-code/src/mode/ocaml_highlight_rules" {
     export const OcamlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/odin" {
+declare module "ace-code/src/mode/ocaml" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -960,7 +956,7 @@ declare module "ace-code/src/mode/odin_highlight_rules" {
     export const OdinHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/partiql" {
+declare module "ace-code/src/mode/odin" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -968,7 +964,7 @@ declare module "ace-code/src/mode/partiql_highlight_rules" {
     export const PartiqlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/pascal" {
+declare module "ace-code/src/mode/partiql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -976,7 +972,7 @@ declare module "ace-code/src/mode/pascal_highlight_rules" {
     export const PascalHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/perl" {
+declare module "ace-code/src/mode/pascal" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -984,7 +980,7 @@ declare module "ace-code/src/mode/perl_highlight_rules" {
     export const PerlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/pgsql" {
+declare module "ace-code/src/mode/perl" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -992,7 +988,7 @@ declare module "ace-code/src/mode/pgsql_highlight_rules" {
     export const PgsqlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/php" {
+declare module "ace-code/src/mode/pgsql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1005,15 +1001,15 @@ declare module "ace-code/src/mode/php_highlight_rules" {
     export const PhpLangHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/php_laravel_blade" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
 declare module "ace-code/src/mode/php_laravel_blade_highlight_rules" {
     export const PHPLaravelBladeHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/pig" {
+declare module "ace-code/src/mode/php_laravel_blade" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/php" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1021,11 +1017,11 @@ declare module "ace-code/src/mode/pig_highlight_rules" {
     export const PigHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/plain_text" {
+declare module "ace-code/src/mode/pig" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/plsql" {
+declare module "ace-code/src/mode/plain_text" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1033,7 +1029,7 @@ declare module "ace-code/src/mode/plsql_highlight_rules" {
     export const plsqlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/powershell" {
+declare module "ace-code/src/mode/plsql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1041,7 +1037,7 @@ declare module "ace-code/src/mode/powershell_highlight_rules" {
     export const PowershellHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/praat" {
+declare module "ace-code/src/mode/powershell" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1049,7 +1045,7 @@ declare module "ace-code/src/mode/praat_highlight_rules" {
     export const PraatHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/prisma" {
+declare module "ace-code/src/mode/praat" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1057,7 +1053,7 @@ declare module "ace-code/src/mode/prisma_highlight_rules" {
     export const PrismaHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/prolog" {
+declare module "ace-code/src/mode/prisma" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1065,7 +1061,7 @@ declare module "ace-code/src/mode/prolog_highlight_rules" {
     export const PrologHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/properties" {
+declare module "ace-code/src/mode/prolog" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1073,7 +1069,7 @@ declare module "ace-code/src/mode/properties_highlight_rules" {
     export const PropertiesHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/protobuf" {
+declare module "ace-code/src/mode/properties" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1081,7 +1077,7 @@ declare module "ace-code/src/mode/protobuf_highlight_rules" {
     export const ProtobufHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/prql" {
+declare module "ace-code/src/mode/protobuf" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1089,7 +1085,7 @@ declare module "ace-code/src/mode/prql_highlight_rules" {
     export const PrqlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/puppet" {
+declare module "ace-code/src/mode/prql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1097,7 +1093,7 @@ declare module "ace-code/src/mode/puppet_highlight_rules" {
     export const PuppetHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/python" {
+declare module "ace-code/src/mode/puppet" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1105,7 +1101,7 @@ declare module "ace-code/src/mode/python_highlight_rules" {
     export const PythonHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/qml" {
+declare module "ace-code/src/mode/python" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1113,11 +1109,15 @@ declare module "ace-code/src/mode/qml_highlight_rules" {
     export const QmlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/r" {
+declare module "ace-code/src/mode/qml" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/raku" {
+declare module "ace-code/src/mode/r_highlight_rules" {
+    export const RHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/r" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1125,7 +1125,7 @@ declare module "ace-code/src/mode/raku_highlight_rules" {
     export const RakuHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/razor" {
+declare module "ace-code/src/mode/raku" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1138,7 +1138,7 @@ declare module "ace-code/src/mode/razor_highlight_rules" {
     export const RazorLangHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/rdoc" {
+declare module "ace-code/src/mode/razor" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1146,11 +1146,15 @@ declare module "ace-code/src/mode/rdoc_highlight_rules" {
     export const RDocHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/red" {
+declare module "ace-code/src/mode/rdoc" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/redshift" {
+declare module "ace-code/src/mode/red_highlight_rules" {
+    export const RedHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/red" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1158,11 +1162,7 @@ declare module "ace-code/src/mode/redshift_highlight_rules" {
     export const RedshiftHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/red_highlight_rules" {
-    export const RedHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/rhtml" {
+declare module "ace-code/src/mode/redshift" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1170,7 +1170,7 @@ declare module "ace-code/src/mode/rhtml_highlight_rules" {
     export const RHtmlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/robot" {
+declare module "ace-code/src/mode/rhtml" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1178,7 +1178,7 @@ declare module "ace-code/src/mode/robot_highlight_rules" {
     export const RobotHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/rst" {
+declare module "ace-code/src/mode/robot" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1186,7 +1186,7 @@ declare module "ace-code/src/mode/rst_highlight_rules" {
     export const RSTHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/ruby" {
+declare module "ace-code/src/mode/rst" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1206,7 +1206,7 @@ declare module "ace-code/src/mode/ruby_highlight_rules" {
     export const RubyHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/rust" {
+declare module "ace-code/src/mode/ruby" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1214,11 +1214,7 @@ declare module "ace-code/src/mode/rust_highlight_rules" {
     export const RustHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/r_highlight_rules" {
-    export const RHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/sac" {
+declare module "ace-code/src/mode/rust" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1226,7 +1222,7 @@ declare module "ace-code/src/mode/sac_highlight_rules" {
     export const sacHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/sass" {
+declare module "ace-code/src/mode/sac" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1234,7 +1230,7 @@ declare module "ace-code/src/mode/sass_highlight_rules" {
     export const SassHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/scad" {
+declare module "ace-code/src/mode/sass" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1242,7 +1238,7 @@ declare module "ace-code/src/mode/scad_highlight_rules" {
     export const scadHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/scala" {
+declare module "ace-code/src/mode/scad" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1250,7 +1246,7 @@ declare module "ace-code/src/mode/scala_highlight_rules" {
     export const ScalaHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/scheme" {
+declare module "ace-code/src/mode/scala" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1258,7 +1254,7 @@ declare module "ace-code/src/mode/scheme_highlight_rules" {
     export const SchemeHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/scrypt" {
+declare module "ace-code/src/mode/scheme" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1266,7 +1262,7 @@ declare module "ace-code/src/mode/scrypt_highlight_rules" {
     export const scryptHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/scss" {
+declare module "ace-code/src/mode/scrypt" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1274,7 +1270,7 @@ declare module "ace-code/src/mode/scss_highlight_rules" {
     export const ScssHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/sh" {
+declare module "ace-code/src/mode/scss" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1284,7 +1280,7 @@ declare module "ace-code/src/mode/sh_highlight_rules" {
     export const ShHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/sjs" {
+declare module "ace-code/src/mode/sh" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1292,7 +1288,7 @@ declare module "ace-code/src/mode/sjs_highlight_rules" {
     export const SJSHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/slim" {
+declare module "ace-code/src/mode/sjs" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1300,7 +1296,7 @@ declare module "ace-code/src/mode/slim_highlight_rules" {
     export const SlimHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/smarty" {
+declare module "ace-code/src/mode/slim" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1308,12 +1304,16 @@ declare module "ace-code/src/mode/smarty_highlight_rules" {
     export const SmartyHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/smithy" {
+declare module "ace-code/src/mode/smarty" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
 declare module "ace-code/src/mode/smithy_highlight_rules" {
     export const SmithyHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/smithy" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
 declare module "ace-code/src/mode/snippets" {
@@ -1322,15 +1322,11 @@ declare module "ace-code/src/mode/snippets" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/soy_template" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
-}
-
 declare module "ace-code/src/mode/soy_template_highlight_rules" {
     export const SoyTemplateHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/space" {
+declare module "ace-code/src/mode/soy_template" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1338,7 +1334,7 @@ declare module "ace-code/src/mode/space_highlight_rules" {
     export const SpaceHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/sparql" {
+declare module "ace-code/src/mode/space" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1346,11 +1342,15 @@ declare module "ace-code/src/mode/sparql_highlight_rules" {
     export const SPARQLHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/sql" {
+declare module "ace-code/src/mode/sparql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/sqlserver" {
+declare module "ace-code/src/mode/sql_highlight_rules" {
+    export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/sql" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1358,11 +1358,7 @@ declare module "ace-code/src/mode/sqlserver_highlight_rules" {
     export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/sql_highlight_rules" {
-    export const SqlHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/stylus" {
+declare module "ace-code/src/mode/sqlserver" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1370,7 +1366,7 @@ declare module "ace-code/src/mode/stylus_highlight_rules" {
     export const StylusHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/svg" {
+declare module "ace-code/src/mode/stylus" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1378,7 +1374,7 @@ declare module "ace-code/src/mode/svg_highlight_rules" {
     export const SvgHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/swift" {
+declare module "ace-code/src/mode/svg" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1387,7 +1383,7 @@ declare module "ace-code/src/mode/swift_highlight_rules" {
     export const SwiftHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/tcl" {
+declare module "ace-code/src/mode/swift" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1395,7 +1391,7 @@ declare module "ace-code/src/mode/tcl_highlight_rules" {
     export const TclHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/terraform" {
+declare module "ace-code/src/mode/tcl" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1403,15 +1399,23 @@ declare module "ace-code/src/mode/terraform_highlight_rules" {
     export const TerraformHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
+declare module "ace-code/src/mode/terraform" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/tex_highlight_rules" {
+    export const TexHighlightRules: new () => import(".").Ace.HighlightRules;
+}
+
 declare module "ace-code/src/mode/tex" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
-declare module "ace-code/src/mode/text" {
-    export const Mode: new () => import(".").Ace.SyntaxMode;
+declare module "ace-code/src/mode/text_highlight_rules" {
+    export const TextHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/textile" {
+declare module "ace-code/src/mode/text" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1419,15 +1423,7 @@ declare module "ace-code/src/mode/textile_highlight_rules" {
     export const TextileHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/text_highlight_rules" {
-    export const TextHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/tex_highlight_rules" {
-    export const TexHighlightRules: new () => import(".").Ace.HighlightRules;
-}
-
-declare module "ace-code/src/mode/toml" {
+declare module "ace-code/src/mode/textile" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1435,7 +1431,7 @@ declare module "ace-code/src/mode/toml_highlight_rules" {
     export const TomlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/tsx" {
+declare module "ace-code/src/mode/toml" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1443,7 +1439,7 @@ declare module "ace-code/src/mode/tsx_highlight_rules" {
     export const TsxHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/turtle" {
+declare module "ace-code/src/mode/tsx" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1451,7 +1447,7 @@ declare module "ace-code/src/mode/turtle_highlight_rules" {
     export const TurtleHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/twig" {
+declare module "ace-code/src/mode/turtle" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1459,7 +1455,7 @@ declare module "ace-code/src/mode/twig_highlight_rules" {
     export const TwigHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/typescript" {
+declare module "ace-code/src/mode/twig" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1467,7 +1463,7 @@ declare module "ace-code/src/mode/typescript_highlight_rules" {
     export const TypeScriptHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/vala" {
+declare module "ace-code/src/mode/typescript" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1475,7 +1471,7 @@ declare module "ace-code/src/mode/vala_highlight_rules" {
     export const ValaHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/vbscript" {
+declare module "ace-code/src/mode/vala" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1483,7 +1479,7 @@ declare module "ace-code/src/mode/vbscript_highlight_rules" {
     export const VBScriptHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/velocity" {
+declare module "ace-code/src/mode/vbscript" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1491,7 +1487,7 @@ declare module "ace-code/src/mode/velocity_highlight_rules" {
     export const VelocityHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/verilog" {
+declare module "ace-code/src/mode/velocity" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1499,7 +1495,7 @@ declare module "ace-code/src/mode/verilog_highlight_rules" {
     export const VerilogHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/vhdl" {
+declare module "ace-code/src/mode/verilog" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1507,7 +1503,7 @@ declare module "ace-code/src/mode/vhdl_highlight_rules" {
     export const VHDLHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/visualforce" {
+declare module "ace-code/src/mode/vhdl" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1515,7 +1511,7 @@ declare module "ace-code/src/mode/visualforce_highlight_rules" {
     export const VisualforceHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/vue" {
+declare module "ace-code/src/mode/visualforce" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1523,7 +1519,7 @@ declare module "ace-code/src/mode/vue_highlight_rules" {
     export const VueHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/wollok" {
+declare module "ace-code/src/mode/vue" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1531,7 +1527,7 @@ declare module "ace-code/src/mode/wollok_highlight_rules" {
     export const WollokHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/xml" {
+declare module "ace-code/src/mode/wollok" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1539,7 +1535,7 @@ declare module "ace-code/src/mode/xml_highlight_rules" {
     export const XmlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/yaml" {
+declare module "ace-code/src/mode/xml" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1547,7 +1543,7 @@ declare module "ace-code/src/mode/yaml_highlight_rules" {
     export const YamlHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/zeek" {
+declare module "ace-code/src/mode/yaml" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1555,7 +1551,7 @@ declare module "ace-code/src/mode/zeek_highlight_rules" {
     export const ZeekHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/zig" {
+declare module "ace-code/src/mode/zeek" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
 }
 
@@ -1563,122 +1559,6 @@ declare module "ace-code/src/mode/zig_highlight_rules" {
     export const ZigHighlightRules: new () => import(".").Ace.HighlightRules;
 }
 
-declare module "ace-code/src/mode/behaviour/css" {
-    export const CssBehaviour: new () => import(".").Ace.Behaviour;
-}
-
-declare module "ace-code/src/mode/behaviour/cstyle" {
-    export const CstyleBehaviour: new () => import(".").Ace.Behaviour;
-}
-
-declare module "ace-code/src/mode/behaviour/html" {
-    export const HtmlBehaviour: new () => import(".").Ace.Behaviour;
-}
-
-declare module "ace-code/src/mode/behaviour/liquid" {
-    export const LiquidBehaviour: new () => import(".").Ace.Behaviour;
-}
-
-declare module "ace-code/src/mode/behaviour/xml" {
-    export const XmlBehaviour: new () => import(".").Ace.Behaviour;
-}
-
-declare module "ace-code/src/mode/behaviour/xquery" {
-    export const XQueryBehaviour: new () => import(".").Ace.Behaviour;
-}
-
-declare module "ace-code/src/mode/folding/asciidoc" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/c9search" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/coffee" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/csharp" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/cstyle" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/diff" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/drools" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/fold_mode" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/haskell_cabal" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/html" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/ini" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/java" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/latex" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/lua" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/markdown" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/mixed" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/pythonic" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/ruby" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/sql" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/sqlserver" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/vbscript" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/velocity" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/xml" {
-    export const FoldMode: new () => import(".").Ace.Folding;
-}
-
-declare module "ace-code/src/mode/folding/yaml" {
-    export const FoldMode: new () => import(".").Ace.Folding;
+declare module "ace-code/src/mode/zig" {
+    export const Mode: new () => import(".").Ace.SyntaxMode;
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "lint": "eslint \"src/**/*.js\"",
         "fix": "eslint --fix \"src/**/*.js\"",
         "typecheck": "tsc -p tsconfig.json",
+        "update-types": "node ./tool/modes-declaration-generator.js",
         "changelog": "standard-version",
         "prepack": "node tool/esm_resolver_generator.js && node Makefile.dryice.js css --target build-styles && rm -rf styles && mv build-styles/css styles"
     },

--- a/src/mode/ruby_highlight_rules.js
+++ b/src/mode/ruby_highlight_rules.js
@@ -39,7 +39,7 @@ var constantNumericDecimal = exports.constantNumericDecimal = {
     regex: /\b(0[dD](?:[1-9](?:[\d]|_(?=[\d]))*|0))\b/
 };
 
-var constantNumericOctal = exports.constantNumericDecimal = {
+var constantNumericOctal = exports.constantNumericOctal = {
     token: "constant.numeric",
     regex: /\b(0[oO]?(?:[1-7](?:[0-7]|_(?=[0-7]))*|0))\b/
 };

--- a/tool/modes-declaration-generator.js
+++ b/tool/modes-declaration-generator.js
@@ -1,0 +1,149 @@
+var ts = require("typescript");
+var fs = require("fs");
+var path = require("path");
+
+const modeDirPath = __dirname + "/../src/mode";
+const outputFilePath = __dirname + "/../ace-modes.d.ts";
+const moduleNamePrefix = "ace-code";
+
+function processFile(program, filePath) {
+    const sourceFile = program.getSourceFile(filePath);
+    const checker = program.getTypeChecker();
+    if (!sourceFile) return;
+
+    var statements = [];
+    const excludeTypes = [
+        "() => void", "any", "typeof FoldMode", "(voidElements: any, optionalTags: any) => void",
+        "typeof LiveScriptMode"
+    ];
+
+    function visit(node) {
+        // Check for variable statements that might contain exports
+        if (ts.isVariableStatement(node)) {
+            node.declarationList.declarations.forEach(declaration => {
+                if (declaration.initializer && ts.isBinaryExpression(declaration.initializer)
+                    && ts.isPropertyAccessExpression(declaration.initializer.left)
+                    && declaration.initializer.left.expression.getText() === "exports") {
+                    // Extract the export name
+                    const exportName = declaration.initializer.left.name.text;
+
+                    const symbol = checker.getSymbolAtLocation(declaration.name);
+                    let typeNode = undefined;
+                    if (symbol) {
+                        const type = checker.getTypeOfSymbolAtLocation(symbol, symbol.valueDeclaration);
+                        if (!excludeTypes.includes(checker.typeToString(type))) {
+                            typeNode = checker.typeToTypeNode(type, undefined, undefined);
+                        }
+                    }
+                    const exportAssignment = createExportStatement(exportName, typeNode);
+                    statements.push(exportAssignment);
+                }
+            });
+        }
+        else if (ts.isExpressionStatement(node) && ts.isBinaryExpression(node.expression)) {
+            const binaryExpression = node.expression;
+            // Check for "exports.<identifier> = <identifier>;" pattern
+            if (ts.isPropertyAccessExpression(binaryExpression.left) && binaryExpression.left.expression.getText()
+                === "exports" && binaryExpression.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+                const exportName = binaryExpression.left.name.text;
+
+                let typeNode = undefined;
+                const symbol = checker.getSymbolAtLocation(node.expression.left);
+                if (symbol) {
+                    const type = checker.getTypeOfSymbolAtLocation(symbol, symbol.valueDeclaration);
+                    if (!excludeTypes.includes(checker.typeToString(type))) {
+                        typeNode = checker.typeToTypeNode(type, undefined, undefined);
+                    }
+                }
+                const exportAssignment = createExportStatement(exportName, typeNode);
+                statements.push(exportAssignment);
+            }
+        }
+
+        ts.forEachChild(node, visit);
+    }
+
+    visit(sourceFile);
+    return statements;
+}
+
+function createExportStatement(exportName, type) {
+    const exportType = getExportType(exportName);
+    return ts.factory.createVariableStatement([ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createVariableDeclarationList([
+            ts.factory.createVariableDeclaration(ts.factory.createIdentifier(exportName), undefined,
+                type || ts.factory.createConstructorTypeNode(undefined, undefined, [], exportType), undefined
+            )
+        ], ts.NodeFlags.Const)
+    );
+}
+
+function getExportType(exportName) {
+    var aceType = "";
+    if (/highlight|rules/i.test(exportName)) {
+        aceType = "HighlightRules";
+    }
+    else if (/behaviour/i.test(exportName)) {
+        //TODO: we need options for behaviours
+        aceType = "Behaviour";
+    }
+    else if (/completion/i.test(exportName)) {
+        aceType = "Completion";
+    }
+    else if (/fold/i.test(exportName)) {
+        aceType = "Folding";
+    }
+    else if (/mode/i.test(exportName)) {
+        aceType = "SyntaxMode";
+    }
+    else if (/outdent/i.test(exportName)) {
+        aceType = "Outdent";
+    }
+
+    return ts.factory.createImportTypeNode(ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(".")),
+        undefined,
+        ts.factory.createQualifiedName(ts.factory.createIdentifier("Ace"), ts.factory.createIdentifier(aceType)),
+        undefined, false
+    );
+}
+
+function generateModuleDeclarations(dirPath) {
+    const program = createProgram(dirPath);
+    const filePaths = program.getRootFileNames();
+
+    return filePaths.map(filePath => {
+        let normalizedFilePath = filePath.replace(/\\/g, "/").replace(/.*(?=src\/mode)/, "").replace(/\.js$/, "");
+
+        const moduleName = moduleNamePrefix + "/" + normalizedFilePath;
+        const statements = processFile(program, filePath);
+        const moduleBody = ts.factory.createModuleBlock(statements);
+        return ts.factory.createModuleDeclaration([ts.factory.createToken(ts.SyntaxKind.DeclareKeyword)],
+            ts.factory.createStringLiteral(moduleName), moduleBody,
+            ts.NodeFlags.ExportContext | ts.NodeFlags.JavaScriptFile | ts.NodeFlags.Ambient | ts.NodeFlags.ContextFlags
+        );
+    });
+}
+
+function createProgram(dirPath) {
+    const fileNames = fs.readdirSync(dirPath, {recursive: true}).map(file => path.join(dirPath, file)).filter(
+        file => /\.js$/.test(file) && !/test\.js$/.test(file));
+
+    const program = ts.createProgram(fileNames, {
+        target: ts.ScriptTarget.ES5,
+        module: ts.ModuleKind.CommonJS,
+        allowJs: true
+    });
+
+    return program;
+}
+
+function generateModesDeclarationFile() {
+    const moduleDeclarations = generateModuleDeclarations(modeDirPath);
+    const printer = ts.createPrinter({newLine: ts.NewLineKind.LineFeed});
+    const resultFile = ts.createSourceFile(outputFilePath, "", ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+    const result = moduleDeclarations.map(
+        declaration => printer.printNode(ts.EmitHint.Unspecified, declaration, resultFile)).join('\n\n');
+    fs.writeFileSync(outputFilePath, result);
+}
+
+generateModesDeclarationFile();

--- a/tool/modes-declaration-generator.js
+++ b/tool/modes-declaration-generator.js
@@ -111,7 +111,7 @@ function generateModuleDeclarations(dirPath) {
     const program = createProgram(dirPath);
     const filePaths = program.getRootFileNames();
 
-    return filePaths.map(filePath => {
+    return filePaths.sort((a, b) => a.localeCompare(b)).map(filePath => {
         let normalizedFilePath = filePath.replace(/\\/g, "/").replace(/.*(?=src\/mode)/, "").replace(/\.js$/, "");
 
         const moduleName = moduleNamePrefix + "/" + normalizedFilePath;


### PR DESCRIPTION
*Issue #, if available:* #5511

*Description of changes:*
This PR introduces an automated process for generating TypeScript declaration files for the ACE Editor modes located within our `src/mode` directory. By analyzing our JavaScript codebase using the TypeScript Compiler API, we can now dynamically create a single `ace-modes.d.ts` file that accurately represents the types and exports of our editor modes.

**This can serve as a short- to mid-term solution until the modes are converted to ES6 and properly checked with TypeScript.**

### Discussion Points:
- **Integration Timing:** The optimal timing for integrating this script into our development or build process remains open for discussion. Input is needed to determine whether it should be run as part of our regular build process, pre-commit hooks, or at another stage to best suit our workflow.
- **Feedback and Improvements:** Feedback on the accuracy of the generated types and suggestions for enhancing the script's integration with TypeScript projects are highly welcomed. Collaboration will be key in refining this process to fit our project needs seamlessly.
### Next Steps:
I invite all ACE team members to review the proposed changes and participate in a discussion about integrating this script into workflow. Your insights are invaluable to ensuring the effectiveness and efficiency of this solution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

