### PR TITLE
Fix: not determined folding widgets for html tags

### DIFF
--- a/src/mode/folding/php_test.js
+++ b/src/mode/folding/php_test.js
@@ -13,13 +13,38 @@ module.exports = {
 
     "test: php folding with alternative syntax": function () {
         var session = new EditSession([
-            '<?php', 'function checkNumber($number)', '{', '   switch ($number) {', '       case 0:',
-            '       echo "Number is zero again";', '           if ($number == 0):',
-            '               echo "Number is zero";', '           elseif ($number > 0):',
-            '               echo "Number is positive";', '           else:',
-            '               echo "Number is negative";', 'endif;', '       break;', '       default:',
-            '           echo "Number is not zero";', '       }', 'foreach (array(1, 2, 3) as $num):',
-            '       echo "Num: $num";', '   endforeach;', '}', '?>'
+            '<?php', 
+            'function checkNumber($number)', 
+            '{', 
+            '   switch ($number) {', 
+            '       case 0:',
+            '       echo "Number is zero again";', 
+            '           if ($number == 0):',
+            '               echo "Number is zero";', 
+            '           elseif ($number > 0):',
+            '               echo "Number is positive";', 
+            '           else:',
+            '               echo "Number is negative";', 
+            'endif;', 
+            '       break;', 
+            '       default:',
+            '           echo "Number is not zero";', 
+            '       }', 'foreach (array(1, 2, 3) as $num):',
+            '       echo "Num: $num";', 
+            '   endforeach;', 
+            '}', 
+            '?>', 
+            '', 
+            '<script>', 
+            '    function test() {', 
+            '        ', 
+            '    }', 
+            '</script>', 
+            '<style>', 
+            '    div {', 
+            '        color: red;', 
+            '    }', 
+            '</style>'
         ]);
 
         session.setFoldStyle("markbeginend");
@@ -41,6 +66,18 @@ module.exports = {
         assert.equal(session.getFoldWidget(17), "start");
         assert.equal(session.getFoldWidget(19), "end");
         assert.equal(session.getFoldWidget(20), "end");
+        assert.equal(session.getFoldWidget(21), "");
+        assert.equal(session.getFoldWidget(22), "");
+        assert.equal(session.getFoldWidget(23), "start");
+        assert.equal(session.getFoldWidget(24), "start");
+        assert.equal(session.getFoldWidget(25), "");
+        assert.equal(session.getFoldWidget(26), "end");
+        assert.equal(session.getFoldWidget(27), "end");
+        assert.equal(session.getFoldWidget(28), "start");
+        assert.equal(session.getFoldWidget(29), "start");
+        assert.equal(session.getFoldWidget(30), "");
+        assert.equal(session.getFoldWidget(31), "end");
+        assert.equal(session.getFoldWidget(32), "end");
 
         assert.range(session.getFoldWidgetRange(2), 2, 1, 20, 0); // Range for the function's foldable section
         assert.range(session.getFoldWidgetRange(3), 3, 21, 16, 7); // Range for the 'switch' statement
@@ -50,6 +87,14 @@ module.exports = {
         assert.range(session.getFoldWidgetRange(12), 10, 16, 12, 0); // Range for the 'endif' line
         assert.range(session.getFoldWidgetRange(17), 17, 33, 19, 3);
         assert.range(session.getFoldWidgetRange(19), 17, 33, 19, 3);
+        assert.range(session.getFoldWidgetRange(23), 23, 8, 27, 0); // Range for script tag
+        assert.range(session.getFoldWidgetRange(24), 24, 21, 26, 4); // Range for cstyle { } block
+        assert.range(session.getFoldWidgetRange(26), 24, 21, 26, 4); // Range for closing cstyle { } block
+        assert.range(session.getFoldWidgetRange(27), 23, 8, 27, 0); // Range for closing script tag
+        assert.range(session.getFoldWidgetRange(28), 28, 7, 32, 0); // Range for openning style tag
+        assert.range(session.getFoldWidgetRange(29), 29, 9, 31, 4); // Range for cstyle { } block
+        assert.range(session.getFoldWidgetRange(31), 29, 9, 31, 4); // Range for closing cstyle { } block
+        assert.range(session.getFoldWidgetRange(32), 28, 7, 32, 0); // Range for closing style tag
     }
 };
 

--- a/src/mode/php.js
+++ b/src/mode/php.js
@@ -9,6 +9,9 @@ var WorkerClient = require("../worker/worker_client").WorkerClient;
 var PhpCompletions = require("./php_completions").PhpCompletions;
 var PhpFoldMode = require("./folding/php").FoldMode;
 var unicode = require("../unicode");
+var MixedFoldMode = require("./folding/mixed").FoldMode;
+var HtmlFoldMode = require("./folding/html").FoldMode;
+var CstyleFoldMode = require("./folding/cstyle").FoldMode;
 var HtmlMode = require("./html").Mode;
 var JavaScriptMode = require("./javascript").Mode;
 var CssMode = require("./css").Mode;
@@ -18,7 +21,11 @@ var PhpMode = function(opts) {
     this.$outdent = new MatchingBraceOutdent();
     this.$behaviour = this.$defaultBehaviour;
     this.$completer = new PhpCompletions();
-    this.foldingRules = new PhpFoldMode();
+    this.foldingRules = new MixedFoldMode(new HtmlFoldMode(), {
+        "js-": new CstyleFoldMode(),
+        "css-": new CstyleFoldMode(),
+        "php-": new PhpFoldMode()
+    });
 };
 oop.inherits(PhpMode, TextMode);
 
@@ -91,7 +98,11 @@ var Mode = function(opts) {
         "css-": CssMode,
         "php-": PhpMode
     });
-    this.foldingRules = new PhpFoldMode();
+    this.foldingRules = new MixedFoldMode(new HtmlFoldMode(), {
+        "js-": new CstyleFoldMode(),
+        "css-": new CstyleFoldMode(),
+        "php-": new PhpFoldMode()
+    });
 };
 oop.inherits(Mode, HtmlMode);
 


### PR DESCRIPTION
*Issue #, if available:* #5547

*Description of changes:*
This change should fix the regression related to determining folding widgets for HTML tags, which was introduced by #5491.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

