### PR TITLE
chore: allow custom version number release script

### DIFF
--- a/tool/release.sh
+++ b/tool/release.sh
@@ -56,7 +56,13 @@ git checkout -- package.json
 git checkout -- CHANGELOG.md
 npm run changelog
 VERSION_NUM="$(node -p "require('./package.json').version")";
-echo "version number for the build is" $VERSION_NUM
+echo "recommended version number for the build is" $VERSION_NUM 
+
+read -p "do you want to continue with the recommended version number? [y/n] " yn
+
+if [[ $yn == "n" ]]; then 
+    read -p "what should the new version be? (Example: 1.2.3) " VERSION_NUM 
+fi
 
 # update version number everywhere
 node -e "
@@ -77,7 +83,7 @@ node -e "
     update('./src/config.js');
 "
 
-pause "versions updated. do you want to start build script? [y/n]"
+pause "versions updated to $VERSION_NUM. do you want to start build script? [y/n]"
 
 node Makefile.dryice.js full
 cd build


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Currently, when releasing a new Ace version, the new version number is automatically picked up through conventional commits. Sometimes we want to be able to override this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

