### PR TITLE
Fix Incorrect Module Reference for TypeScriptHighlightRules

### DIFF
--- a/src/mode/tsx_highlight_rules.js
+++ b/src/mode/tsx_highlight_rules.js
@@ -1,12 +1,12 @@
 "use strict";
 
 var oop = require("../lib/oop");
-var TypeScriptHighlightRules = require("./javascript_highlight_rules").TypeScriptHighlightRules;
-
+var TypeScriptHighlightRules =
+  require("./typescript_highlight_rules").TypeScriptHighlightRules;
 
 var TsxHighlightRules = function () {
   TypeScriptHighlightRules.call(this, {
-    jsx: true
+    jsx: true,
   });
 };
 oop.inherits(TsxHighlightRules, TypeScriptHighlightRules);

--- a/src/mode/tsx_highlight_rules.js
+++ b/src/mode/tsx_highlight_rules.js
@@ -1,13 +1,12 @@
 "use strict";
 
 var oop = require("../lib/oop");
-var TypeScriptHighlightRules =
-  require("./typescript_highlight_rules").TypeScriptHighlightRules;
+var TypeScriptHighlightRules = require("./typescript_highlight_rules").TypeScriptHighlightRules;
 
 var TsxHighlightRules = function () {
-  TypeScriptHighlightRules.call(this, {
-    jsx: true,
-  });
+    TypeScriptHighlightRules.call(this, {
+      jsx: true
+    });
 };
 oop.inherits(TsxHighlightRules, TypeScriptHighlightRules);
 


### PR DESCRIPTION
*Issue #, if available:* [#5498](https://github.com/ajaxorg/ace/pull/5498)

*Description of changes:*

It appear that this [PR](https://github.com/ajaxorg/ace/pull/5498) provides an incorrect module reference

`var TypeScriptHighlightRules = require("./javascript_highlight_rules").TypeScriptHighlightRules;`

This should actually reference ./typescript_highlight_rules. As a result, when attempting to access TypeScriptHighlightRules in tsx_highlight_rules, it returns undefined.
