### PR TITLE
chore: make typedef EditSession.curOp consistent

### DIFF
--- a/demo/test_package/index.ts
+++ b/demo/test_package/index.ts
@@ -124,11 +124,11 @@ function createPopup() {
 }
 
 const acePopup = createPopup();
-
 const activeCommand = acePopup.getData(acePopup.getRow());
 if (activeCommand && activeCommand.command && activeCommand.command.name) {
     acePopup.setData([]);
 }
+acePopup.destroy();
 
 const filter = new FilteredList([]);
 filter.setFilter("test");

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -127,7 +127,7 @@ class EditSession {
         }
 
         this.$operationResetTimer.schedule();
-        /**@type {import("../ace-internal").Ace.Operation | null}*/
+        /**@type {import("../ace-internal").Ace.Operation}*/
         this.curOp = {
             command: commandEvent.command || {},
             args: commandEvent.args

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -90,6 +90,7 @@ class EditSession {
     }
 
     $initOperationListeners() {
+        /**@type {import("../ace-internal").Ace.Operation | null}*/
         this.curOp = null;
         this.on("change", () => {
             if (!this.curOp) {
@@ -127,7 +128,6 @@ class EditSession {
         }
 
         this.$operationResetTimer.schedule();
-        /**@type {import("../ace-internal").Ace.Operation}*/
         this.curOp = {
             command: commandEvent.command || {},
             args: commandEvent.args

--- a/tool/ace_declaration_generator.js
+++ b/tool/ace_declaration_generator.js
@@ -147,6 +147,7 @@ function updateMainAceModule(node) {
     }
 }
 
+
 /**
  * Updates the module declaration for the "keys" and "linking" modules by adding the corresponding internal statements
  * to support mixins (EventEmitter, OptionsProvider, etc.).

--- a/tool/ace_declaration_generator.js
+++ b/tool/ace_declaration_generator.js
@@ -147,7 +147,6 @@ function updateMainAceModule(node) {
     }
 }
 
-
 /**
  * Updates the module declaration for the "keys" and "linking" modules by adding the corresponding internal statements
  * to support mixins (EventEmitter, OptionsProvider, etc.).

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -3772,7 +3772,7 @@ declare module "ace-code/src/edit_session" {
         bgTokenizer: BackgroundTokenizer;
         selection: Selection;
         destroyed: boolean;
-        curOp: import("ace-code").Ace.Operation;
+        curOp: import("ace-code").Ace.Operation | null;
         /**
          * Start an Ace operation, which will then batch all the subsequent changes (to either content or selection) under a single atomic operation.
          * @param {{command?: {name?: string}, args?: any}|undefined} [commandEvent] Optional name for the operation

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -890,7 +890,7 @@ declare module "ace-code/src/virtual_renderer" {
          * @param {EditSession} session The session to associate with
          **/
         setSession(session: EditSession): void;
-        session: import("ace-code").Ace.EditSession;
+        session: import("ace-code/src/edit_session").EditSession;
         /**
          * Triggers a partial update of the text, from the range given by the two parameters.
          * @param {Number} firstRow The first row to update
@@ -3772,7 +3772,7 @@ declare module "ace-code/src/edit_session" {
         bgTokenizer: BackgroundTokenizer;
         selection: Selection;
         destroyed: boolean;
-        curOp: import("ace-code").Ace.Operation | null;
+        curOp: import("ace-code").Ace.Operation;
         /**
          * Start an Ace operation, which will then batch all the subsequent changes (to either content or selection) under a single atomic operation.
          * @param {{command?: {name?: string}, args?: any}|undefined} [commandEvent] Optional name for the operation


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Makes sure the type definition for `EditSession.curOp` is consistent by moving the typedef comment to the init function. Fixes the currently [broken](https://github.com/ajaxorg/ace/actions/runs/12351248536/job/34523916305) CI build at master.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

