### PR TITLE
fix: narrowing platform to be either win or mac

### DIFF
--- a/src/commands/command_manager.js
+++ b/src/commands/command_manager.js
@@ -10,7 +10,7 @@ var EventEmitter = require("../lib/event_emitter").EventEmitter;
 class CommandManager extends MultiHashHandler{
     /**
      * new CommandManager(platform, commands)
-     * @param {String} platform Identifier for the platform; must be either `"mac"` or `"win"`
+     * @param {import("../keyboard/hash_handler").Platform} platform Identifier for the platform; must be either `"mac"` or `"win"`
      * @param {any[]} commands A list of commands
      **/
     constructor(platform, commands) {

--- a/src/keyboard/hash_handler.js
+++ b/src/keyboard/hash_handler.js
@@ -9,10 +9,14 @@
 var useragent = require("../lib/useragent");
 var KEY_MODS = keyUtil.KEY_MODS;
 
+/**
+ * @typedef {"win" | "mac"} Platform
+ */
+
 class MultiHashHandler {
     /**
      * @param {Record<string, CommandLike> | Command[]} [config]
-     * @param {string} [platform]
+     * @param {Platform} [platform]
      */
     constructor(config, platform) {
         this.$init(config, platform, false);
@@ -20,7 +24,7 @@ class MultiHashHandler {
 
     /**
      * @param {Record<string, CommandLike> | Command[]} config
-     * @param {string} [platform]
+     * @param {Platform} [platform]
      * @param {boolean} [$singleCommand]
      */
     $init(config, platform, $singleCommand) {
@@ -281,7 +285,7 @@ function getPosition(command) {
 class HashHandler extends MultiHashHandler {
     /**
      * @param {Record<string, CommandLike> | Command[]} [config]
-     * @param {string} [platform]
+     * @param {Platform} [platform]
      */
     constructor(config, platform) {
         super(config, platform);

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -1841,14 +1841,15 @@ declare module "ace-code/src/search" {
 declare module "ace-code/src/keyboard/hash_handler" {
     export type Command = import("ace-code").Ace.Command;
     export type CommandLike = import("ace-code").Ace.CommandLike;
+    export type Platform = "win" | "mac";
     export class HashHandler extends MultiHashHandler {
     }
     export namespace HashHandler {
         function call(thisArg: any, config: any, platform: any): void;
     }
     export class MultiHashHandler {
-        constructor(config?: Record<string, CommandLike> | Command[], platform?: string);
-        platform: string;
+        constructor(config?: Record<string, CommandLike> | Command[], platform?: Platform);
+        platform: Platform;
         commands: Record<string, Command>;
         commandKeyBinding: {};
         addCommand(command: Command): void;
@@ -1884,10 +1885,10 @@ declare module "ace-code/src/commands/command_manager" {
     export class CommandManager extends MultiHashHandler {
         /**
          * new CommandManager(platform, commands)
-         * @param {String} platform Identifier for the platform; must be either `"mac"` or `"win"`
+         * @param {import("ace-code/src/keyboard/hash_handler").Platform} platform Identifier for the platform; must be either `"mac"` or `"win"`
          * @param {any[]} commands A list of commands
          **/
-        constructor(platform: string, commands: any[]);
+        constructor(platform: import("ace-code/src/keyboard/hash_handler").Platform, commands: any[]);
         byName: Record<string, import("ace-code").Ace.Command>;
         exec(command: string | string[] | import("ace-code").Ace.Command, editor: Editor, args: any): boolean;
         canExecute(command: string | import("ace-code").Ace.Command, editor: Editor): boolean;


### PR DESCRIPTION
*Description of changes:*
- narrowing CommandManager and HashHandler `platform` to be either "win" or "mac" instead of any string
- it is technically a breaking type change because the type was narrowed down, but it should now be a more accurate representation of what it really is


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [❌] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

