### PR TITLE
Fix: wrong doc comment * insert behaviour

### DIFF
--- a/src/mode/behaviour/behaviour_test.js
+++ b/src/mode/behaviour/behaviour_test.js
@@ -460,6 +460,37 @@ module.exports = {
         editor.setValue("    /**", 1);
         exec("insertstring", 1, "\n");
         assert.equal(editor.getValue(), "    /**\n     * \n     */");
+
+        // Test case 4: Cursor between closing */ and opening /** on the same line
+        editor.setValue("/**\n * Some comment\n *//**", 1);
+        editor.gotoLine(3, 3);
+        exec("insertstring", 1, "\n");
+        assert.equal(editor.getValue(), "/**\n * Some comment\n */\n /**");
+
+        // Test case 5: Cursor at start of the line with doc comment
+        editor.setValue("/**\n * Some comment\n */", 1);
+        editor.gotoLine(1, 0);
+        exec("insertstring", 1, "\n");
+        assert.equal(editor.getValue(), "\n/**\n * Some comment\n */");
+
+        // Test case 6: Cursor at the end of the first comment
+        editor.setValue("/** comment */identifier/**", 1);
+        editor.gotoLine(1, 14);
+        exec("insertstring", 1, "\n");
+        assert.equal(editor.getValue(), "/** comment */\nidentifier/**");
+
+        // Test case 7: Cursor at the start of the second comment
+        editor.setValue("/** comment */identifier/**", 1);
+        editor.gotoLine(1, 24);
+        exec("insertstring", 1, "\n");
+        assert.equal(editor.getValue(), "/** comment */identifier\n/**");
+
+        // Test case 8: Cursor between '/' and '*' in a comment
+        editor.setValue("/** comment */", 1);
+        editor.gotoLine(1, 1);
+        exec("insertstring", 1, "\n");
+        assert.equal(editor.getValue(), "/\n** comment */");
+
     },
     "test: fragment auto-closing": function () {
         editor.setWrapBehavioursEnabled(true);

--- a/src/mode/javascript.js
+++ b/src/mode/javascript.js
@@ -46,13 +46,6 @@ oop.inherits(Mode, TextMode);
             if (endState == "start" || endState == "no_regex") {
                 return "";
             }
-            var match = line.match(/^\s*(\/?)\*/);
-            if (match) {
-                if (match[1]) {
-                    indent += " ";
-                }
-                indent += "* ";
-            }
         }
 
         return indent;

--- a/src/mode/javascript_test.js
+++ b/src/mode/javascript_test.js
@@ -141,15 +141,7 @@ module.exports = {
         assert.equal("    ", this.mode.getNextLineIndent("start", "    cde", "  "));
         assert.equal("    ", this.mode.getNextLineIndent("start", "function foo(items) {", "    "));
     },
-
-    "test: special indent in doc comments" : function() {
-        assert.equal(" * ", this.mode.getNextLineIndent("doc-start", "/**", " "));
-        assert.equal("   * ", this.mode.getNextLineIndent("doc-start", "  /**", " "));
-        assert.equal(" * ", this.mode.getNextLineIndent("doc-start", " *", " "));
-        assert.equal("    * ", this.mode.getNextLineIndent("doc-start", "    *", " "));
-        assert.equal("  ", this.mode.getNextLineIndent("doc-start", "  abc", " "));
-    },
-
+    
     "test: no indent after doc comments" : function() {
         assert.equal("", this.mode.getNextLineIndent("doc-start", "   */", "  "));
     },


### PR DESCRIPTION
*Issue #, if available:* #5555 #5320

*Description of changes:*
This change should fix most of wrong newline adding asterisk insert behaviours

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

