### PR TITLE
Edit session operation

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -428,6 +428,10 @@ export namespace Ace {
          */
         "change": (delta: Delta) => void;
         /**
+         * Emitted when the selection changes.
+         */
+        "changeSelection": () => void;
+        /**
          * Emitted when the tab size changes, via [[EditSession.setTabSize]].
          * @param tabSize
          */

--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -496,6 +496,16 @@ export namespace Ace {
          **/
         "changeScrollLeft": (scrollLeft: number) => void;
         "changeEditor": (e: { editor: Editor }) => void;
+        /**
+         * Emitted after operation starts.
+         * @param commandEvent event causing the operation
+         */
+        "startOperation": (commandEvent) => void;
+        /**
+         * Emitted after operation finishes.
+         * @param e event causing the finish
+         */
+        "endOperation": (e) => void;
     }
 
     interface EditorEvents {

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -506,6 +506,13 @@ export namespace Ace {
 
   export interface EditSession extends EventEmitter, OptionsProvider, Folding {
     selection: Selection;
+    curOp?: {
+      docChanged?: boolean;
+      selectionChanged?: boolean;
+      command?: {
+          name?: string;
+      };
+  };
 
     // TODO: define BackgroundTokenizer
 
@@ -517,7 +524,7 @@ export namespace Ace {
        callback: (obj: { data: { first: number, last: number } }) => void): Function;
     on(name: 'change', callback: () => void): Function;
     on(name: 'changeTabSize', callback: () => void): Function;
-
+    on(name: "beforeEndOperation", callback: () => void);
 
     setOption<T extends keyof EditSessionOptions>(name: T, value: EditSessionOptions[T]): void;
     getOption<T extends keyof EditSessionOptions>(name: T): EditSessionOptions[T];
@@ -625,6 +632,8 @@ export namespace Ace {
     documentToScreenRow(docRow: number, docColumn: number): number;
     getScreenLength(): number;
     getPrecedingCharacter(): string;
+    startOperation(commandEvent: {command: {name: string}}): void;
+    endOperation(): void;
     toJSON(): Object;
     destroy(): void;
   }

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -524,7 +524,7 @@ export namespace Ace {
        callback: (obj: { data: { first: number, last: number } }) => void): Function;
     on(name: 'change', callback: () => void): Function;
     on(name: 'changeTabSize', callback: () => void): Function;
-    on(name: "beforeEndOperation", callback: () => void);
+    on(name: "beforeEndOperation", callback: () => void): Function;
 
     setOption<T extends keyof EditSessionOptions>(name: T, value: EditSessionOptions[T]): void;
     getOption<T extends keyof EditSessionOptions>(name: T): EditSessionOptions[T];

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -45,6 +45,8 @@ class EditSession {
         this.$backMarkers = {};
         this.$markerId = 1;
         this.$undoSelect = true;
+        this.curOp = null;
+        this.prevOp = {};
 
         /** @type {FoldLine[]} */
         this.$foldData = [];
@@ -71,11 +73,9 @@ class EditSession {
         this.setDocument(text);
 
         this.selection = new Selection(this);
-        const onSelectionChange = () => {
-            this._signal("changeSelection");
-        };
-        this.selection.on("changeSelection", onSelectionChange);
-        this.selection.on("changeCursor", onSelectionChange);
+        this.$onSelectionChange = this.onSelectionChange.bind(this);
+        this.selection.on("changeSelection", this.$onSelectionChange);
+        this.selection.on("changeCursor", this.$onSelectionChange);
 
         this.$bidiHandler = new BidiHandler(this);
 
@@ -89,35 +89,35 @@ class EditSession {
 
     $initOperationListeners() {
         this.on("change", () => {
-            this.startOperation();
+            if (!this.curOp) {
+                this.startOperation();
+                this.curOp.selectionBefore = this.$lastSel;
+            }
             this.curOp.docChanged = true;
-        });
+        }, true);
         this.on("changeSelection", () => {
-            this.startOperation();
+            if (!this.curOp) {
+                this.startOperation();
+                this.curOp.selectionBefore = this.$lastSel;
+            }
             this.curOp.selectionChanged = true;
-        });
+        }, true);
 
         // Fallback mechanism in case current operation doesn't finish more explicitly.
         // Triggered, for example, when a consumer makes programmatic changes without invoking endOperation afterwards.
-        this.$operationResetTimer = lang.delayedCall(() => {
-            if (this.curOp && this.curOp.command && this.curOp.command.name === "mouse") {
-                // When current operation is mousedown, we wait for the mouseup to end the operation.
-                // So during a user selection, we would only end the operation when the final selection is known.
-                return;
-            }
-            this.endOperation();
-        });
+        this.$operationResetTimer = lang.delayedCall(this.endOperation.bind(this, true));
     }
 
     /**
      * Start an Ace operation, which will then batch all the subsequent changes (to either content or selection) under a single atomic operation.
-     * @param {{command?: {name?: string}}|undefined} [commandEvent] Optional name for the operation
+     * @param {{command?: {name?: string}, args?: any}|undefined} [commandEvent] Optional name for the operation
      */
     startOperation(commandEvent) {
         if (this.curOp) {
             if (!commandEvent || this.curOp.command) {
                 return;
             }
+            this.prevOp = this.curOp;
         }
         if (!commandEvent) {
             commandEvent = {};
@@ -125,20 +125,41 @@ class EditSession {
 
         this.$operationResetTimer.schedule();
         this.curOp = {
-            command: commandEvent.command || {}
+            command: commandEvent.command || {},
+            args: commandEvent.args,
         };
+        this.curOp.selectionBefore = this.selection.toJSON();
+        this._signal("startOperation", commandEvent);
     }
 
     /**
-     * End the current Ace operation.
+     * End current Ace operation.
      * Emits "beforeEndOperation" event just before clearing everything, where the current operation can be accessed through `curOp` property.
+     * @param {any} e 
      */
-    endOperation() {
-        this.$operationResetTimer.cancel();
+    endOperation(e) {
         if (this.curOp) {
+            if (e && e.returnValue === false) {
+                this.curOp = null;
+                this._signal("endOperation", e);
+                return;
+            }
+            if (e == true && this.curOp.command && this.curOp.command.name == "mouse") {
+                // When current operation is mousedown, we wait for the mouseup to end the operation.
+                // So during a user selection, we would only end the operation when the final selection is known.
+                return;
+            }
+
+            const currentSelection = this.selection.toJSON();
+            this.curOp.selectionAfter = currentSelection;
+            this.$lastSel = this.selection.toJSON();
+            this.getUndoManager().addSelection(currentSelection);
+
             this._signal("beforeEndOperation");
+            this.prevOp = this.curOp;
+            this.curOp = null;
+            this._signal("endOperation", e);
         }
-        this.curOp = null;
     }
 
     /**
@@ -246,6 +267,10 @@ class EditSession {
 
         this.bgTokenizer.$updateOnChange(delta);
         this._signal("change", delta);
+    }
+
+    onSelectionChange() {
+        this._signal("changeSelection");
     }
 
     /**
@@ -2448,10 +2473,15 @@ class EditSession {
             this.bgTokenizer.cleanup();
             this.destroyed = true;
         }
+        this.endOperation();
         this.$stopWorker();
         this.removeAllListeners();
         if (this.doc) {
             this.doc.off("change", this.$onChange);
+        }
+        if (this.selection) {
+            this.selection.off("changeCursor", this.$onSelectionChange);
+            this.selection.off("changeSelection", this.$onSelectionChange);
         }
         this.selection.detach();
     }

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -126,7 +126,7 @@ class EditSession {
         this.$operationResetTimer.schedule();
         this.curOp = {
             command: commandEvent.command || {},
-            args: commandEvent.args,
+            args: commandEvent.args
         };
         this.curOp.selectionBefore = this.selection.toJSON();
         this._signal("startOperation", commandEvent);

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -45,7 +45,6 @@ class EditSession {
         this.$backMarkers = {};
         this.$markerId = 1;
         this.$undoSelect = true;
-        this.curOp = null;
         this.prevOp = {};
 
         /** @type {FoldLine[]} */
@@ -88,6 +87,7 @@ class EditSession {
     }
 
     $initOperationListeners() {
+        this.curOp = null;
         this.on("change", () => {
             if (!this.curOp) {
                 this.startOperation();

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1203,7 +1203,6 @@ module.exports = {
         editor.insert("update");
         editor.endOperation();
         assert.equal(beforeEndOperationSpy.length, 1);
-        console.log(beforeEndOperationSpy);
         assert.equal(beforeEndOperationSpy[0].command.name, "imperative-update");
         assert.equal(beforeEndOperationSpy[0].docChanged, true);
         assert.equal(beforeEndOperationSpy[0].selectionChanged, true);

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1199,7 +1199,7 @@ module.exports = {
         });
 
         // Imperative update 
-        editor.startOperation({command: {name: "imperative-update"}})
+        editor.startOperation({command: {name: "imperative-update"}});
         editor.insert("update");
         editor.endOperation();
         assert.equal(beforeEndOperationSpy.length, 1);
@@ -1216,7 +1216,7 @@ module.exports = {
         assert.equal(beforeEndOperationSpy[1].docChanged, true);
         assert.equal(beforeEndOperationSpy[1].selectionChanged, true);
         assert.equal(!!beforeEndOperationSpy[1].selectionBefore, true);
-    },
+    }
 };
 
 if (typeof module !== "undefined" && module === require.main) {

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1198,31 +1198,71 @@ module.exports = {
         }, 10);
     },
 
-    "test: operation handling : when session is attached to an editor": function() {
+    "test: operation handling : when session is attached to an editor": function(done) {
         const session = new EditSession("Hello world!");
         const editor = new Editor(new MockRenderer(), session);
-        const beforeEndOperationSpy = [];
+        const beforeEndOperationSpySession = [];
         session.on("beforeEndOperation", () => {
-            beforeEndOperationSpy.push(session.curOp);
+            beforeEndOperationSpySession.push(session.curOp);
+        });
+        const beforeEndOperationSpyEditor = [];
+        editor.on("beforeEndOperation", () => {
+            beforeEndOperationSpyEditor.push(editor.curOp);
         });
 
-        // Imperative update 
+        // Imperative update from editor
         editor.startOperation({command: {name: "imperative-update"}});
         editor.insert("update");
         editor.endOperation();
-        assert.equal(beforeEndOperationSpy.length, 1);
-        assert.equal(beforeEndOperationSpy[0].command.name, "imperative-update");
-        assert.equal(beforeEndOperationSpy[0].docChanged, true);
-        assert.equal(beforeEndOperationSpy[0].selectionChanged, true);
-        assert.equal(!!beforeEndOperationSpy[0].selectionBefore, true);
+        for (const beforeEndOperationSpy of [beforeEndOperationSpySession, beforeEndOperationSpyEditor ]) {
+            assert.equal(beforeEndOperationSpy.length, 1);
+            assert.equal(beforeEndOperationSpy[0].command.name, "imperative-update");
+            assert.equal(beforeEndOperationSpy[0].docChanged, true);
+            assert.equal(beforeEndOperationSpy[0].selectionChanged, true);
+            assert.equal(!!beforeEndOperationSpy[0].selectionBefore, true);
+        }
+
+        // Imperative update from session
+        session.startOperation({command: {name: "session-update"}});
+        session.insert({row: 0, column : 0},"update");
+        session.endOperation();
+        for (const beforeEndOperationSpy of [beforeEndOperationSpySession, beforeEndOperationSpyEditor ]) {
+            assert.equal(beforeEndOperationSpy.length, 2);
+            assert.equal(beforeEndOperationSpy[1].command.name, "session-update");
+            assert.equal(beforeEndOperationSpy[1].docChanged, true);
+            assert.equal(beforeEndOperationSpy[1].selectionChanged, true);
+            assert.equal(!!beforeEndOperationSpy[1].selectionBefore, true);
+        }
 
         // Command update
         editor.execCommand(editor.commands.byName.indent);
-        assert.equal(beforeEndOperationSpy.length, 2);
-        assert.equal(beforeEndOperationSpy[1].command.name, "indent");
-        assert.equal(beforeEndOperationSpy[1].docChanged, true);
-        assert.equal(beforeEndOperationSpy[1].selectionChanged, true);
-        assert.equal(!!beforeEndOperationSpy[1].selectionBefore, true);
+        for (const beforeEndOperationSpy of [beforeEndOperationSpySession, beforeEndOperationSpyEditor ]) {
+            assert.equal(beforeEndOperationSpy.length, 3);
+            assert.equal(beforeEndOperationSpy[2].command.name, "indent");
+            assert.equal(beforeEndOperationSpy[2].docChanged, true);
+            assert.equal(beforeEndOperationSpy[2].selectionChanged, true);
+            assert.equal(!!beforeEndOperationSpy[2].selectionBefore, true);
+        }
+
+        // Session cleanup logic
+        const newSession = new EditSession("Hello again!");
+        editor.setSession(newSession);
+        const beforeEndOperationSpyNewSession = [];
+        newSession.on("beforeEndOperation", () => {
+            beforeEndOperationSpyNewSession.push(newSession.curOp);
+        });
+        editor.execCommand(editor.commands.byName.indent);
+        assert.equal(beforeEndOperationSpyEditor.length, 4);
+        assert.equal(beforeEndOperationSpyNewSession.length, 1);
+        assert.equal(beforeEndOperationSpySession.length, 3);
+
+        // Imperative implicit update from editor
+        editor.insert("update");
+        setTimeout(() => {
+            assert.equal(beforeEndOperationSpyEditor.length, 5);
+            assert.equal(beforeEndOperationSpyNewSession.length, 2);
+            done();
+        }, 10);
     }
 };
 

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1164,26 +1164,34 @@ module.exports = {
         session.insert({row: 0, column : 0}, "both");
         session.endOperation();
         assert.equal(beforeEndOperationSpy.length, 1);
-        assert.deepEqual(beforeEndOperationSpy[0], {command: {name: "inserting-both"}, docChanged: true, selectionChanged: true});
+        assert.equal(beforeEndOperationSpy[0].command.name, "inserting-both");
+        assert.equal(beforeEndOperationSpy[0].docChanged, true);
+        assert.equal(beforeEndOperationSpy[0].selectionChanged, true);
 
         // When only start operation is invoked
         session.startOperation({command: {name: "inserting-start"}});
         session.insert({row: 0, column : 0}, "start");
         setTimeout(() => {
             assert.equal(beforeEndOperationSpy.length, 2);
-            assert.deepEqual(beforeEndOperationSpy[1], {command: {name: "inserting-start"}, docChanged: true, selectionChanged: true});
+            assert.equal(beforeEndOperationSpy[1].command.name, "inserting-start");
+            assert.equal(beforeEndOperationSpy[1].docChanged, true);
+            assert.equal(beforeEndOperationSpy[1].selectionChanged, true);
             
             // When only end operation is invoked
             session.insert({row: 0, column : 0}, "end");
             session.endOperation();
             assert.equal(beforeEndOperationSpy.length, 3);
-            assert.deepEqual(beforeEndOperationSpy[2], {command: {}, docChanged: true, selectionChanged: true});
+            assert.deepEqual(beforeEndOperationSpy[2].command, {});
+            assert.equal(beforeEndOperationSpy[2].docChanged, true);
+            assert.equal(beforeEndOperationSpy[2].selectionChanged, true);
 
             // When nothing is invoked
             session.insert({row: 0, column : 0}, "none");
             setTimeout(() => {
                 assert.equal(beforeEndOperationSpy.length, 4);
-                assert.deepEqual(beforeEndOperationSpy[3], {command: {}, docChanged: true, selectionChanged: true});
+                assert.deepEqual(beforeEndOperationSpy[3].command, {});
+                assert.equal(beforeEndOperationSpy[3].docChanged, true);
+                assert.equal(beforeEndOperationSpy[3].selectionChanged, true);
                 
                 done();
             }, 10);

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1213,18 +1213,9 @@ module.exports = {
         editor.execCommand(editor.commands.byName.indent);
         assert.equal(beforeEndOperationSpy.length, 2);
         assert.equal(beforeEndOperationSpy[1].command.name, "indent");
-        assert.equal(beforeEndOperationSpy[0].docChanged, true);
-        assert.equal(beforeEndOperationSpy[0].selectionChanged, true);
-        assert.equal(!!beforeEndOperationSpy[0].selectionBefore, true);
-
-
-        // console.log(beforeEndOperationSpy);
-        // assert.equal(beforeEndOperationSpy[0].command.name, "imperative-update");
-        // assert.equal(beforeEndOperationSpy[0].docChanged, true);
-        // assert.equal(beforeEndOperationSpy[0].selectionChanged, true);
-        // assert.equal(!!beforeEndOperationSpy[0].selectionBefore, true);
-
-
+        assert.equal(beforeEndOperationSpy[1].docChanged, true);
+        assert.equal(beforeEndOperationSpy[1].selectionChanged, true);
+        assert.equal(!!beforeEndOperationSpy[1].selectionBefore, true);
     },
 };
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -112,11 +112,9 @@ class Editor {
     }
 
     onStartOperation(commandEvent) {
-        this.curOp = this.session.curOp = {
-            ...this.session.curOp,
-            // scrollTop is kept inside of EditSession only for backwards compatibility reasons
-            scrollTop: this.renderer.scrollTop
-        }
+        // scrollTop is kept inside of session.curOp only for backwards compatibility reasons
+        this.session.curOp.scrollTop = this.renderer.scrollTop;
+        this.curOp = this.session.curOp;
         this.prevOp = this.session.prevOp;
 
         if (!commandEvent) {
@@ -128,7 +126,7 @@ class Editor {
      * @arg e
      */
     onEndOperation(e) {
-        if (this.curOp) {
+        if (this.curOp && this.session) {
             if (e && e.returnValue === false) {
                 this.curOp = null;
                 return;
@@ -2665,6 +2663,7 @@ class Editor {
         if (this._$emitInputEvent)
             this._$emitInputEvent.cancel();
         this.removeAllListeners();
+
     }
 
     /**

--- a/src/editor.js
+++ b/src/editor.js
@@ -112,9 +112,8 @@ class Editor {
     }
 
     onStartOperation(commandEvent) {
-        // scrollTop is kept inside of session.curOp only for backwards compatibility reasons
-        this.session.curOp.scrollTop = this.renderer.scrollTop;
         this.curOp = this.session.curOp;
+        this.curOp.scrollTop = this.renderer.scrollTop;
         this.prevOp = this.session.prevOp;
 
         if (!commandEvent) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -48,7 +48,6 @@ class Editor {
      **/
     constructor(renderer, session, options) {
         /**@type{EditSession}*/this.session;
-        
         this.$toDestroy = [];
         
         var container = renderer.getContainerElement();
@@ -131,12 +130,13 @@ class Editor {
             commandEvent = {};
         }
 
+        this.session.startOperation(commandEvent);
         this.$opResetTimer.schedule();
         /**
          * @type {{[key: string]: any;}}
          */
         this.curOp = this.session.curOp = {
-            command: commandEvent.command || {},
+            command: commandEvent.command || (this.session.curOp && this.session.curOp.command) || {},
             args: commandEvent.args,
             scrollTop: this.renderer.scrollTop
         };
@@ -148,10 +148,10 @@ class Editor {
      */
     endOperation(e) {
         if (this.curOp && this.session) {
-            if (e && e.returnValue === false || !this.session)
-                return (this.curOp = null);
-            if (e == true && this.curOp.command && this.curOp.command.name == "mouse")
-                return;
+            if (e && e.returnValue === false) return (this.curOp = this.session.curOp = null);
+            if (e == true && this.curOp.command && this.curOp.command.name == "mouse") return;
+
+            this.session.endOperation();
             this._signal("beforeEndOperation");
             if (!this.curOp) return;
             var command = this.curOp.command;

--- a/src/editor.js
+++ b/src/editor.js
@@ -148,9 +148,10 @@ class Editor {
      */
     endOperation(e) {
         if (this.curOp && this.session) {
-            if (e && e.returnValue === false) return (this.curOp = this.session.curOp = null);
-            if (e == true && this.curOp.command && this.curOp.command.name == "mouse") return;
-
+            if (e && e.returnValue === false || !this.session)
+                return (this.curOp = this.session.curOp = null);
+            if (e == true && this.curOp.command && this.curOp.command.name == "mouse")
+                return;
             this.session.endOperation();
             this._signal("beforeEndOperation");
             if (!this.curOp) return;


### PR DESCRIPTION
## What
- Adding a concept of an "operation" to EditSession, the same one that we right now have in the Editor
- When EditSession is attached to an Editor, the Editor listens to the events from EditSession and EditSession is the true owner of the event.
- When EditSession is on it's own, it can only get programmatic changes, in which case it relies on programmatic handling of the operation lifecycle, where we still handle gracefully when that doesn't happen as expected.

## Why 
- When integrating Ace in a multiple files experiences, such as IDEs or just an editor with a tab bar, you work with multiple EditSessions and you swap them out within the Editor depending on which one is currently active/focussed. 
- It's very useful for those integrators to freely do changes to EditSession, even when one is not mounted to Editor, and listen to changes through `beforeEndOperation` to avoid intermediary states.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [X] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

