### PR TITLE
Fix: Contrast is too low for searched items

### DIFF
--- a/src/theme/cloud_editor_dark-css.js
+++ b/src/theme/cloud_editor_dark-css.js
@@ -26,7 +26,7 @@ module.exports = `
 }
 
 .ace-cloud_editor_dark .ace_marker-layer .ace_selection {
-    background: #213a70;
+    background: #4376bd;
 }
 
 .ace-cloud_editor_dark.ace_multiselect .ace_selection.ace_start {
@@ -63,7 +63,7 @@ module.exports = `
 }
 
 .ace-cloud_editor_dark .ace_marker-layer .ace_selected-word {
-    border: 1px solid #282c34;
+    border: 1px solid #9bd0f7;
 }
 
 .ace-cloud_editor_dark .ace_fold {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In CloudEditor Dark Theme whenever a user searches for a term in the editor, the contrast for the searched items is too low which makes it hard to see the active search text and it's nearly impossible to view other searched text as contrast is too low.
So updated the colours for both above mentioned cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts
    
 ScreenShot Without new changes

<img width="1512" alt="Screenshot 2024-04-03 at 09 13 17" src="https://github.com/ajaxorg/ace/assets/164378643/a93a27a9-89d1-44e4-9991-c101a61ac502">

 ScreenShot With new changes

<img width="1512" alt="Screenshot 2024-04-03 at 09 12 44" src="https://github.com/ajaxorg/ace/assets/164378643/7dedc1cf-51eb-4025-9833-e7ff8245ae62">

   
 



