### PR TITLE
feat: allow users to add arialabel to text input

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -235,6 +235,7 @@ export namespace Ace {
     relativeLineNumbers: boolean;
     enableMultiselect: boolean;
     enableKeyboardAccessibility: boolean;
+    textInputAriaLabel: string;
   }
 
   export interface SearchOptions {

--- a/src/editor.js
+++ b/src/editor.js
@@ -3002,6 +3002,10 @@ config.defineOptions(Editor.prototype, "editor", {
         },
         initialValue: false
     },
+    textInputAriaLabel: {
+        set: function(val) { this.$textInputAriaLabel = val; },
+        initialValue: ""
+    },
     customScrollbar: "renderer",
     hScrollBarAlwaysVisible: "renderer",
     vScrollBarAlwaysVisible: "renderer",

--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -90,7 +90,11 @@ TextInput= function(parentNode, host) {
             text.setAttribute("aria-roledescription", nls("text-input.aria-roledescription", "editor"));
             if(host.session) {
                 var row =  host.session.selection.cursor.row;
-                var arialLabel = `${host.$textInputAriaLabel}, ${nls("text-input.aria-label", "Cursor at row $0", [row + 1])}`;
+                var arialLabel = "";
+                if (host.$textInputAriaLabel) {
+                    arialLabel += `${host.$textInputAriaLabel}, `;
+                }
+                arialLabel += nls("text-input.aria-label", "Cursor at row $0", [row + 1]);
                 text.setAttribute("aria-label", arialLabel);
             }
         }

--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -90,7 +90,8 @@ TextInput= function(parentNode, host) {
             text.setAttribute("aria-roledescription", nls("text-input.aria-roledescription", "editor"));
             if(host.session) {
                 var row =  host.session.selection.cursor.row;
-                text.setAttribute("aria-label", nls("text-input.aria-label", "Cursor at row $0", [row + 1]));
+                var arialLabel = `${host.$textInputAriaLabel}, ${nls("text-input.aria-label", "Cursor at row $0", [row + 1])}`;
+                text.setAttribute("aria-label", arialLabel);
             }
         }
     };

--- a/src/keyboard/textinput_test.js
+++ b/src/keyboard/textinput_test.js
@@ -755,7 +755,18 @@ module.exports = {
         assert.equal(editor.getValue(), "x");
     },
 
-    "test: text input aria label": function() {
+    "test: text input aria label without extra label set": function() {
+        editor.setValue("x      x", -1);
+        editor.setOption('enableKeyboardAccessibility', true);
+        editor.renderer.$loop._flush();
+
+        editor.focus();
+
+        let text = editor.container.querySelector(".ace_text-input"); 
+        assert.equal(text.getAttribute("aria-label"), "Cursor at row 1");
+    },
+
+    "test: text input aria label with extra label set": function() {
         editor.setValue("x      x", -1);
         editor.setOption('textInputAriaLabel', "super cool editor");
         editor.setOption('enableKeyboardAccessibility', true);

--- a/src/keyboard/textinput_test.js
+++ b/src/keyboard/textinput_test.js
@@ -753,6 +753,18 @@ module.exports = {
         assert.equal(editor.getValue(), "");
         sendEvent("input", {key: {inputType: "historyRedo"}});
         assert.equal(editor.getValue(), "x");
+    },
+
+    "test: text input aria label": function() {
+        editor.setValue("x      x", -1);
+        editor.setOption('textInputAriaLabel', "super cool editor");
+        editor.setOption('enableKeyboardAccessibility', true);
+        editor.renderer.$loop._flush();
+
+        editor.focus();
+
+        let text = editor.container.querySelector(".ace_text-input"); 
+        assert.equal(text.getAttribute("aria-label"), "super cool editor, Cursor at row 1");
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently, the aria-label of the text input says `Cursor at row x`, some users might want to add context about their editor to this aria label. This change adds an option, `textInputAriaLabel`, which is used to create and aria-label as `textInputAriaLabel, Cursor at row x`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

