### PR TITLE
feat: allow '{n}' as placeholder for translated strings

### DIFF
--- a/src/config_test.js
+++ b/src/config_test.js
@@ -54,7 +54,7 @@ module.exports = {
         config.setMessages({
             foo: "hello world of $1",
             test_key: "hello world for test key",
-            test_with_curly_brackets: "hello world $0 of {1} and $2"
+            test_with_curly_brackets: "hello world $0 of {1} and $2 to the {3} degree"
         });
         assert.equal(nls("untranslated_key","bar $1"), "bar $1");
         assert.equal(nls("untranslated_key", "bar"), "bar");
@@ -63,7 +63,7 @@ module.exports = {
         assert.equal(nls("untranslated_key", "$0B is $1$$", [0.11, 22]), "0.11B is 22$");
         assert.equal(nls("untranslated_key_but_translated_default_string", "foo", {1: "goo"}), "hello world of goo");
         assert.equal(nls("test_key", "this text should not appear"), "hello world for test key");
-        assert.equal(nls("test_with_curly_brackets", "hello world $0 of {1} and $2", ["foo", "bar", "yay"]), "hello world foo of bar and yay");
+        assert.equal(nls("test_with_curly_brackets", "hello world $0 of {1} and $2 to the {3} degree", ["foo", "bar", "yay", "third"]), "hello world foo of bar and yay to the third degree");
     },
     "test: define options" : function() {
         var o = {};

--- a/src/config_test.js
+++ b/src/config_test.js
@@ -53,7 +53,8 @@ module.exports = {
         var nls = config.nls;
         config.setMessages({
             foo: "hello world of $1",
-            test_key: "hello world for test key"
+            test_key: "hello world for test key",
+            test_with_curly_brackets: "hello world $0 of {1} and $2"
         });
         assert.equal(nls("untranslated_key","bar $1"), "bar $1");
         assert.equal(nls("untranslated_key", "bar"), "bar");
@@ -62,6 +63,7 @@ module.exports = {
         assert.equal(nls("untranslated_key", "$0B is $1$$", [0.11, 22]), "0.11B is 22$");
         assert.equal(nls("untranslated_key_but_translated_default_string", "foo", {1: "goo"}), "hello world of goo");
         assert.equal(nls("test_key", "this text should not appear"), "hello world for test key");
+        assert.equal(nls("test_with_curly_brackets", "hello world $0 of {1} and $2", ["foo", "bar", "yay"]), "hello world foo of bar and yay");
     },
     "test: define options" : function() {
         var o = {};

--- a/src/lib/app_config.js
+++ b/src/lib/app_config.js
@@ -158,9 +158,15 @@ class AppConfig {
 
         var translated = messages[key] || messages[defaultString] || defaultString;
         if (params) {
-            translated = translated.replace(/\$(\$|[\d]+)/g, function(_, name) {
-                if (name == "$") return "$";
-                return params[name];
+            // We support both $n or {n} as placeholder indicators in the provided translated strings
+            // Replace $n with the nth element in params
+            translated = translated.replace(/\$(\$|[\d]+)/g, function(_, dollarMatch) {
+                if (dollarMatch == "$") return "$";
+                return params[dollarMatch];
+            });
+             // Replace {n} with the nth element in params
+            translated = translated.replace(/\{([^\}]+)\}/g, function(_, curlyBracketMatch) {
+                return params[curlyBracketMatch];
             });
         }
         return translated;


### PR DESCRIPTION
*Issue #, if available:* na

*Description of changes:* Currently, we only allow `$n` as the placeholder when providing translated strings to Ace (e.g. `Cursor at row $0`). This change allows to also use `{n}` (e.g. `Cursor at row {n}`) as the syntax as that's a syntax used by some translation libraries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

