### PR TITLE
fix: improve type getMarkerAtPosition markergroup

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -292,7 +292,7 @@ export namespace Ace {
   export class MarkerGroup {
     constructor(session: EditSession, options?: {markerType?: "fullLine" | "line"});
     setMarkers(markers: MarkerGroupItem[]): void;
-    getMarkerAtPosition(pos: Position): MarkerGroupItem;
+    getMarkerAtPosition(pos: Position): MarkerGroupItem | undefined;
   }
 
 

--- a/src/marker_group.js
+++ b/src/marker_group.js
@@ -36,7 +36,7 @@ class MarkerGroup {
     /**
      * Finds the first marker containing pos
      * @param {import("../ace-internal").Ace.Point} pos 
-     * @returns import("../ace-internal").Ace.MarkerGroupItem
+     * @returns {import("../ace-internal").Ace.MarkerGroupItem | undefined} 
      */
     getMarkerAtPosition(pos) {
         return this.markers.find(function(marker) {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* `getMarkerAtPosition` uses [`Array.find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) to find the matching marker. When the position we search at doesn't have any markers, this returns `undefined` which we currently don't include in the exported type.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

