### PR TITLE
fix: Fix GutterTooltip and GutterKeyboardEvent declarations 

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -27,8 +27,8 @@ export namespace Ace {
     type DragdropHandler = import("./src/mouse/dragdrop_handler").DragdropHandler;
     type AppConfig = import("./src/lib/app_config").AppConfig;
     type Config = typeof import("./src/config");
-    type GutterTooltip = typeof import( "./src/mouse/default_gutter_handler").GutterTooltip;
-    type GutterKeyboardEvent = typeof import( "./src/keyboard/gutter_handler").GutterKeyboardEvent;
+    type GutterTooltip = import( "./src/mouse/default_gutter_handler").GutterTooltip;
+    type GutterKeyboardEvent = import( "./src/keyboard/gutter_handler").GutterKeyboardEvent;
 
     type AfterLoadCallback = (err: Error | null, module: unknown) => void;
     type LoaderFunction = (moduleName: string, afterLoad: AfterLoadCallback) => void;

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -36,8 +36,8 @@ declare module "ace-code" {
         type DragdropHandler = import("ace-code/src/mouse/dragdrop_handler").DragdropHandler;
         type AppConfig = import("ace-code/src/lib/app_config").AppConfig;
         type Config = typeof import("ace-code/src/config");
-        type GutterTooltip = typeof import("ace-code/src/mouse/default_gutter_handler").GutterTooltip;
-        type GutterKeyboardEvent = typeof import("ace-code/src/keyboard/gutter_handler").GutterKeyboardEvent;
+        type GutterTooltip = import("ace-code/src/mouse/default_gutter_handler").GutterTooltip;
+        type GutterKeyboardEvent = import("ace-code/src/keyboard/gutter_handler").GutterKeyboardEvent;
         type AfterLoadCallback = (err: Error | null, module: unknown) => void;
         type LoaderFunction = (moduleName: string, afterLoad: AfterLoadCallback) => void;
         export interface ConfigOptions {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

The usage of `typeof` prevents consumers from reading the type properties. In our case, this triggers TypeScript errors [here](https://github.com/cloudscape-design/components/blob/f7988a7d2a9d43b9e03156b084b3220189b693f5/src/code-editor/setup-editor.ts#L64-L65) like:

```
Property 'isInAnnotationLane' does not exist on type 'typeof GutterKeyboardEvent'. ts(2339)
```

Applying the change in this PR to the local ace-builds package fixes this error and the type properties are available to TS as expected.

I assume the `typeof` was copied over unintentionally from the previous line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

