### PR TITLE
chore: small type fixes

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -845,7 +845,7 @@ export namespace Ace {
          */
         $quotes: { [quote: string]: string };
         HighlightRules: {
-            new(config: any): HighlightRules
+            new(config?: any): HighlightRules
         }; //TODO: fix this
         foldingRules?: FoldMode;
         $behaviour?: Behaviour;

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -695,7 +695,7 @@ declare module "ace-code" {
         }
         interface SyntaxMode {
             HighlightRules: {
-                new(config: any): HighlightRules;
+                new(config?: any): HighlightRules;
             }; //TODO: fix this
             foldingRules?: FoldMode;
             /**

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -138,7 +138,7 @@ class EditSession {
     /**
      * End current Ace operation.
      * Emits "beforeEndOperation" event just before clearing everything, where the current operation can be accessed through `curOp` property.
-     * @param {any} e
+     * @param {any} [e]
      */
     endOperation(e) {
         if (this.curOp) {

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -129,6 +129,10 @@ class SearchBox {
             }
         });
 
+        /**
+         * @type {{schedule: (timeout?: number) => void}}
+         * @external
+        */
         this.$onChange = lang.delayedCall(function() {
             _this.find(false, false);
         });
@@ -158,6 +162,7 @@ class SearchBox {
 
     /**
      * @param {boolean} [preventScroll]
+     * @external
      */
     $syncOptions(preventScroll) {
         dom.setCssClass(this.replaceOption, "checked", this.searchRange);

--- a/tool/ace_declaration_generator.js
+++ b/tool/ace_declaration_generator.js
@@ -363,7 +363,7 @@ function fixDeclaration(content, aceNamespacePath) {
 
                             const startsWithDollar = ts.isIdentifier(node.name) && /^[$_]/.test(node.name.text);
 
-                            if (isPrivate || startsWithDollar || hasInternalTag(node)) {
+                            if (isPrivate || (startsWithDollar && !hasExternalTag(node)) || hasInternalTag(node)) {
                                 return ts.factory.createNotEmittedStatement(node);
                             }
                         }
@@ -456,6 +456,14 @@ function hasInternalTag(node) {
     if (!sourceFile) return false;
 
     const jsDocs = ts.getJSDocTags(node).filter(tag => tag.tagName.text === 'internal');
+    return jsDocs.length > 0;
+}
+
+function hasExternalTag(node) {
+    const sourceFile = node.getSourceFile();
+    if (!sourceFile) return false;
+
+    const jsDocs = ts.getJSDocTags(node).filter(tag => tag.tagName.text === 'external');
     return jsDocs.length > 0;
 }
 

--- a/types/ace-ext.d.ts
+++ b/types/ace-ext.d.ts
@@ -183,8 +183,19 @@ declare module "ace-code/src/ext/searchbox" {
         searchInput: HTMLInputElement;
         replaceInput: HTMLInputElement;
         searchCounter: HTMLElement;
+        /**
+         * 
+         * @external
+        */
+        $onChange: {
+            schedule: (timeout?: number) => void;
+        };
         setSearchRange(range: any): void;
         searchRangeMarker: number;
+        /**
+         * @external
+         */
+        $syncOptions(preventScroll?: boolean): void;
         highlight(re?: RegExp): void;
         find(skipCurrent: boolean, backwards: boolean, preventScroll?: any): void;
         updateCounter(): void;

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -3767,7 +3767,7 @@ declare module "ace-code/src/edit_session" {
          * End current Ace operation.
          * Emits "beforeEndOperation" event just before clearing everything, where the current operation can be accessed through `curOp` property.
          */
-        endOperation(e: any): void;
+        endOperation(e?: any): void;
         /**
          * Sets the `EditSession` to point to a new `Document`. If a `BackgroundTokenizer` exists, it also points to `doc`.
          *


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- mark `event` as optional in `endOperation` to be inline with the previously defined types.
- mark `config` as optional in the contstructor of `SyntaxMode.HighlightRules` to be inline with the previously defined types.
- Expose `$onChange` and `$syncOptions` from `SearchBox` to expose these methods to users building custom search boxes based on the `SearchBox` implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

