### PR TITLE
feat(forced-color): do not adjust the forced colors for the editor

### DIFF
--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -35,6 +35,7 @@ module.exports = `
     direction: ltr;
     text-align: left;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    forced-color-adjust: none;
 }
 
 .ace_scroller {


### PR DESCRIPTION
*Issue #5028, if available:*

*Description of changes:*
For windows high contrast mode, we disable the colors changing to avoid conflicts with the theme by setting `forced-colors-adjust: none;`

**Before**

<img width="100%" alt="kitchen sink showing the forced colors emulation with the issue" src="https://github.com/user-attachments/assets/0eae637c-2814-4465-b28b-312b15d1e80c"> 

**After**

<img width="100%" alt="kitchen sink showing the forced colors emulation showing that we don't override that forced colros" src="https://github.com/user-attachments/assets/5fb08639-ffa5-4299-860b-0e08d4b012cd">


 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

