### PR TITLE
fix: always set aria-label to text input in a11y mode

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -235,6 +235,7 @@ export namespace Ace {
     relativeLineNumbers: boolean;
     enableMultiselect: boolean;
     enableKeyboardAccessibility: boolean;
+    textInputAriaLabel: string;
   }
 
   export interface SearchOptions {

--- a/src/editor.js
+++ b/src/editor.js
@@ -2939,6 +2939,7 @@ config.defineOptions(Editor.prototype, "editor", {
             // - Prevent tab-trapping.
             // - Hide irrelevant elements from assistive technology.
             // - On Windows, set more lines to the textarea.
+            // - set aria-label to the text input.
             if (value){
                 this.renderer.enableKeyboardAccessibility = true;
                 this.renderer.keyboardFocusClassName = "ace_keyboard-focus";
@@ -2973,6 +2974,10 @@ config.defineOptions(Editor.prototype, "editor", {
                     gutterKeyboardHandler = new GutterKeyboardHandler(this);
 
                 gutterKeyboardHandler.addListener();
+
+                this.textInput.setAriaOptions({
+                    setLabel: true
+                });
             } else {
                 this.renderer.enableKeyboardAccessibility = false;
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -3002,6 +3002,10 @@ config.defineOptions(Editor.prototype, "editor", {
         },
         initialValue: false
     },
+    textInputAriaLabel: {
+        set: function(val) { this.$textInputAriaLabel = val; },
+        initialValue: ""
+    },
     customScrollbar: "renderer",
     hScrollBarAlwaysVisible: "renderer",
     vScrollBarAlwaysVisible: "renderer",

--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -90,7 +90,11 @@ TextInput= function(parentNode, host) {
             text.setAttribute("aria-roledescription", nls("text-input.aria-roledescription", "editor"));
             if(host.session) {
                 var row =  host.session.selection.cursor.row;
-                var arialLabel = `${host.$textInputAriaLabel}, ${nls("text-input.aria-label", "Cursor at row $0", [row + 1])}`;
+                var arialLabel = "";
+                if (host.$textInputAriaLabel) {
+                    arialLabel += `${host.$textInputAriaLabel}, `;
+                }
+                arialLabel += nls("text-input.aria-label", "Cursor at row $0", [row + 1]);
                 text.setAttribute("aria-label", arialLabel);
             }
         }

--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -88,19 +88,19 @@ TextInput= function(parentNode, host) {
         }     
         if (options.setLabel) {
             text.setAttribute("aria-roledescription", nls("text-input.aria-roledescription", "editor"));
+            var arialLabel = "";
+            if (host.$textInputAriaLabel) {
+                arialLabel += `${host.$textInputAriaLabel}, `;
+            }
             if(host.session) {
                 var row =  host.session.selection.cursor.row;
-                var arialLabel = "";
-                if (host.$textInputAriaLabel) {
-                    arialLabel += `${host.$textInputAriaLabel}, `;
-                }
                 arialLabel += nls("text-input.aria-label", "Cursor at row $0", [row + 1]);
-                text.setAttribute("aria-label", arialLabel);
             }
+            text.setAttribute("aria-label", arialLabel);
         }
     };
 
-    this.setAriaOptions({role: "textbox"}); 
+    this.setAriaOptions({role: "textbox", setLabel: host.renderer.enableKeyboardAccessibility}); 
 
     event.addListener(text, "blur", function(e) {
         if (ignoreFocusEvents) return;

--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -90,7 +90,8 @@ TextInput= function(parentNode, host) {
             text.setAttribute("aria-roledescription", nls("text-input.aria-roledescription", "editor"));
             if(host.session) {
                 var row =  host.session.selection.cursor.row;
-                text.setAttribute("aria-label", nls("text-input.aria-label", "Cursor at row $0", [row + 1]));
+                var arialLabel = `${host.$textInputAriaLabel}, ${nls("text-input.aria-label", "Cursor at row $0", [row + 1])}`;
+                text.setAttribute("aria-label", arialLabel);
             }
         }
     };

--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -100,7 +100,7 @@ TextInput= function(parentNode, host) {
         }
     };
 
-    this.setAriaOptions({role: "textbox", setLabel: host.renderer.enableKeyboardAccessibility}); 
+    this.setAriaOptions({role: "textbox"}); 
 
     event.addListener(text, "blur", function(e) {
         if (ignoreFocusEvents) return;

--- a/src/keyboard/textinput_test.js
+++ b/src/keyboard/textinput_test.js
@@ -760,10 +760,25 @@ module.exports = {
         editor.setOption('enableKeyboardAccessibility', true);
         editor.renderer.$loop._flush();
 
-        editor.focus();
+        let text = editor.container.querySelector(".ace_text-input"); 
+        assert.equal(text.getAttribute("aria-label"), "Cursor at row 1");
+    },
+
+    "test: text input aria label updated on focus": function() {
+        editor.setValue("x      x\ny      y", -1);
+        editor.setOption('enableKeyboardAccessibility', true);
+        editor.renderer.$loop._flush();
 
         let text = editor.container.querySelector(".ace_text-input"); 
         assert.equal(text.getAttribute("aria-label"), "Cursor at row 1");
+
+        editor.focus();
+        sendEvent("keydown", {key: { code: "ArrowDown", key: "ArrowDown", keyCode: 40}});
+        editor.renderer.$loop._flush();
+
+        editor.blur();
+        editor.focus();
+        assert.equal(text.getAttribute("aria-label"), "Cursor at row 2");
     },
 
     "test: text input aria label with extra label set": function() {
@@ -771,8 +786,6 @@ module.exports = {
         editor.setOption('textInputAriaLabel', "super cool editor");
         editor.setOption('enableKeyboardAccessibility', true);
         editor.renderer.$loop._flush();
-
-        editor.focus();
 
         let text = editor.container.querySelector(".ace_text-input"); 
         assert.equal(text.getAttribute("aria-label"), "super cool editor, Cursor at row 1");

--- a/src/keyboard/textinput_test.js
+++ b/src/keyboard/textinput_test.js
@@ -755,7 +755,18 @@ module.exports = {
         assert.equal(editor.getValue(), "x");
     },
 
-    "test: text input aria label": function() {
+    "test: text input aria label without extra label set": function() {
+        editor.setValue("x      x", -1);
+        editor.setOption('enableKeyboardAccessibility', true);
+        editor.renderer.$loop._flush();
+
+        editor.focus();
+
+        let text = editor.container.querySelector(".ace_text-input"); 
+        assert.equal(text.getAttribute("aria-label"), "Cursor at row 1");
+    },
+
+    "test: text input aria label with extra label set": function() {
         editor.setValue("x      x", -1);
         editor.setOption('textInputAriaLabel', "super cool editor");
         editor.setOption('enableKeyboardAccessibility', true);

--- a/src/keyboard/textinput_test.js
+++ b/src/keyboard/textinput_test.js
@@ -753,6 +753,18 @@ module.exports = {
         assert.equal(editor.getValue(), "");
         sendEvent("input", {key: {inputType: "historyRedo"}});
         assert.equal(editor.getValue(), "x");
+    },
+
+    "test: text input aria label": function() {
+        editor.setValue("x      x", -1);
+        editor.setOption('textInputAriaLabel', "super cool editor");
+        editor.setOption('enableKeyboardAccessibility', true);
+        editor.renderer.$loop._flush();
+
+        editor.focus();
+
+        let text = editor.container.querySelector(".ace_text-input"); 
+        assert.equal(text.getAttribute("aria-label"), "super cool editor, Cursor at row 1");
     }
 };
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* We recently allowed users to set custom aria-labels to the text input, we currently only set the label on focus which makes it hard for users to find their custom label for their first input. This fixes that by always setting the label.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

