### PR TITLE
Fix: recursive `readdirSync` for NodeJS < 20.1.0 

### DIFF
--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -130,6 +130,34 @@ declare module "ace-code/src/mode/behaviour" {
     export const Behaviour: new () => import(".").Ace.Behaviour;
 }
 
+declare module "ace-code/src/mode/behaviour/css" {
+    export const CssBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/cstyle" {
+    export const CstyleBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/html" {
+    export const HtmlBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/javascript" {
+    export const JavaScriptBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/liquid" {
+    export const LiquidBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/xml" {
+    export const XmlBehaviour: new () => import(".").Ace.Behaviour;
+}
+
+declare module "ace-code/src/mode/behaviour/xquery" {
+    export const XQueryBehaviour: new () => import(".").Ace.Behaviour;
+}
+
 declare module "ace-code/src/mode/bibtex_highlight_rules" {
     export const BibTeXHighlightRules: new () => import(".").Ace.HighlightRules;
 }
@@ -390,6 +418,110 @@ declare module "ace-code/src/mode/flix_highlight_rules" {
 
 declare module "ace-code/src/mode/flix" {
     export const Mode: new () => import(".").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/folding/asciidoc" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/c9search" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/coffee" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/csharp" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/cstyle" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/diff" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/drools" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/fold_mode" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/haskell_cabal" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/html" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/ini" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/java" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/javascript" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/latex" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/lua" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/markdown" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/mixed" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/php" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/pythonic" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/ruby" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/sql" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/sqlserver" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/vbscript" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/velocity" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/xml" {
+    export const FoldMode: new () => import(".").Ace.Folding;
+}
+
+declare module "ace-code/src/mode/folding/yaml" {
+    export const FoldMode: new () => import(".").Ace.Folding;
 }
 
 declare module "ace-code/src/mode/forth_highlight_rules" {

--- a/tool/modes-declaration-generator.js
+++ b/tool/modes-declaration-generator.js
@@ -124,9 +124,28 @@ function generateModuleDeclarations(dirPath) {
     });
 }
 
+function getAllFiles(dirPath) {
+    let files = [];
+
+    const entries = fs.readdirSync(dirPath);
+
+    entries.sort().forEach(entry => {
+        const fullPath = path.join(dirPath, entry);
+        const stat = fs.statSync(fullPath);
+
+        if (stat.isDirectory()) {
+            files = files.concat(getAllFiles(fullPath));
+        }
+        else if (stat.isFile()) {
+            files.push(fullPath);
+        }
+    });
+
+    return files;
+}
+
 function createProgram(dirPath) {
-    const fileNames = fs.readdirSync(dirPath, {recursive: true}).map(file => path.join(dirPath, file)).filter(
-        file => /\.js$/.test(file) && !/test\.js$/.test(file));
+    const fileNames = getAllFiles(dirPath).filter(file => /\.js$/.test(file) && !/test\.js$/.test(file));
 
     const program = ts.createProgram(fileNames, {
         target: ts.ScriptTarget.ES5,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Read all files with all subdirectories due to manual recursion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

