### PR TITLE
[wip] fix: move right of cursor tokens to end of ghost text.

### DIFF
--- a/src/autocomplete/inline_test.js
+++ b/src/autocomplete/inline_test.js
@@ -50,6 +50,10 @@ var completions = [
     {
         value: "long\nlong\nlong\nlong\nlong\nlong".repeat(100),
         score: 0
+    },
+    {
+        value: "foo suggestion with a\n\n\ngap",
+        score: 0
     }
 ];
 
@@ -101,7 +105,7 @@ module.exports = {
         inline.show(editor, completions[3], "f");
         editor.renderer.$loop._flush();
         assert.strictEqual(getAllLines(), textBase + "function foo() {");
-        assert.strictEqual(editor.renderer.$ghostTextWidget.el.innerHTML, `<div>        console.log('test');</div><div>    }</div>`);
+        assert.strictEqual(editor.renderer.$ghostTextWidget.el.innerHTML, `<div><span class="ace_ghost_text">        console.log('test');</span></div><div><span class="ace_ghost_text">    }</span><span class="ace_text ace_ghost_text_offset"></span></div>`);
         done();
     },
     "test: boundary tests": function(done) {
@@ -304,6 +308,14 @@ module.exports = {
                 done();
             }, 50); 
         }, 50);  
+    },
+    "test: renders multi-line ghost text with empty lines": function(done) {
+        assert.equal(editor.renderer.$ghostTextWidget, null);
+        inline.show(editor, completions[8], "f");
+        editor.renderer.$loop._flush();
+        assert.strictEqual(getAllLines(), textBase + "foo suggestion with a");
+        assert.strictEqual(editor.renderer.$ghostTextWidget.el.innerHTML, `<div><span class="ace_ghost_text"> </span></div><div><span class="ace_ghost_text"> </span></div><div><span class="ace_ghost_text">gap</span><span class="ace_text ace_ghost_text_offset"></span></div>`);
+        done();
     },
     tearDown: function() {
         inline.destroy();

--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -660,7 +660,7 @@ module.exports = `
     font-style: italic;
 }
 
-.ace_ghost_text > div {
+.ace_ghost_text_container > div {
     white-space: pre;
 }
 
@@ -680,4 +680,13 @@ module.exports = `
     width:1px;
     height:1px;
     overflow:hidden;
+}
+
+.ace_hidden-token {
+    display: none;
+}
+
+.ace_ghost_text_offset {
+    font-style: normal;
+    opacity: 1;
 }`;

--- a/src/ext/inline_autocomplete_test.js
+++ b/src/ext/inline_autocomplete_test.js
@@ -358,7 +358,7 @@ module.exports = {
         typeAndChange("u", "n");
         editor.renderer.$loop._flush();
         assert.strictEqual(autocomplete.isOpen(), true);
-        assert.equal(getAllLines(), `function foo() {\n<div>    console.log('test');</div><div>}</div>`);
+        assert.equal(getAllLines(), `function foo() {\n<div><span class="ace_ghost_text">    console.log('test');</span></div><div><span class="ace_ghost_text">}</span><span class="ace_text ace_ghost_text_offset"></span></div>`);
 
         typeAndChange("d");
         editor.renderer.$loop._flush();

--- a/src/virtual_renderer_test.js
+++ b/src/virtual_renderer_test.js
@@ -376,7 +376,7 @@ module.exports = {
         editor.renderer.$loop._flush();
         assert.equal(editor.renderer.content.textContent, "abcdefGhost1");
         
-        assert.equal(editor.session.lineWidgets[0].el.innerHTML, `<div>Ghost2</div><div>Ghost3</div>`);
+        assert.equal(editor.session.lineWidgets[0].el.innerHTML, `<div><span class="ace_ghost_text">Ghost2</span></div><div><span class="ace_ghost_text">Ghost3</span><span class="ace_text ace_ghost_text_offset"></span></div>`);
 
         editor.removeGhostText();
 
@@ -395,7 +395,7 @@ module.exports = {
         editor.renderer.$loop._flush();
         assert.equal(editor.renderer.content.textContent, "abcdefThis is a long test text that is longer than ");
 
-        assert.equal(editor.session.lineWidgets[0].el.innerHTML, `<div class="ghost_text_line_wrapped">30 characters</div><div></div><div>Ghost3</div>`);
+        assert.equal(editor.session.lineWidgets[0].el.innerHTML, `<div class="ghost_text_line_wrapped"><span class="ace_ghost_text">30 characters</span></div><div><span class="ace_ghost_text"> </span></div><div><span class="ace_ghost_text">Ghost3</span><span class="ace_text ace_ghost_text_offset"></span></div>`);
 
         editor.removeGhostText();
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* When inserting ghost text in the middle of a line, move the tokens to the right of the cursor to the end of the ghost text.

https://github.com/user-attachments/assets/d2c9b0f2-8b0a-4767-a677-90a327afb10d

to do:
 - add tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

