### PR TITLE
fix: allow completers to trigger on newline characters

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -622,6 +622,7 @@ export namespace Ace {
     documentToScreenColumn(row: number, docColumn: number): number;
     documentToScreenRow(docRow: number, docColumn: number): number;
     getScreenLength(): number;
+    getPrecedingCharacter(): string;
     toJSON(): Object;
     destroy(): void;
   }

--- a/src/autocomplete/util.js
+++ b/src/autocomplete/util.js
@@ -65,10 +65,13 @@ exports.getCompletionPrefix = function (editor) {
 
 /**
  * @param {Editor} editor
+ * @param {string} [previousChar] if not provided, it falls back to the preceding character in the editor
  * @returns {boolean} whether autocomplete should be triggered
  */
-exports.triggerAutocomplete = function (editor) {
-    var previousChar = editor.session.getPrecedingCharacter();
+exports.triggerAutocomplete = function (editor, previousChar) {
+    var previousChar = previousChar == null
+        ? editor.session.getPrecedingCharacter()
+        : previousChar;
     return editor.completers.some((completer) => {
         if (completer.triggerCharacters && Array.isArray(completer.triggerCharacters)) {
             return completer.triggerCharacters.includes(previousChar);

--- a/src/autocomplete/util.js
+++ b/src/autocomplete/util.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * @typedef {import("../editor").Editor} Editor
+ */
+
 exports.parForEach = function(array, fn, callback) {
     var completed = 0;
     var arLength = array.length;
@@ -59,14 +63,15 @@ exports.getCompletionPrefix = function (editor) {
     return prefix || this.retrievePrecedingIdentifier(line, pos.column);
 };
 
+/**
+ * @param {Editor} editor
+ * @returns {boolean} whether autocomplete should be triggered
+ */
 exports.triggerAutocomplete = function (editor) {
-    var pos = editor.getCursorPosition();
-    var line = editor.session.getLine(pos.row);
-    var column = (pos.column === 0) ? 0 : pos.column - 1;
-    var previousChar = line[column];
-    return editor.completers.some((el) => {
-        if (el.triggerCharacters && Array.isArray(el.triggerCharacters)) {
-            return el.triggerCharacters.includes(previousChar);
+    var previousChar = editor.session.getPreviousChar();
+    return editor.completers.some((completer) => {
+        if (completer.triggerCharacters && Array.isArray(completer.triggerCharacters)) {
+            return completer.triggerCharacters.includes(previousChar);
         }
     });
 };

--- a/src/autocomplete/util.js
+++ b/src/autocomplete/util.js
@@ -68,7 +68,7 @@ exports.getCompletionPrefix = function (editor) {
  * @returns {boolean} whether autocomplete should be triggered
  */
 exports.triggerAutocomplete = function (editor) {
-    var previousChar = editor.session.getPreviousChar();
+    var previousChar = editor.session.getPrecedingCharacter();
     return editor.completers.some((completer) => {
         if (completer.triggerCharacters && Array.isArray(completer.triggerCharacters)) {
             return completer.triggerCharacters.includes(previousChar);

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -403,6 +403,7 @@ module.exports = {
     },
     "test: trigger autocomplete for specific characters": function (done) {
         var editor = initEditor("document");
+        var newLineCharacter = editor.session.doc.getNewLineCharacter();
 
         editor.completers = [
             {
@@ -418,18 +419,27 @@ module.exports = {
                     ];
                     callback(null, completions);
                 },
-                triggerCharacters: ["."]
+                triggerCharacters: [".", newLineCharacter]
             }
         ];
-        
+
         editor.moveCursorTo(0, 8);
-        sendKey(".");
+        user.type(".");
         var popup = editor.completer.popup;
         check(function () {
             assert.equal(popup.data.length, 2);
-            editor.onCommandKey(null, 0, 13);
+            user.type("Return");  // Accept suggestion
             assert.equal(editor.getValue(), "document.all");
-            done();
+
+            user.type(Array(4).fill("Backspace"));  // Delete '.all'
+            user.type("Return");  // Enter new line
+
+            check(function() {
+                assert.equal(popup.data.length, 2);
+                user.type("Return");  // Accept suggestion
+                assert.equal(editor.getValue(), `document${newLineCharacter}all`);
+                done();
+            });
         });
 
         function check(callback) {

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -2367,18 +2367,17 @@ class EditSession {
     }
 
     /**
-     * @returns {string} the last character inserted into the editor
+     * @returns {string} the last character preceding the cursor in the editor
      */
-    getPreviousChar() {
+    getPrecedingCharacter() {
         var pos = this.selection.getCursor();
 
-        if (pos.row === 0) {
-            var line = this.getLine(pos.row);
-            var column = pos.column === 0 ? 0 : pos.column - 1;
-            return line[column];
+        if (pos.column === 0) {
+            return pos.row === 0 ? "" : this.doc.getNewLineCharacter();
         }
 
-        return this.doc.getNewLineCharacter();
+        var currentLine = this.getLine(pos.row);
+        return currentLine[pos.column - 1];
     }
 
     destroy() {

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -2366,6 +2366,21 @@ class EditSession {
         };
     }
 
+    /**
+     * @returns {string} the last character inserted into the editor
+     */
+    getPreviousChar() {
+        var pos = this.selection.getCursor();
+
+        if (pos.row === 0) {
+            var line = this.getLine(pos.row);
+            var column = pos.column === 0 ? 0 : pos.column - 1;
+            return line[column];
+        }
+
+        return this.doc.getNewLineCharacter();
+    }
+
     destroy() {
         if (!this.destroyed) {
             this.bgTokenizer.setDocument(null);

--- a/src/ext/language_tools.js
+++ b/src/ext/language_tools.js
@@ -162,7 +162,8 @@ var showLiveAutocomplete = function(e) {
     var editor = e.editor;
     var prefix = util.getCompletionPrefix(editor);
     // Only autocomplete if there's a prefix that can be matched or previous char is trigger character 
-    var triggerAutocomplete = util.triggerAutocomplete(editor);
+    var previousChar = e.args;
+    var triggerAutocomplete = util.triggerAutocomplete(editor, previousChar);
     if (prefix && prefix.length >= editor.$liveAutocompletionThreshold || triggerAutocomplete) {
         var completer = Autocomplete.for(editor);
         // Set a flag for auto shown


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Completers may want to use newline characters for triggering suggestions. This is particularly useful when showing suggestions after typing prompts in the form of inline comments in the case of GenAI suggestions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [✓] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

