### PR TITLE
fix: fix return type of supportsFile modelist

### DIFF
--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -48,6 +48,7 @@ class Mode {
 
     /**
      * @param {string} filename
+     * @returns {RegExpMatchArray | null}
      */
     supportsFile(filename) {
         return filename.match(this.extRe);

--- a/types/ace-ext.d.ts
+++ b/types/ace-ext.d.ts
@@ -400,7 +400,7 @@ declare module "ace-code/src/ext/modelist" {
         mode: string;
         extensions: string;
         extRe: RegExp;
-        supportsFile(filename: string): RegExpMatchArray;
+        supportsFile(filename: string): RegExpMatchArray | null;
     }
 }
 declare module "ace-code/src/ext/themelist" {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* we use `String.match`, which has a [return type](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) of `RegExpMatchArray | null`, this was not correctly picked up by our type generation. Explicitly set return type in this PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [na] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

