### PR TITLE
Fix: wrong behaviour rules in modes

### DIFF
--- a/src/mode/java.js
+++ b/src/mode/java.js
@@ -9,6 +9,7 @@ var Mode = function() {
     JavaScriptMode.call(this);
     this.HighlightRules = JavaHighlightRules;
     this.foldingRules = new JavaFoldMode();
+    this.$behaviour = this.$defaultBehaviour;
 };
 oop.inherits(Mode, JavaScriptMode);
 

--- a/src/mode/scala.js
+++ b/src/mode/scala.js
@@ -7,6 +7,7 @@ var ScalaHighlightRules = require("./scala_highlight_rules").ScalaHighlightRules
 var Mode = function() {
     JavaScriptMode.call(this);
     this.HighlightRules = ScalaHighlightRules;
+    this.$behaviour = this.$defaultBehaviour;
 };
 oop.inherits(Mode, JavaScriptMode);
 

--- a/src/mode/wollok.js
+++ b/src/mode/wollok.js
@@ -7,6 +7,7 @@ var WollokHighlightRules = require("./wollok_highlight_rules").WollokHighlightRu
 var Mode = function() {
     JavaScriptMode.call(this);
     this.HighlightRules = WollokHighlightRules;
+    this.$behaviour = this.$defaultBehaviour;
 };
 oop.inherits(Mode, JavaScriptMode);
 


### PR DESCRIPTION
*Issue #, if available:* #5679

*Description of changes:*

Fix wrong behaviour rules inherited from JavaScript Mode in `java`, `wollok` and `scala`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

