### PR TITLE
feat: allow setting marker type for MarkerGroups

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -290,7 +290,7 @@ export namespace Ace {
   }
 
   export class MarkerGroup {
-    constructor(session: EditSession);
+    constructor(session: EditSession, options?: {markerType?: "fullLine" | "line"});
     setMarkers(markers: MarkerGroupItem[]): void;
     getMarkerAtPosition(pos: Position): MarkerGroupItem;
   }

--- a/src/marker_group.js
+++ b/src/marker_group.js
@@ -16,7 +16,7 @@ Potential improvements:
 class MarkerGroup {
     /**
      * @param {EditSession} session
-     * @param {{markerType: "fullLine" | "line"}} options
+     * @param {{markerType: "fullLine" | "line" | undefined}} [options]
      */
     constructor(session, options) {
         if (options)

--- a/src/marker_group.js
+++ b/src/marker_group.js
@@ -16,7 +16,11 @@ Potential improvements:
 class MarkerGroup {
     /**
      * @param {EditSession} session
-     * @param {{markerType: "fullLine" | "line" | undefined}} [options]
+     * @param {{markerType: "fullLine" | "line" | undefined}} [options] Options controlling the behvaiour of the marker.
+     * User `markerType` to control how the markers which are part of this group will be rendered:
+     * - `undefined`: uses `text` type markers where only text characters within the range will be highlighted.
+     * - `fullLine`: will fully highlight all the rows within the range, including the characters before and after the range on the respective rows.
+     * - `line`: will fully highlight the lines within the range but will only cover the characters between the start and end of the range.
      */
     constructor(session, options) {
         if (options)

--- a/src/marker_group.js
+++ b/src/marker_group.js
@@ -120,7 +120,7 @@ class MarkerGroup {
                 else
                     markerLayer.drawTextMarker(html, screenRange, marker.className, config);
             } else {
-                markerLayer.drawSingleLineMarker(html, screenRange, marker.className + " ace_start" + " ace_br15", config);
+                markerLayer.drawSingleLineMarker(html, screenRange, marker.className + " ace_br15", config);
             }
         }
     }

--- a/src/marker_group.js
+++ b/src/marker_group.js
@@ -2,6 +2,7 @@
 /**
  * @typedef {import("./edit_session").EditSession} EditSession
  * @typedef {{range: import("./range").Range, className: string}} MarkerGroupItem
+ * @typedef {import("../ace-internal").Ace.LayerConfig} LayerConfig
  */
 /**
  * @typedef {import("./layer/marker").Marker} Marker
@@ -15,8 +16,12 @@ Potential improvements:
 class MarkerGroup {
     /**
      * @param {EditSession} session
+     * @param {{markerType: "fullLine" | "line"}} options
      */
-    constructor(session) {
+    constructor(session, options) {
+        if (options)
+            this.markerType = options.markerType;
+
         this.markers = [];
         /**@type {EditSession}*/
         this.session = session;
@@ -59,12 +64,12 @@ class MarkerGroup {
      * @param {any} html
      * @param {Marker} markerLayer
      * @param {EditSession} session
-     * @param {{ firstRow: any; lastRow: any; }} config
+     * @param {LayerConfig} config
      */
     update(html, markerLayer, session, config) {
         if (!this.markers || !this.markers.length)
             return;
-        var visibleRangeStartRow = config.firstRow, visibleRangeEndRow = config.lastRow;
+        var visibleRangeStartRow = config.firstRow, visibleRangeEndRow = 100;
         var foldLine;
         var markersOnOneLine = 0;
         var lastRow = 0;
@@ -103,10 +108,15 @@ class MarkerGroup {
                 continue;
             }
 
-            if (screenRange.isMultiLine()) {
-                markerLayer.drawTextMarker(html, screenRange, marker.className, config);
+            if (this.markerType === "fullLine") {
+                markerLayer.drawFullLineMarker(html, screenRange, marker.className, config);
+            } else if (screenRange.isMultiLine()) {
+                if (this.markerType === "line")
+                    markerLayer.drawMultiLineMarker(html, screenRange, marker.className, config);
+                else
+                    markerLayer.drawTextMarker(html, screenRange, marker.className, config);
             } else {
-                markerLayer.drawSingleLineMarker(html, screenRange, marker.className, config);
+                markerLayer.drawSingleLineMarker(html, screenRange, marker.className + " ace_start" + " ace_br15", config);
             }
         }
     }

--- a/src/marker_group.js
+++ b/src/marker_group.js
@@ -69,7 +69,7 @@ class MarkerGroup {
     update(html, markerLayer, session, config) {
         if (!this.markers || !this.markers.length)
             return;
-        var visibleRangeStartRow = config.firstRow, visibleRangeEndRow = 100;
+        var visibleRangeStartRow = config.firstRow, visibleRangeEndRow = config.lastRow;
         var foldLine;
         var markersOnOneLine = 0;
         var lastRow = 0;

--- a/src/marker_group_test.js
+++ b/src/marker_group_test.js
@@ -31,7 +31,7 @@ module.exports = {
 
         next();
     },
-   "test: show markers": function() {
+   "test: should show and update markers": function() {
         editor.resize(true);
         editor.renderer.$loop._flush();
         var markerGroup = new MarkerGroup(session1);
@@ -64,6 +64,87 @@ module.exports = {
         markerGroup.setMarkers([]);
         editor.renderer.$loop._flush();
         assert.equal(editor.container.querySelectorAll(".m1").length, 0);
+    },
+    "test: should show markers of fullLine type": function() {
+        editor.resize(true);
+        editor.renderer.$loop._flush();
+        var markerGroup = new MarkerGroup(session1, {markerType: "fullLine"});
+
+        // this marker should be rendered as a full block across lines 1 and 2
+        markerGroup.setMarkers([{
+            range: new Range(0, 12, 1, 4),
+            className: "ace_tooltip-marker_test m"
+        }]);
+        assert.ok(markerGroup.getMarkerAtPosition({row: 1, column: 1}));
+        editor.renderer.$loop._flush();
+        assert.equal(editor.container.querySelectorAll(".m").length, 1);
+
+        // Get dimensions of the full line marker
+        var markerSize = editor.container.querySelector(".m").getBoundingClientRect();
+        var lineHeight = editor.renderer.lineHeight;
+
+        // Height should be two lines
+        assert.equal(markerSize.height, 2 * lineHeight);
+        // Should start at the beginning of the line
+        assert.equal(markerSize.left, 0);
+        // Shoud be as wide as the marker layer itself.
+        assert.equal(markerSize.width, editor.renderer.$markerBack.element.getBoundingClientRect().width);
+    },
+    "test: should show markers of line type": function() {
+        editor.resize(true);
+        editor.renderer.$loop._flush();
+        var markerGroup = new MarkerGroup(session1, {markerType: "line"});
+
+        // this marker should be rendered just covering the range, but extending to the edge of the editor on newlines
+        markerGroup.setMarkers([{
+            range: new Range(0, 12, 1, 4),
+            className: "ace_tooltip-marker_test m"
+        }]);
+        assert.ok(markerGroup.getMarkerAtPosition({row: 1, column: 1}));
+        editor.renderer.$loop._flush();
+        // Should render two separate markers for each row
+        assert.equal(editor.container.querySelectorAll(".m").length, 2);
+
+        // Get dimensions of the first line marker
+        var markerSize = editor.container.querySelectorAll(".m")[0].getBoundingClientRect();
+        var lineHeight = editor.renderer.lineHeight;
+        var characterWidth = editor.renderer.characterWidth;
+
+        // Height should be one lines
+        assert.equal(markerSize.height, lineHeight);
+        // Should start at the 13th character (including 4px offset)
+        assert.equal(markerSize.left, 12 * characterWidth + 4);
+        // Shoud be as wide as the marker layer - 12 characters and the offset.
+        assert.equal(markerSize.width, editor.renderer.$markerBack.element.getBoundingClientRect().width - 12 * characterWidth - 4);
+    },
+    "test: should default to markers of text type": function() {
+        editor.resize(true);
+        editor.renderer.$loop._flush();
+
+        // We don't set options.markerType, should default to text markers
+        var markerGroup = new MarkerGroup(session1);
+
+        // this marker should be rendered just covering the range
+        markerGroup.setMarkers([{
+            range: new Range(0, 12, 1, 4),
+            className: "ace_tooltip-marker_test m"
+        }]);
+        assert.ok(markerGroup.getMarkerAtPosition({row: 1, column: 1}));
+        editor.renderer.$loop._flush();
+        // Should render two separate markers for each row
+        assert.equal(editor.container.querySelectorAll(".m").length, 2);
+
+        // Get dimensions of the first line marker
+        var markerSize = editor.container.querySelectorAll(".m")[0].getBoundingClientRect();
+        var lineHeight = editor.renderer.lineHeight;
+        var characterWidth = editor.renderer.characterWidth;
+
+        // Height should be one lines
+        assert.equal(markerSize.height, lineHeight);
+        // Should start at the 13th character (including 4px offset)
+        assert.equal(markerSize.left, 12 * characterWidth + 4);
+        // Shoud be as wide as the remaining characters in the range on the first line.
+        assert.equal(markerSize.width, 6 * characterWidth);
     },
     tearDown: function() {
         editor.destroy();


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* When using `MarkerGroup`s, currently, all markers default to being of the `text` type in which only the text itself is highlighted within a range. Users of `MarkerGroup`s might want to have different types of markers. 

This change adds an `options` parameter to allow setting marker type to `fullLine` or `line`. In `fullLine`, all the rows within the range will be fully highlighted, for `line` we highlight the same as default but when newlines are part of the range we fill up the highlight from the last character within the line to the right side of the editor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

