### PR TITLE
feat: update mouse selection at user's refresh rate

### DIFF
--- a/src/mouse/mouse_handler.js
+++ b/src/mouse/mouse_handler.js
@@ -129,7 +129,7 @@ class MouseHandler {
         renderer.$isMousePressed = true;
 
         var self = this;
-        var continueCapture = false;
+        var continueCapture = true;
 
         var onMouseMove = function(e) {
             if (!e) return;
@@ -192,7 +192,6 @@ class MouseHandler {
         self.$onCaptureMouseMove = onMouseMove;
         self.releaseMouse = event.capture(this.editor.container, onMouseMove, onCaptureEnd);
 
-        continueCapture = true;
         onCaptureInterval();
     }
     cancelContextMenu() {

--- a/src/mouse/mouse_handler.js
+++ b/src/mouse/mouse_handler.js
@@ -129,6 +129,8 @@ class MouseHandler {
         renderer.$isMousePressed = true;
 
         var self = this;
+        var continueCapture = false;
+
         var onMouseMove = function(e) {
             if (!e) return;
             // if editor is loaded inside iframe, and mouseup event is outside
@@ -145,8 +147,8 @@ class MouseHandler {
 
         var onCaptureEnd = function(e) {
             editor.off("beforeEndOperation", onOperationEnd);
-            clearInterval(timerId);
-            if (editor.session) onCaptureInterval();
+            continueCapture = false;
+            if (editor.session) onCaptureUpdate();
             self[self.state + "End"] && self[self.state + "End"](e);
             self.state = "";
             self.isMousePressed = renderer.$isMousePressed = false;
@@ -157,9 +159,16 @@ class MouseHandler {
             editor.endOperation();
         };
 
-        var onCaptureInterval = function() {
+        var onCaptureUpdate = function() {
             self[self.state] && self[self.state]();
             self.$mouseMoved = false;
+        };
+
+        var onCaptureInterval = function() {
+            if (continueCapture) {
+                onCaptureUpdate();
+                event.nextFrame(onCaptureInterval);
+            }
         };
 
         if (useragent.isOldIE && ev.domEvent.type == "dblclick") {
@@ -182,7 +191,9 @@ class MouseHandler {
 
         self.$onCaptureMouseMove = onMouseMove;
         self.releaseMouse = event.capture(this.editor.container, onMouseMove, onCaptureEnd);
-        var timerId = setInterval(onCaptureInterval, 20);
+
+        continueCapture = true;
+        onCaptureInterval();
     }
     cancelContextMenu() {
         var stop = function(e) {


### PR DESCRIPTION
*Issue #, if available:* #5716

*Description of changes:*
Rather than updating the mouse selection at a fixed interval of 20 milliseconds, I've changed it to use `event.nextFrame()`, which calls `requestAnimationFrame()`. This means that user selection is updated at their refresh rate, and thus results in a much smoother experience; this is especially noticeable on (but not limited to) high refresh-rate monitors.

I did note that there are many places within Ace where this fixed magic number of 20 is used, rather than hooking into the animation loop - these could also be made smoother by making similar adjustments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

