### PR TITLE
fix: allow setting the placeholder type for nls

### DIFF
--- a/src/config_test.js
+++ b/src/config_test.js
@@ -53,8 +53,7 @@ module.exports = {
         var nls = config.nls;
         config.setMessages({
             foo: "hello world of $1",
-            test_key: "hello world for test key",
-            test_with_curly_brackets: "hello world $0 of {1} and $2 to the {3} degree"
+            test_key: "hello world for test key"
         });
         assert.equal(nls("untranslated_key","bar $1"), "bar $1");
         assert.equal(nls("untranslated_key", "bar"), "bar");
@@ -63,7 +62,25 @@ module.exports = {
         assert.equal(nls("untranslated_key", "$0B is $1$$", [0.11, 22]), "0.11B is 22$");
         assert.equal(nls("untranslated_key_but_translated_default_string", "foo", {1: "goo"}), "hello world of goo");
         assert.equal(nls("test_key", "this text should not appear"), "hello world for test key");
-        assert.equal(nls("test_with_curly_brackets", "hello world $0 of {1} and $2 to the {3} degree", ["foo", "bar", "yay", "third"]), "hello world foo of bar and yay to the third degree");
+    },
+    "test: nls setting nlsPlaceholders": function() {
+        var nls = config.nls;
+
+        // Should default to using dollar signs
+        config.setMessages({
+            test_with_curly_brackets: "hello world $0 of {0} and $1 to the {1} degree"
+        });
+        assert.equal(nls("test_with_curly_brackets", "hello world $0 of {1} and $1 to the {1} degree", ["bar", "third"]), "hello world bar of {0} and third to the {1} degree");
+
+        config.setMessages({
+            test_with_curly_brackets: "hello world $0 of {0} and $1 to the {1} degree"
+        }, {placeholders: "curlyBrackets"});
+        assert.equal(nls("test_with_curly_brackets", "hello world $0 of {1} and $1 to the {1} degree", ["bar", "third"]), "hello world $0 of bar and $1 to the third degree");
+
+        config.setMessages({
+            test_with_curly_brackets: "hello world $0 of {0} and $1 to the {1} degree"
+        }, {placeholders: "dollarSigns"});
+        assert.equal(nls("test_with_curly_brackets", "hello world $0 of {1} and $1 to the {1} degree", ["bar", "third"]), "hello world bar of {0} and third to the {1} degree");
     },
     "test: define options" : function() {
         var o = {};

--- a/src/lib/app_config.js
+++ b/src/lib/app_config.js
@@ -59,11 +59,13 @@ function warn(message) {
 }
 
 var messages;
+var nlsPlaceholders;
 
 class AppConfig {
     constructor() {
             this.$defaultOptions = {};
             messages = defaultEnglishMessages;
+            nlsPlaceholders = "dollarSigns";
         }
     
     /**
@@ -138,9 +140,13 @@ class AppConfig {
 
     /**
      * @param {any} value
+     * @param {{placeholders?: "dollarSigns" | "curlyBrackets"}} [options]
      */
-    setMessages(value) {
+    setMessages(value, options) {
         messages = value;
+        if (options && options.placeholders) {
+            nlsPlaceholders = options.placeholders;
+        }
     }
 
     /**
@@ -159,15 +165,19 @@ class AppConfig {
         var translated = messages[key] || messages[defaultString] || defaultString;
         if (params) {
             // We support both $n or {n} as placeholder indicators in the provided translated strings
-            // Replace $n with the nth element in params
-            translated = translated.replace(/\$(\$|[\d]+)/g, function(_, dollarMatch) {
-                if (dollarMatch == "$") return "$";
-                return params[dollarMatch];
-            });
-             // Replace {n} with the nth element in params
-            translated = translated.replace(/\{([^\}]+)\}/g, function(_, curlyBracketMatch) {
-                return params[curlyBracketMatch];
-            });
+            if (nlsPlaceholders === "dollarSigns") {
+                // Replace $n with the nth element in params
+                translated = translated.replace(/\$(\$|[\d]+)/g, function(_, dollarMatch) {
+                    if (dollarMatch == "$") return "$";
+                    return params[dollarMatch];
+                });
+            }
+            if (nlsPlaceholders === "curlyBrackets") {
+                // Replace {n} with the nth element in params
+                translated = translated.replace(/\{([^\}]+)\}/g, function(_, curlyBracketMatch) {
+                    return params[curlyBracketMatch];
+                });
+            }
         }
         return translated;
     }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Follow-up to #5581, when setting the translated messages, allow configuring which placeholder is used for parameters. The allowed options are dollar signs or curly brackets. Default to dollar signs to not break current behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

