### PR TITLE
fix(a11y): update aria-label of textinput on cursor move

### DIFF
--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -73,6 +73,19 @@ TextInput= function(parentNode, host) {
         
         numberOfExtraLines = number;
     };
+
+    this.setAriaLabel = function() {
+        var ariaLabel = "";
+        if (host.$textInputAriaLabel) {
+            ariaLabel += `${host.$textInputAriaLabel}, `;
+        }
+        if(host.session) {
+            var row = host.session.selection.cursor.row;
+            ariaLabel += nls("text-input.aria-label", "Cursor at row $0", [row + 1]);
+        }
+        text.setAttribute("aria-label", ariaLabel);
+    };
+
     this.setAriaOptions = function(options) {
         if (options.activeDescendant) {
             text.setAttribute("aria-haspopup", "true");
@@ -88,19 +101,11 @@ TextInput= function(parentNode, host) {
         }     
         if (options.setLabel) {
             text.setAttribute("aria-roledescription", nls("text-input.aria-roledescription", "editor"));
-            var arialLabel = "";
-            if (host.$textInputAriaLabel) {
-                arialLabel += `${host.$textInputAriaLabel}, `;
-            }
-            if(host.session) {
-                var row =  host.session.selection.cursor.row;
-                arialLabel += nls("text-input.aria-label", "Cursor at row $0", [row + 1]);
-            }
-            text.setAttribute("aria-label", arialLabel);
+            this.setAriaLabel();
         }
     };
 
-    this.setAriaOptions({role: "textbox"}); 
+    this.setAriaOptions({role: "textbox"});
 
     event.addListener(text, "blur", function(e) {
         if (ignoreFocusEvents) return;
@@ -191,6 +196,9 @@ TextInput= function(parentNode, host) {
         // sync value of textarea
         resetSelection();
     });
+
+    // if cursor changes position, we need to update the label with the correct row
+    host.on("changeSelection", this.setAriaLabel);
     
     // Convert from row,column position to the linear position with respect to the current
     // block of lines in the textarea.

--- a/src/keyboard/textinput_test.js
+++ b/src/keyboard/textinput_test.js
@@ -789,7 +789,24 @@ module.exports = {
 
         let text = editor.container.querySelector(".ace_text-input"); 
         assert.equal(text.getAttribute("aria-label"), "super cool editor, Cursor at row 1");
-    }
+    },
+
+    "test: text input aria label updated on cursor move": function() {
+        editor.setValue("line1\nline2\nline3", -1);
+        editor.setOption('enableKeyboardAccessibility', true);
+        editor.renderer.$loop._flush();
+
+        let text = editor.container.querySelector(".ace_text-input");
+        assert.equal(text.getAttribute("aria-label"), "Cursor at row 1");
+
+        editor.focus();
+        sendEvent("keydown", {key: { code: "ArrowDown", key: "ArrowDown", keyCode: 40}});
+        sendEvent("keydown", {key: { code: "ArrowDown", key: "ArrowDown", keyCode: 40}});
+        sendEvent("keydown", {key: { code: "ArrowRight", key: "ArrowRight", keyCode: 39}});
+        editor.renderer.$loop._flush();
+
+        assert.equal(text.getAttribute("aria-label"), "Cursor at row 3");
+    },
 };
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The aria-label on ace text-input ("Cursor at row X"), was being set only on focus, which means that if the cursor moved within the editor, the label would still be set for the initial row. This lead to the screen reader announcing the wrong row number when accepting a suggestion.

With this change, the aria-label will be updated on every cursor change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

