### PR TITLE
chore: bump version in d.ts files on release

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -972,6 +972,6 @@ declare module "ace-code" {
     import { Range } from "ace-code/src/range";
     import { UndoManager } from "ace-code/src/undomanager";
     import { VirtualRenderer as Renderer } from "ace-code/src/virtual_renderer";
-    export var version: "1.36.5";
+    export var version: "1.37.0";
     export { Range, Editor, EditSession, UndoManager, Renderer as VirtualRenderer };
 }

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -81,6 +81,8 @@ node -e "
     update('package.json');
     update('build/package.json');
     update('./src/config.js');
+    update('ace.d.ts');
+    update('./types/ace-modules.d.ts');
 "
 
 pause "versions updated to $VERSION_NUM. do you want to start build script? [y/n]"

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -371,7 +371,7 @@ declare module "ace-code/src/config" {
             string
         ], onLoad: (module: any) => void) => void;
         setModuleLoader: (moduleName: any, onLoad: any) => void;
-        version: "1.36.5";
+        version: "1.37.0";
     };
     export = _exports;
 }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* The current version number is part of the `ace.d.ts` and `types/ace-modules.d.ts` files, we need to update those as well when releasing a new version.

Fixes currently broken CI build on main branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [na] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

