### PR TITLE
Support JSDoc comment optional values with negative exponents

### DIFF
--- a/src/mode/jsdoc_comment_highlight_rules.js
+++ b/src/mode/jsdoc_comment_highlight_rules.js
@@ -24,7 +24,7 @@ var JsDocCommentHighlightRules = function() {
                         ]
                     }, {
                         token: ["rparen.doc", "text.doc", "variable.parameter.doc", "lparen.doc", "variable.parameter.doc", "rparen.doc"],
-                        regex: /(})(\s*)(?:([\w=:\/\.]+)|(?:(\[)([\w=:\/\.]+)(\])))/,
+                        regex: /(})(\s*)(?:([\w=:\/\.]+)|(?:(\[)([\w=:\/\.\-]+)(\])))/,
                         next: "pop"
                     }, {
                         token: "rparen.doc",

--- a/src/mode/jsdoc_comment_highlight_rules.js
+++ b/src/mode/jsdoc_comment_highlight_rules.js
@@ -24,7 +24,7 @@ var JsDocCommentHighlightRules = function() {
                         ]
                     }, {
                         token: ["rparen.doc", "text.doc", "variable.parameter.doc", "lparen.doc", "variable.parameter.doc", "rparen.doc"],
-                        regex: /(})(\s*)(?:([\w=:\/\.]+)|(?:(\[)([\w=:\/\.\-]+)(\])))/,
+                        regex: /(})(\s*)(?:([\w=:\/\.]+)|(?:(\[)([\w=:\/\.\-\'\" ]+)(\])))/,
                         next: "pop"
                     }, {
                         token: "rparen.doc",


### PR DESCRIPTION
Now we support JSDoc comment optional values with negative exponents like: `@param {number} [min_value=1e-5]`

Fixes: #5595 

I just added a minus to the `RegExp`, so now it is recognized as a proper token:

Before:

![image](https://github.com/ajaxorg/ace/assets/5236548/ec722a0f-3f46-4a73-abe2-9743192fd5e7)

After:

![image](https://github.com/ajaxorg/ace/assets/5236548/a582396f-b66c-4e79-b9b4-4b7103efad7b)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.