### PR TITLE
disable loading emmet from other domain

### DIFF
--- a/demo/emmet.html
+++ b/demo/emmet.html
@@ -23,7 +23,7 @@
 <pre id="editor"></pre>
 
 <!-- load emmet code and snippets compiled for browser -->
-<script src="https://cloud9ide.github.io/emmet-core/emmet.js"></script>
+<!-- <script src="https://cloud9ide.github.io/emmet-core/emmet.js"></script> -->
 
 <script src="kitchen-sink/require.js"></script>
 <script>

--- a/demo/emmet.html
+++ b/demo/emmet.html
@@ -23,7 +23,7 @@
 <pre id="editor"></pre>
 
 <!-- load emmet code and snippets compiled for browser -->
-<!-- <script src="https://cloud9ide.github.io/emmet-core/emmet.js"></script> -->
+<!-- <script src="..."></script> -->
 
 <script src="kitchen-sink/require.js"></script>
 <script>

--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -490,13 +490,6 @@ function synchroniseScrolling() {
 var StatusBar = require("ace/ext/statusbar").StatusBar;
 new StatusBar(env.editor, cmdLine.container);
 
-
-var Emmet = require("ace/ext/emmet");
-net.loadScript("https://cloud9ide.github.io/emmet-core/emmet.js", function() {
-    Emmet.setCore(window.emmet);
-    env.editor.setOption("enableEmmet", true);
-});
-
 require("ace/placeholder").PlaceHolder;
 
 var snippetManager = require("ace/snippets").snippetManager;

--- a/doc/site/js/main.js
+++ b/doc/site/js/main.js
@@ -17,13 +17,6 @@ $(function() {
             autoScrollEditorIntoView: true
         });
         
-        ace.config.loadModule("ace/ext/emmet", function() {
-            ace.require("ace/lib/net").loadScript("https://cloud9ide.github.io/emmet-core/emmet.js", function() {
-                embedded_editor.setOption("enableEmmet", true);
-                editor.setOption("enableEmmet", true);
-            });
-        });
-        
         ace.config.loadModule("ace/ext/language_tools", function() {
             embedded_editor.setOptions({
                 enableSnippets: true,


### PR DESCRIPTION
*Description of changes:*

We don't want to load dependencies from other domains (including our own). In this case, the cloud9ide repo marked as archived so this dependency is not updated.