### PR TITLE
chore: small tweaks LineWidget type

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -1112,16 +1112,16 @@ export namespace Ace {
     el: HTMLElement; 
     row: number; 
     rowCount?: number; 
-    hidden: boolean;
-    editor: Editor, 
-    session: EditSession, 
+    hidden?: boolean;
+    editor?: Editor; 
+    session?: EditSession; 
     column?: number; 
-    className?: string,
-    coverGutter?: boolean, 
-    pixelHeight?: number, 
-    fixedWidth?: boolean, 
-    fullWidth?: boolean,
-    screenWidth?: number,
+    className?: string;
+    coverGutter?: boolean; 
+    pixelHeight?: number; 
+    fixedWidth?: boolean; 
+    fullWidth?: boolean;
+    screenWidth?: number;
   }
   
   export class WidgetManager {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* In #5673, we recently exposed `LineWidget` interface, this makes some small tweaks to it by making `hidden`, `editor` and `session` optional bringing the external type definition a bit closer to the [internal type](https://github.com/ajaxorg/ace/blob/master/ace-internal.d.ts#L295).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

