### PR TITLE
fix: ghost text rendering of empty lines

### DIFF
--- a/src/autocomplete/inline_test.js
+++ b/src/autocomplete/inline_test.js
@@ -50,6 +50,10 @@ var completions = [
     {
         value: "long\nlong\nlong\nlong\nlong\nlong".repeat(100),
         score: 0
+    },
+    {
+        value: "foo suggestion with a\n\n\ngap",
+        score: 0
     }
 ];
 
@@ -304,6 +308,14 @@ module.exports = {
                 done();
             }, 50); 
         }, 50);  
+    },
+    "test: renders multi-line ghost text with empty lines": function(done) {
+        assert.equal(editor.renderer.$ghostTextWidget, null);
+        inline.show(editor, completions[8], "f");
+        editor.renderer.$loop._flush();
+        assert.strictEqual(getAllLines(), textBase + "foo suggestion with a");
+        assert.strictEqual(editor.renderer.$ghostTextWidget.el.innerHTML, `<div> </div><div> </div><div>gap</div>`);
+        done();
     },
     tearDown: function() {
         inline.destroy();

--- a/src/virtual_renderer.js
+++ b/src/virtual_renderer.js
@@ -1785,6 +1785,10 @@ class VirtualRenderer {
                 // If the line is wider than the viewport, wrap the line
                 if (el.wrapped) chunkDiv.className = "ghost_text_line_wrapped";
 
+                // If a given line doesn't have text (e.g. it's a line of whitespace), set a space as the 
+                // textcontent so that browsers render the empty line div.
+                if (el.text.length === 0) el.text = " "; 
+                
                 chunkDiv.appendChild(dom.createTextNode(el.text));
                 widgetDiv.appendChild(chunkDiv);
             });

--- a/src/virtual_renderer_test.js
+++ b/src/virtual_renderer_test.js
@@ -395,7 +395,7 @@ module.exports = {
         editor.renderer.$loop._flush();
         assert.equal(editor.renderer.content.textContent, "abcdefThis is a long test text that is longer than ");
 
-        assert.equal(editor.session.lineWidgets[0].el.innerHTML, `<div class="ghost_text_line_wrapped">30 characters</div><div></div><div>Ghost3</div>`);
+        assert.equal(editor.session.lineWidgets[0].el.innerHTML, `<div class="ghost_text_line_wrapped">30 characters</div><div> </div><div>Ghost3</div>`);
 
         editor.removeGhostText();
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* In the ghost text, we set the content of a line as the text content of a div. For lines without any text (e.g. when the suggestion has a line of white space) this results in a div without any contents, which most browsers will not render. This change sets a space as the text content if it's empty to ensure the empty lines get rendered.

Before this change:


https://github.com/user-attachments/assets/7c03e522-b978-4ed9-9f28-ea4b7eb9cf1e



After:


https://github.com/user-attachments/assets/f3f3b371-3e83-4c28-938b-cbd18310e5f2



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

