### PR TITLE
feat: Multiline Search Support: line breaks `\n`

### DIFF
--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -192,7 +192,7 @@ class EditSession {
 
     /**
      * Get "widgetManager" from EditSession
-     * 
+     *
      * @returns {LineWidgets} object
      */
     get widgetManager() {
@@ -202,18 +202,18 @@ class EditSession {
 
         if (this.$editor)
             widgetManager.attach(this.$editor);
-        
+
         return widgetManager;
     }
 
     /**
      * Set "widgetManager" in EditSession
-     * 
+     *
      * @returns void
      */
     set widgetManager(value) {
         Object.defineProperty(this, "widgetManager", {
-            writable: true, 
+            writable: true,
             enumerable: true,
             configurable: true,
             value: value,
@@ -2747,4 +2747,3 @@ config.defineOptions(EditSession.prototype, "session", {
 });
 
 exports.EditSession = EditSession;
-

--- a/src/editor.js
+++ b/src/editor.js
@@ -617,10 +617,6 @@ class Editor {
 
         // Update cursor because tab characters can influence the cursor position.
         this.$cursorChange();
-
-        // Updates "updateCounter" and "ace_nomatch" in the search box
-        if (this.searchBox && this.searchBox.active === true)
-            this.searchBox.find(false, false, true);
     }
 
     /**

--- a/src/editor.js
+++ b/src/editor.js
@@ -617,6 +617,10 @@ class Editor {
 
         // Update cursor because tab characters can influence the cursor position.
         this.$cursorChange();
+
+        // Updates "updateCounter" and "ace_nomatch" in the search box
+        if (this.searchBox && this.searchBox.active === true)
+            this.searchBox.find(false, false, true);
     }
 
     /**

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -293,6 +293,9 @@ class SearchBox {
         this.element.style.display = "";
         this.replaceOption.checked = isReplace;
 
+        if (this.editor.$search.$options.regExp)
+            value = lang.escapeRegExp(value);
+
         if (value)
             this.searchInput.value = value;
 

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -51,6 +51,7 @@ class SearchBox {
         this.element = div.firstChild;
 
         this.setSession = this.setSession.bind(this);
+        this.$onEditorInput = this.onEditorInput.bind(this);
 
         this.$init();
         this.setEditor(editor);
@@ -70,6 +71,11 @@ class SearchBox {
     setSession(e) {
         this.searchRange = null;
         this.$syncOptions(true);
+    }
+
+    // Auto update "updateCounter" and "ace_nomatch"
+    onEditorInput() {
+        this.find(false, false, true);
     }
 
     /**
@@ -283,6 +289,7 @@ class SearchBox {
         this.active = false;
         this.setSearchRange(null);
         this.editor.off("changeSession", this.setSession);
+        this.editor.off("input", this.$onEditorInput);
 
         this.element.style.display = "none";
         this.editor.keyBinding.removeKeyboardHandler(this.$closeSearchBarKb);
@@ -296,6 +303,7 @@ class SearchBox {
     show(value, isReplace) {
         this.active = true;
         this.editor.on("changeSession", this.setSession);
+        this.editor.on("input", this.$onEditorInput);
         this.element.style.display = "";
         this.replaceOption.checked = isReplace;
 

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -218,8 +218,10 @@ class SearchBox {
              * Convert all line ending variations to Unix-style = \n
              * Windows (\r\n), MacOS Classic (\r), and Unix (\n)
              */
-            if (editor.$search.$isMultilineSearch(editor.getLastSearchOptions()))
+            if (editor.$search.$isMultilineSearch(editor.getLastSearchOptions())) {
                 value = value.replace(/\r\n|\r|\n/g, "\n");
+                editor.session.doc.$autoNewLine = "\n";
+            }
 
             var offset = editor.session.doc.positionToIndex(editor.selection.anchor);
             if (this.searchRange)

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -214,7 +214,7 @@ class SearchBox {
                 ? editor.session.getTextRange(this.searchRange)
                 : editor.getValue();
 
-            if (editor.$search.$isMultilineSearch(editor.$search.$options))
+            if (editor.$search.$isMultilineSearch(editor.getLastSearchOptions()))
                 value = value.replace(/\r\n|\r|\n/g, "\n");
 
             var offset = editor.session.doc.positionToIndex(editor.selection.anchor);

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -214,6 +214,9 @@ class SearchBox {
                 ? editor.session.getTextRange(this.searchRange)
                 : editor.getValue();
 
+            if (editor.$search.$isMultilineSearch(editor.$search.$options))
+                value = value.replace(/\r\n|\r|\n/g, "\n");
+
             var offset = editor.session.doc.positionToIndex(editor.selection.anchor);
             if (this.searchRange)
                 offset -= editor.session.doc.positionToIndex(this.searchRange.start);

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -214,6 +214,10 @@ class SearchBox {
                 ? editor.session.getTextRange(this.searchRange)
                 : editor.getValue();
 
+            /**
+             * Convert all line ending variations to Unix-style = \n
+             * Windows (\r\n), MacOS Classic (\r), and Unix (\n)
+             */
             if (editor.$search.$isMultilineSearch(editor.getLastSearchOptions()))
                 value = value.replace(/\r\n|\r|\n/g, "\n");
 

--- a/src/search.js
+++ b/src/search.js
@@ -264,7 +264,7 @@ class Search {
 
     $multiLineForward(session, re, start, last) {
         var line,
-            chunk = 1;
+            chunk = chunkEnd(session, start);
 
         for (var row = start; row <= last;) {
             for (var i = 0; i < chunk; i++) {
@@ -273,9 +273,9 @@ class Search {
                 var next = session.getLine(row++);
                 line = line == null ? next : line + "\n" + next;
             }
-            chunk = chunk * 2;
 
             var match = re.exec(line);
+            re.lastIndex = 0;
             if (match) {
                 var before = line.slice(0, match.index).split("\n");
                 var inside = match[0].split("\n");
@@ -297,7 +297,7 @@ class Search {
 
     $multiLineBackward(session, re, endIndex, start, first) {
         var line,
-            chunk = 1,
+            chunk = chunkEnd(session, start),
             endMargin = session.getLine(start).length - endIndex;
 
         for (var row = start; row >= first;) {
@@ -305,7 +305,6 @@ class Search {
                 var next = session.getLine(row--);
                 line = line == null ? next : next + "\n" + line;
             }
-            chunk = chunk * 2;
 
             var match = multiLineBackwardMatch(line, re, endMargin);
             if (match) {
@@ -515,6 +514,16 @@ function multiLineBackwardMatch(line, re, endMargin) {
         from = newMatch.index + 1;
     }
     return match;
+}
+
+function chunkEnd(session, start) {
+    var base = 5000,
+        startPosition = { row: start, column: 0 },
+        startIndex = session.doc.positionToIndex(startPosition),
+        targetIndex = startIndex + base,
+        targetPosition = session.doc.indexToPosition(targetIndex),
+        targetLine = targetPosition.row;
+    return targetLine + 1;
 }
 
 exports.Search = Search;

--- a/src/search.js
+++ b/src/search.js
@@ -592,8 +592,8 @@ function addWordBoundary(needle, options) {
 }
 
 function multiLineBackwardMatch(line, re, endMargin) {
-    var match,
-        from = 0;
+    var match = null;
+    var from = 0;
     while (from <= line.length) {
         re.lastIndex = from;
         var newMatch = re.exec(line);

--- a/src/search.js
+++ b/src/search.js
@@ -378,7 +378,7 @@ class Search {
                 };
             }
         }
-        return false;
+        return null;
     }
 
     $multiLineBackward(session, re, endIndex, start, first) {
@@ -411,7 +411,7 @@ class Search {
                 };
             }
         }
-        return false;
+        return null;
     }
 
     /**

--- a/src/search_highlight.js
+++ b/src/search_highlight.js
@@ -15,6 +15,7 @@ class SearchHighlight {
         this.setRegexp(regExp);
         this.clazz = clazz;
         this.type = type;
+        this.docLen = 0;
     }
 
     setRegexp(regExp) {
@@ -33,14 +34,15 @@ class SearchHighlight {
     update(html, markerLayer, session, config) {
         if (!this.regExp)
             return;
-        var start = config.firstRow, end = config.lastRow;
+        var start = config.firstRow;
+        var end = config.lastRow;
         var renderedMarkerRanges = {};
         var _search = session.$editor.$search;
         var mtSearch = _search.$isMultilineSearch(session.$editor.getLastSearchOptions());
 
         for (var i = start; i <= end; i++) {
             var ranges = this.cache[i];
-            if (ranges == null) {
+            if (ranges == null || session.getValue().length != this.docLen) {
                 if (mtSearch) {
                     ranges = [];
                     var match = _search.$multiLineForward(session, this.regExp, i, end);
@@ -64,6 +66,8 @@ class SearchHighlight {
                 this.cache[i] = ranges.length ? ranges : "";
             }
 
+            if (ranges.length === 0) continue;
+
             for (var j = ranges.length; j --; ) {
                 var rangeToAddMarkerTo = ranges[j].toScreenRange(session);
                 var rangeAsString = rangeToAddMarkerTo.toString();
@@ -74,6 +78,7 @@ class SearchHighlight {
                     html, rangeToAddMarkerTo, this.clazz, config);
             }
         }
+        this.docLen = session.getValue().length;
     }
 }
 

--- a/src/search_highlight.js
+++ b/src/search_highlight.js
@@ -36,15 +36,20 @@ class SearchHighlight {
         var start = config.firstRow, end = config.lastRow;
         var renderedMarkerRanges = {};
         var _search = session.$editor.$search;
-        var multiline = _search.$isMultilineSearch(session.$editor.getLastSearchOptions());
+        var mtSearch = _search.$isMultilineSearch(session.$editor.getLastSearchOptions());
 
         for (var i = start; i <= end; i++) {
             var ranges = this.cache[i];
             if (ranges == null) {
-                if (multiline) {
+                if (mtSearch) {
                     ranges = [];
-                    var matches = _search.$multiLineForward(session, this.regExp, i, end, true);
-                    if (matches) ranges.push(new Range(matches.startRow, matches.startCol, matches.endRow, matches.endCol));
+                    var match = _search.$multiLineForward(session, this.regExp, i, end);
+                    if (match) {
+                        var end_row = match.endRow <= end ? match.endRow - 1 : end;
+                        if (end_row > i)
+                            i = end_row;
+                        ranges.push(new Range(match.startRow, match.startCol, match.endRow, match.endCol));
+                    }
                     if (ranges.length > this.MAX_RANGES)
                         ranges = ranges.slice(0, this.MAX_RANGES);
                 }

--- a/src/search_test.js
+++ b/src/search_test.js
@@ -684,8 +684,6 @@ module.exports = {
     },
 
     "test: replace with line breaks (\\n) and TAB (\\t) using regular expression" : function() {
-        var session = new EditSession('\nfunction foo(items, nada) {\n    for (var i=0; i<items.length; i++) {\n        alert(items[i] + "juhu\\n");\n    }\t/* Real Tab */\n\n\n\n\n}\n\n\n// test search/replace line break with regexp\r\n\r\n\t\t\t\t\n');
-
         var search = new Search().set({
             needle: "with",
             regExp: true,

--- a/src/search_test.js
+++ b/src/search_test.js
@@ -153,7 +153,7 @@ module.exports = {
         var range = search.find(session);
         assert.position(range.start, 0, 12);
         assert.position(range.end, 0, 13);
-        
+
         search.set({ needle: "ab\\{2}" });
         range = search.find(session);
         assert.position(range.start, 1, 8);
@@ -369,8 +369,8 @@ module.exports = {
         assert.position(ranges[1].start, 2, 1);
         assert.position(ranges[1].end, 2, 3);
     },
-    
-    
+
+
     "test: find all multiline matches" : function() {
         var session = new EditSession(["juhu", "juhu", "juhu", "juhu"]);
 
@@ -420,13 +420,17 @@ module.exports = {
 
     "test: replace with RegExp match and capture groups" : function() {
         var search = new Search().set({
-            needle: "ab(\\d\\d)",
+            needle: "ab((\\d)\\d)",
             regExp: true
         });
 
         assert.equal(search.replace("ab12", "cd$1"), "cd12");
+        assert.equal(search.replace("ab56", "pr$17$2"), "pr5675");
         assert.equal(search.replace("ab12", "-$&-"), "-ab12-");
-        assert.equal(search.replace("ab12", "$$"), "$");
+        assert.equal(search.replace("ab12", "_$0_"), "_ab12_");
+
+        search.set({ needle: "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)" });
+        assert.equal(search.replace("abcdefghijkl", "$2$9$7_$11$9$4_$8$9$4$5_$10$1$3$11_$6$12$1$7_$13"), "big_kid_hide_jack_flag_a3");
     },
 
     "test: replace() should correctly handle $$ in the replacement string": function () {
@@ -435,11 +439,11 @@ module.exports = {
         });
 
         // Expecting $$ to be preserved in the output
+        assert.equal(search.replace("example", "$test"), "$test");
         assert.equal(search.replace("example", "$$test"), "$$test");
-
-        // Expecting $$$$ to be preserved as $$$$
+        assert.equal(search.replace("example", "$$$test"), "$$$test");
         assert.equal(search.replace("example", "$$$$test"), "$$$$test");
-        
+
         search.set({
             regExp: true,
             needle: "(example)"
@@ -448,9 +452,38 @@ module.exports = {
         // Tests that $1 is replaced by the text that matches the capturing group.
         assert.equal(search.replace("example", "$1test"), "exampletest");
 
-        search.set({regExp: false});
+        assert.equal(search.replace("example", "$"), "$");
+        assert.equal(search.replace("example", "$$"), "$");
+        assert.equal(search.replace("example", "$$$"), "$$");
+        assert.equal(search.replace("example", "$$$$"), "$$");
+        assert.equal(search.replace("example", "$$$$$"), "$$$");
+        assert.equal(search.replace("example", "$$$$$$"), "$$$");
+        assert.equal(search.replace("example", "$$$$$$$"), "$$$$");
+
+        search.set({ regExp: false });
         // Tests that without regular expression, "$1test" is treated as a literal string with $ escape.
         assert.equal(search.replace("(example)", "$1test"), "$1test");
+    },
+
+    "test: replace() should correctly handle \\\\ in the replacement string": function () {
+        var search = new Search().set({
+            needle: "example"
+        });
+
+        // Expecting \\ to be preserved in the output
+        assert.equal(search.replace("example", "\\test"), "\\test");
+        assert.equal(search.replace("example", "\\\\test"), "\\\\test");
+        assert.equal(search.replace("example", "\\\\\\test"), "\\\\\\test");
+
+        search.set({ regExp: true });
+
+        assert.equal(search.replace("example", "\\"), "\\");
+        assert.equal(search.replace("example", "\\\\"), "\\");
+        assert.equal(search.replace("example", "\\\\\\"), "\\\\");
+        assert.equal(search.replace("example", "\\\\\\\\"), "\\\\");
+        assert.equal(search.replace("example", "\\\\\\\\\\"), "\\\\\\");
+        assert.equal(search.replace("example", "\\\\\\\\\\\\"), "\\\\\\");
+        assert.equal(search.replace("example", "\\\\\\\\\\\\\\"), "\\\\\\\\");
     },
 
     "test: find all using regular expresion containing $" : function() {
@@ -518,7 +551,7 @@ module.exports = {
     "test: find next empty range" : function() {
         var session = new EditSession("foo foobar foo");
         var editor = new Editor(new MockRenderer(), session);
-        
+
         var options = {
             needle: "o*",
             wrap: true,
@@ -526,7 +559,7 @@ module.exports = {
             backwards: false
         };
         var positions = [4, 5.2, 7, 8, 9, 10, 11, 12.2, 14, 0, 1.2, 3];
-        
+
         session.selection.moveCursorTo(0, 3);
         for (var i = 0; i < positions.length; i++) {
             editor.find(options);
@@ -545,10 +578,11 @@ module.exports = {
             assert.equal(start + 0.1 * len, positions[i]);
         }
     },
+
     "test: repeating text": function() {
         var session = new EditSession("tttttt\ntttttt\ntttttt\ntttttt\ntttttt\ntttttt");
         var editor = new Editor(new MockRenderer(), session);
-        
+
         var options = {
             needle: "^",
             wrap: true,
@@ -560,15 +594,15 @@ module.exports = {
             var range = editor.selection.getRange();
             assert.range(range, sl, sc, el, ec);
         }
-        
+
         session.selection.moveCursorTo(1, 3);
         check(2, 0, 2, 0);
-        
+
         options.needle = "tttt\ntttt";
         check(2, 2, 3, 4);
         check(4, 2, 5, 4);
         check(0, 2, 1, 4);
-        
+
         options.backwards = true;
         check(4, 2, 5, 4);
         check(2, 2, 3, 4);
@@ -601,6 +635,72 @@ module.exports = {
         assert.position(ranges[1].end, 1, 39);
         assert.position(ranges[2].start, 2, 4);
         assert.position(ranges[2].end, 2, 7);
+    },
+
+    "test: find all line breaks (\\r\\n, \\n) using regular expression" : function() {
+        var session = new EditSession('\nfunction foo(items, nada) {\n    for (var i=0; i<items.length; i++) {\n        alert(items[i] + "juhu\\n");\n    }\t/* Real Tab */\n\n\n\n\n}\n\n\n// test search/replace line break with regexp\r\n\r\n\t\t\t\t\n');
+
+        var search = new Search().set({
+            needle: "\\n",
+            regExp: true,
+            wrap: true
+        });
+
+        var ranges = search.findAll(session);
+        assert.equal(ranges.length, 15);
+
+        search.set({ needle: "\\n{2,}" });
+        ranges = search.findAll(session);
+        assert.equal(ranges.length, 3);
+
+        search.set({ needle: "\\n\\s+" });
+        ranges = search.findAll(session);
+        assert.equal(ranges.length, 6);
+
+        search.set({ needle: "\\)\\s\\{\\n\\s+" });
+        ranges = search.findAll(session);
+        assert.equal(ranges.length, 2);
+
+        search.set({ needle: "\\n+" });
+        ranges = search.findAll(session);
+
+        assert.equal(ranges.length, 8);
+        assert.position(ranges[0].start, 0, 0);
+        assert.position(ranges[0].end, 1, 0);
+        assert.position(ranges[1].start, 1, 27);
+        assert.position(ranges[1].end, 2, 0);
+        assert.position(ranges[2].start, 2, 40);
+        assert.position(ranges[2].end, 3, 0);
+        assert.position(ranges[3].start, 3, 35);
+        assert.position(ranges[3].end, 4, 0);
+        assert.position(ranges[4].start, 4, 20);
+        assert.position(ranges[4].end, 9, 0);
+        assert.position(ranges[5].start, 9, 1);
+        assert.position(ranges[5].end, 12, 0);
+        assert.position(ranges[6].start, 12, 45);
+        assert.position(ranges[6].end, 14, 0);
+        assert.position(ranges[7].start, 14, 4);
+        assert.position(ranges[7].end, 15, 0);
+    },
+
+    "test: replace with line breaks (\\n) and TAB (\\t) using regular expression" : function() {
+        var session = new EditSession('\nfunction foo(items, nada) {\n    for (var i=0; i<items.length; i++) {\n        alert(items[i] + "juhu\\n");\n    }\t/* Real Tab */\n\n\n\n\n}\n\n\n// test search/replace line break with regexp\r\n\r\n\t\t\t\t\n');
+
+        var search = new Search().set({
+            needle: "with",
+            regExp: true,
+            wrap: true
+        });
+
+        assert.equal(search.replace("with", "\n// $0"), "\n// with");
+        assert.equal(search.replace("with", "\t-\t$0"), "\t-\twith");
+
+        search.set({ needle: "(\\n+)" });
+        assert.equal(search.replace("\n", ""), "");
+        assert.equal(search.replace("\n", "\t"), "\t");
+        assert.equal(search.replace("\n\n\n", "\n"), "\n");
+        assert.equal(search.replace("\n\t\n\n", "\t$1"), "\t\n\t\t\n\n");
+        assert.equal(search.replace("\r\n /* CRLF */", "\n"), "\n /* CRLF */");
     }
 };
 


### PR DESCRIPTION
*Issue #2869*

*Description of changes:*

* highlight line break `\n`
* search line break `\n`
* replace line break `\n`
* replace **{search}** value with `\n` or `\t`
ㅤ

### Benefit

Users can now perform search/replace line breaks (`\n`) with regex.
ㅤ

### Test

1. Open: https://sekedus.github.io/ace/kitchen-sink.html
2. Settings: `Document: JavaScript`
3. Set value:
  ```javascript
  /**
   * 
   * @param {string[]} items
   * @param nada
   */
  function foo(items, nada) {
      for (var i=0; i<items.length; i++) {
          alert(items[i] + "juhu\n");
      }	/* Real Tab */
  
  
  
  
  }
  
  
  // test search/replace line break with regexp

				

  ```
4. Open **search box**
    * Fill in search field with `\n` or `\n+` or `\n\s+` or `\)\s\{\n\s+`
    * Enable **RegExp mode**

   ![screenshot-ace-searchbox-2024_11_15-20_18_39](https://github.com/user-attachments/assets/6c23f72f-ff75-4640-8c5d-021c4ccb14ba)
5. **Example**: 
    * Replace two or more line breaks with one line break:
      - `\n{2}` with `\n`
      - `\n+` with `\n`
    * Remove line breaks, replace `\n` with `{empty}`
    * Replace `{any_string}` with `\n` or`\t`
ㅤ

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

