### PR TITLE
add z-index: 1 to ace_placeholder

### DIFF
--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -645,12 +645,14 @@ module.exports = `
 }
 
 .ace_placeholder {
+    position: relative;
     font-family: arial;
     transform: scale(0.9);
     transform-origin: left;
     white-space: pre;
     opacity: 0.7;
     margin: 0 10px;
+    z-index: 1;
 }
 
 .ace_ghost_text {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/ajaxorg/ace/issues/5361

*Description of changes:*
Add z-index: 1 to ace_placeholder to make it appear on top of the active line indicator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [X] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

