### PR TITLE
fix bracket highlighting in css mode

### DIFF
--- a/src/mode/css_highlight_rules.js
+++ b/src/mode/css_highlight_rules.js
@@ -134,6 +134,9 @@ var CssHighlightRules = function() {
             token : keywordMapper,
             regex : "\\-?[a-zA-Z_][a-zA-Z0-9_\\-]*"
         }, {
+            token: "paren.lparen",
+            regex: "\\{"
+        }, {
             caseInsensitive: true
         }],
 


### PR DESCRIPTION
fixes https://github.com/ajaxorg/ace/issues/5556 by assigning compatible classnames to `{` and `}`