### PR TITLE
expose gutter tooltip row information in gutter tooltip class

### DIFF
--- a/src/mouse/default_gutter_handler.js
+++ b/src/mouse/default_gutter_handler.js
@@ -133,6 +133,8 @@ class GutterTooltip extends Tooltip {
     constructor(editor) {
         super(editor.container);
         this.editor = editor;
+        /**@type {Number | Undefined}*/
+        this.visibleTooltipRow;
     }
 
     setPosition(x, y) {
@@ -267,6 +269,7 @@ class GutterTooltip extends Tooltip {
         }
 
         this.show();
+        this.visibleTooltipRow = row;
         this.editor._signal("showGutterTooltip", this);
     }
 
@@ -276,6 +279,7 @@ class GutterTooltip extends Tooltip {
         }
         this.$element.removeAttribute("aria-live");
         this.hide();
+        this.visibleTooltipRow = undefined;
         this.editor._signal("hideGutterTooltip", this);
     }
 

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -890,7 +890,7 @@ declare module "ace-code/src/virtual_renderer" {
          * @param {EditSession} session The session to associate with
          **/
         setSession(session: EditSession): void;
-        session: import("ace-code/src/edit_session").EditSession;
+        session: import("ace-code").Ace.EditSession;
         /**
          * Triggers a partial update of the text, from the range given by the two parameters.
          * @param {Number} firstRow The first row to update
@@ -1702,6 +1702,7 @@ declare module "ace-code/src/mouse/default_gutter_handler" {
         static annotationsToSummaryString(annotations: any): string;
         constructor(editor: any);
         editor: any;
+        visibleTooltipRow: number | undefined;
         setPosition(x: any, y: any): void;
         showTooltip(row: any): void;
         hideTooltip(): void;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Exposing gutter tooltip row information in gutter tooltip class which can be used to get which rows tooltip is visible currently.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

