### PR TITLE
Feat: exposing getter setter for widget manager created using line widgets

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -293,21 +293,23 @@ export namespace Ace {
     }
 
     interface LineWidget {
-        el: HTMLElement;
-        rowCount: number;
-        hidden: boolean;
-        _inDocument: boolean;
+        editor?: Editor,
+        el?: HTMLElement;
+        rowCount?: number;
+        hidden?: boolean;
+        _inDocument?: boolean;
         column?: number;
-        row?: number;
+        row: number;
         $oldWidget?: LineWidget,
-        session: EditSession,
+        session?: EditSession,
         html?: string,
         text?: string,
         className?: string,
         coverGutter?: boolean,
         pixelHeight?: number,
         $fold?: Fold,
-        editor: Editor,
+        type?:any,
+        destroy?:()=>void;
         coverLine?: boolean,
         fixedWidth?: boolean,
         fullWidth?: boolean,

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -513,7 +513,7 @@ export namespace Ace {
           name?: string;
       };
   };
-
+    widgetManager:WidgetManager;
     // TODO: define BackgroundTokenizer
 
     on(name: 'changeFold',
@@ -1106,6 +1106,28 @@ export namespace Ace {
     show(pos: Point, lineHeight: number, topdownOnly: boolean): void;
     tryShow(pos: Point, lineHeight: number, anchor: "top" | "bottom" | undefined, forceShow?: boolean): boolean;
     goTo(where: AcePopupNavigation): void;
+  }
+
+  export interface LineWidget {
+    el: HTMLElement; 
+    row: number; 
+    rowCount?: number; 
+    hidden: boolean;
+    editor: Editor, 
+    session: EditSession, 
+    column?: number; 
+    className?: string,
+    coverGutter?: boolean, 
+    pixelHeight?: number, 
+    fixedWidth?: boolean, 
+    fullWidth?: boolean,
+    screenWidth?: number,
+  }
+  
+  export class WidgetManager {
+    constructor(session: EditSession);
+    addLineWidget(w: LineWidget): LineWidget;
+    removeLineWidget(w: LineWidget): void;
   }
 }
 

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -196,15 +196,14 @@ class EditSession {
      * @returns {LineWidgets} object
      */
     get widgetManager() {
-        if (!this.widgetManager) {
-            const widgetManager = new LineWidgets(this);
-            // todo remove the widgetManger assignement from lineWidgets constructor when introducing breaking changes
-            this.widgetManager = widgetManager;
+        const widgetManager = new LineWidgets(this);
+        // todo remove the widgetManger assignement from lineWidgets constructor when introducing breaking changes
+        this.widgetManager = widgetManager;
 
-            if (this.$editor)
-                widgetManager.attach(this.$editor);
-        }      
-        return this.widgetManager;
+        if (this.$editor)
+            widgetManager.attach(this.$editor);
+        
+        return widgetManager;
     }
 
     /**

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -49,7 +49,6 @@ class EditSession {
         this.$undoSelect = true;
         this.$editor = null;
         this.prevOp = {};
-        this.$widgetManager = null;
 
         /** @type {FoldLine[]} */
         this.$foldData = [];
@@ -197,13 +196,14 @@ class EditSession {
      * @returns {LineWidgets} object
      */
     get widgetManager() {
-        if(!this.$widgetManager) {
-        this.$widgetManager = new LineWidgets(this);
+        const widgetManager = new LineWidgets(this);
+        // todo remove the widgetManger assignement from lineWidgets constructor when introducing breaking changes
+        this.widgetManager = widgetManager;
+
+        if (this.$editor)
+            widgetManager.attach(this.$editor);
         
-            if (this.$editor)
-                this.$widgetManager.attach(this.$editor);
-            }
-       return this.$widgetManager;
+        return widgetManager;
     }
 
     /**
@@ -218,7 +218,6 @@ class EditSession {
             configurable: true,
             value: value,
         });
-        this.$widgetManager = value;
     }
     /**
      * @param {Number} docRow The row to work with

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -196,14 +196,15 @@ class EditSession {
      * @returns {LineWidgets} object
      */
     get widgetManager() {
-        const widgetManager = new LineWidgets(this);
-        // todo remove the widgetManger assignement from lineWidgets constructor when introducing breaking changes
-        this.widgetManager = widgetManager;
+        if (!this.widgetManager) {
+            const widgetManager = new LineWidgets(this);
+            // todo remove the widgetManger assignement from lineWidgets constructor when introducing breaking changes
+            this.widgetManager = widgetManager;
 
-        if (this.$editor)
-            widgetManager.attach(this.$editor);
-        
-        return widgetManager;
+            if (this.$editor)
+                widgetManager.attach(this.$editor);
+        }      
+        return this.widgetManager;
     }
 
     /**

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -6,6 +6,7 @@
  * @typedef {import("../ace-internal").Ace.Delta} Delta
  * @typedef {import("../ace-internal").Ace.IRange} IRange
  * @typedef {import("../ace-internal").Ace.SyntaxMode} SyntaxMode
+ * @typedef {import("../ace-internal").Ace.LineWidget} LineWidget
  */
 
 var oop = require("./lib/oop");
@@ -16,6 +17,7 @@ var EventEmitter = require("./lib/event_emitter").EventEmitter;
 var Selection = require("./selection").Selection;
 var TextMode = require("./mode/text").Mode;
 var Range = require("./range").Range;
+var LineWidgets = require("./line_widgets").LineWidgets;
 var Document = require("./document").Document;
 var BackgroundTokenizer = require("./background_tokenizer").BackgroundTokenizer;
 var SearchHighlight = require("./search_highlight").SearchHighlight;
@@ -45,7 +47,9 @@ class EditSession {
         this.$backMarkers = {};
         this.$markerId = 1;
         this.$undoSelect = true;
+        this.$editor = null;
         this.prevOp = {};
+        this.$widgetManager = null;
 
         /** @type {FoldLine[]} */
         this.$foldData = [];
@@ -187,6 +191,35 @@ class EditSession {
         return this.doc;
     }
 
+    /**
+     * Get "widgetManager" from EditSession
+     * 
+     * @returns {LineWidgets} object
+     */
+    get widgetManager() {
+        if(!this.$widgetManager) {
+        this.$widgetManager = new LineWidgets(this);
+        
+            if (this.$editor)
+                this.$widgetManager.attach(this.$editor);
+            }
+       return this.$widgetManager;
+    }
+
+    /**
+     * Set "widgetManager" in EditSession
+     * 
+     * @returns void
+     */
+    set widgetManager(value) {
+        Object.defineProperty(this, "widgetManager", {
+            writable: true, 
+            enumerable: true,
+            configurable: true,
+            value: value,
+        });
+        this.$widgetManager = value;
+    }
     /**
      * @param {Number} docRow The row to work with
      *

--- a/src/editor.js
+++ b/src/editor.js
@@ -23,7 +23,6 @@ var CommandManager = require("./commands/command_manager").CommandManager;
 var defaultCommands = require("./commands/default_commands").commands;
 var config = require("./config");
 var TokenIterator = require("./token_iterator").TokenIterator;
-var LineWidgets = require("./line_widgets").LineWidgets;
 var GutterKeyboardHandler = require("./keyboard/gutter_handler").GutterKeyboardHandler;
 var nls = require("./config").nls;
 
@@ -357,7 +356,9 @@ class Editor {
         this.curOp = null;
 
         oldSession && oldSession._signal("changeEditor", {oldEditor: this});
+        if (oldSession) oldSession.$editor = null;
         session && session._signal("changeEditor", {editor: this});
+        if (session) session.$editor = this;
 
         if (session && !session.destroyed)
             session.bgTokenizer.scheduleStart();
@@ -1486,10 +1487,6 @@ class Editor {
      * @param {Point} [position] Position to insert text to
      */
     setGhostText(text, position) {
-        if (!this.session.widgetManager) {
-            this.session.widgetManager = new LineWidgets(this.session);
-            this.session.widgetManager.attach(this);
-        }
         this.renderer.setGhostText(text, position);
     }
 
@@ -1497,8 +1494,6 @@ class Editor {
      * Removes "ghost" text currently displayed in the editor.
      */
     removeGhostText() {
-        if (!this.session.widgetManager) return;
-
         this.renderer.removeGhostText();
     }
 

--- a/src/ext/code_lens.js
+++ b/src/ext/code_lens.js
@@ -4,7 +4,6 @@
  * @typedef {import("../virtual_renderer").VirtualRenderer & {$textLayer: import("../layer/text").Text &{$lenses: any}}} VirtualRenderer
  */
 
-var LineWidgets = require("../line_widgets").LineWidgets;
 var event = require("../lib/event");
 var lang = require("../lib/lang");
 var dom = require("../lib/dom");
@@ -156,11 +155,6 @@ function attachToEditor(editor) {
     editor.$updateLenses = function() {
         var session = editor.session;
         if (!session) return;
-
-        if (!session.widgetManager) {
-            session.widgetManager = new LineWidgets(session);
-            session.widgetManager.attach(editor);
-        }
 
         var providersToWaitNum = editor.codeLensProviders.length;
         var lenses = [];

--- a/src/ext/error_marker.js
+++ b/src/ext/error_marker.js
@@ -1,5 +1,4 @@
 "use strict";
-var LineWidgets = require("../line_widgets").LineWidgets;
 var dom = require("../lib/dom");
 var Range = require("../range").Range;
 var nls = require("../config").nls;
@@ -70,11 +69,6 @@ function findAnnotations(session, row, dir) {
  */
 exports.showErrorMarker = function(editor, dir) {
     var session = editor.session;
-    if (!session.widgetManager) {
-        session.widgetManager = new LineWidgets(session);
-        session.widgetManager.attach(editor);
-    }
-    
     var pos = editor.getCursorPosition();
     var row = pos.row;
     var oldWidget = session.widgetManager.getWidgetsAtRow(row).filter(function(w) {


### PR DESCRIPTION
*Description of changes:*
Exposing getter and setter for widget manager created using line widgets.
So now ace consumers can use the getter to access the widgetManager which can be used to create line widgets.

1. Added and setter which creates widgetManger(an instance of line_widgets) link it with editor.session.widgetManager and attached it the editor.
2. Added and getter which returns the widgetManger(an instance of line_widgets) attached with the edit_session and not with editor because session can be created without editor with some line_widgets so session.widgetManager should work without editor. And that session can be linked with editor later.
3. Updated the ace.d.ts types to have the `setWidgetManager ` and `getWidgetManager ` methods in Editor type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

