### PR TITLE
fix: apply padding to right side multi-line markers

### DIFF
--- a/src/layer/marker.js
+++ b/src/layer/marker.js
@@ -165,7 +165,7 @@ class Marker {
         } else {
             this.elt(
                 clazz + " ace_br1 ace_start",
-                "height:"+ height+ "px;"+ "right:0;"+ "top:"+top+ "px;left:"+ left+ "px;" + (extraStyle || "")
+                "height:"+ height+ "px;"+ "right:" + padding + "px;"+ "top:"+top+ "px;left:"+ left+ "px;" + (extraStyle || "")
             );
         }
         // from start of the last line to the selection end
@@ -197,7 +197,7 @@ class Marker {
         this.elt(
             clazz + (radiusClass ? " ace_br" + radiusClass : ""),
             "height:"+ height+ "px;"+
-            "right:0;"+
+            "right:" + padding + "px;"+
             "top:"+ top+ "px;"+
             "left:"+ padding+ "px;"+ (extraStyle || "")
         );

--- a/src/marker_group_test.js
+++ b/src/marker_group_test.js
@@ -114,8 +114,8 @@ module.exports = {
         assert.equal(markerSize.height, lineHeight);
         // Should start at the 13th character (including 4px offset)
         assert.equal(markerSize.left, 12 * characterWidth + 4);
-        // Shoud be as wide as the marker layer - 12 characters and the offset.
-        assert.equal(markerSize.width, editor.renderer.$markerBack.element.getBoundingClientRect().width - 12 * characterWidth - 4);
+        // Shoud be as wide as the marker layer - 12 characters and the offset on both sides.
+        assert.equal(markerSize.width, editor.renderer.$markerBack.element.getBoundingClientRect().width - 12 * characterWidth - 4 - 4);
     },
     "test: should default to markers of text type": function() {
         editor.resize(true);


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Currently, we apply a padding of 4px to the left side of multi line markers but no padding to the right side, making it hard to style both edges the same way. This adds a 4px padding to the right side of multi line selections.

<img width="794" alt="Screenshot 2024-08-30 at 15 30 03" src="https://github.com/user-attachments/assets/025a4b9e-8a76-4f3a-b03f-c9fe947225db">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

