### PR TITLE
fix: nunjucks mode not break completions

### DIFF
--- a/src/mode/nunjucks.js
+++ b/src/mode/nunjucks.js
@@ -5,6 +5,7 @@ var HtmlMode = require("./html").Mode;
 var NunjucksHighlightRules = require("./nunjucks_highlight_rules").NunjucksHighlightRules;
 
 var Mode = function() {
+    HtmlMode.call(this);
     this.HighlightRules = NunjucksHighlightRules;
 };
 


### PR DESCRIPTION
*Issue #, if available:*

![image](https://github.com/user-attachments/assets/21f11311-b56a-421f-ba96-1f5116a074d1)


*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] GUESS: No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

