### PR TITLE
chore: add missing gutter editor events to types

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -524,6 +524,10 @@ export namespace Ace {
         "codeLensClick": (e: any) => void;
 
         "select": () => void;
+        "gutterkeydown": () => void;
+        "gutterclick": () => void;
+        "showGutterTooltip": () => void;
+        "hideGutterTooltip": () => void;
     }
 
     interface AcePopupEvents {

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -437,6 +437,10 @@ declare module "ace-code" {
             //from code_lens extension
             "codeLensClick": (e: any) => void;
             "select": () => void;
+            "gutterkeydown": () => void;
+            "gutterclick": () => void;
+            "showGutterTooltip": () => void;
+            "hideGutterTooltip": () => void;
         }
         interface AcePopupEvents {
             "click": (e: MouseEvent) => void;


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* adds gutter related events to the type declarations 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

