### PR TITLE
use https for homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ace-code",
     "description": "Ajax.org Code Editor is a full featured source code highlighting editor that powers the Cloud9 IDE",
     "version": "1.37.5",
-    "homepage": "http://github.com/ajaxorg/ace",
+    "homepage": "https://github.com/ajaxorg/ace",
     "engines": {
         "node": ">= 0.6.0"
     },
@@ -11,7 +11,7 @@
     "typings": "ace.d.ts",
     "repository": {
         "type": "git",
-        "url": "http://github.com/ajaxorg/ace.git"
+        "url": "https://github.com/ajaxorg/ace.git"
     },
     "devDependencies": {
         "amd-loader": "~0.0.4",


### PR DESCRIPTION
*Description of changes:*

This replaces the two http URLs in `package.json` with https URLs.

This is to satisfy *lintian* (the pedantic package checker that we use in Debian)

<hr>
FYI I just uploaded this as a package to Debian, in order to satisfy a dependency of openQA. See:

  https://tracker.debian.org/pkg/node-ace-code

Hopefully that's OK with you -- I'm new to the world of Javascript packaging, so hopefully I've not done anything terrible to your code while packaging it, but if you happen to notice anything I'll be happy to improve the package.
<hr>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

