### PR TITLE
feat(AcePopup): adding getDataContainer and setVisibleRows methods

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -1495,6 +1495,8 @@ declare module "./src/autocomplete/popup" {
         anchorPos: any,
         isMouseOver?: boolean,
         selectedNode?: HTMLElement,
+        getDataContainer: () => HTMLDivElement;
+        setVisibleRows: (rows: number) => void;
     }
 }
 

--- a/src/autocomplete/popup.js
+++ b/src/autocomplete/popup.js
@@ -408,6 +408,22 @@ class AcePopup {
         popup.$imageSize = 0;
         popup.$borderSize = 1;
 
+        /**
+         * Get HTML element containing the popup data.
+         * @returns {HTMLDivElement} element 
+         */
+        popup.getDataContainer = function() {
+            return this.renderer.$textLayer.element;
+        };
+
+        /**
+         * Number of rows shown in the popup.
+         * @param {number} rows 
+         */
+        popup.setVisibleRows = function(rows) {
+            this.renderer.$maxLines = rows;
+        };
+
         return popup;
     }
 }

--- a/src/autocomplete/popup_test.js
+++ b/src/autocomplete/popup_test.js
@@ -209,6 +209,24 @@ module.exports = {
         assert.strictEqual(popup.container.style.display, "none");
         done();
     },
+    "test: setVisibleRows shows correct number of rows": function() {
+        setupPopup();
+        tryShowAndRender({ top: 0, left: 0 }, lineHeight);
+        assert.strictEqual(popup.getDataContainer().children.length, 8);
+        
+        popup.setVisibleRows(4);
+        popup.renderer.updateFull(true);
+        // We add one more element to the DOM 
+        assert.strictEqual(popup.getDataContainer().children.length, 5);
+        assert.strictEqual(Math.floor(popup.container.clientHeight / lineHeight), 4);
+    },
+    "test: getDataContainer returns element with the popup data": function() {
+        setupPopup();
+        tryShowAndRender({ top: 0, left: 0 }, lineHeight);
+        assert.strictEqual(popup.getDataContainer().children.length, 8);
+        assert.strictEqual(popup.getDataContainer().children[0].textContent, "foo0 ");
+        assert.strictEqual(popup.getDataContainer().children[7].textContent, "foo7 ");
+    },
     tearDown: tearDown
 };
 

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -2855,6 +2855,8 @@ declare module "ace-code/src/autocomplete/popup" {
         anchorPos: any;
         isMouseOver?: boolean;
         selectedNode?: HTMLElement;
+        getDataContainer: () => HTMLDivElement;
+        setVisibleRows: (rows: number) => void;
     }
     export function $singleLineEditor(el?: HTMLElement): Editor;
     export function getAriaId(index: any): string;
@@ -2887,6 +2889,8 @@ declare module "ace-code/src/autocomplete/popup" {
         anchorPos: any;
         isMouseOver?: boolean;
         selectedNode?: HTMLElement;
+        getDataContainer: () => HTMLDivElement;
+        setVisibleRows: (rows: number) => void;
     }
 }
 declare module "ace-code/src/range_list" {


### PR DESCRIPTION
*Description of changes:*
- Extending AcePopup to have a method for setting number of visible rows and a method for fetching the HTML element where data is rendered into. The latter is especially useful for consumers who want to modify the popup themselves, which they often need to if they use the popup within something like https://www.w3.org/WAI/ARIA/apg/patterns/combobox/.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [X] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

