### PR TITLE
Fix: wrong type of paste event and missing types for themelist extension

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -511,7 +511,7 @@ export namespace Ace {
         /**
          * Emitted when text is pasted.
          **/
-        "paste": (e: { text: string }) => void;
+        "paste": (e: { text: string, event?: ClipboardEvent }) => void;
         /**
          * Emitted when the selection style changes, via [[Editor.setSelectionStyle]].
          * @param data Contains one property, `data`, which indicates the new selection style

--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -511,7 +511,7 @@ export namespace Ace {
         /**
          * Emitted when text is pasted.
          **/
-        "paste": (text: string, event: any) => void;
+        "paste": (e: { text: string }) => void;
         /**
          * Emitted when the selection style changes, via [[Editor.setSelectionStyle]].
          * @param data Contains one property, `data`, which indicates the new selection style

--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -530,6 +530,7 @@ export namespace Ace {
         "gutterclick": (e: MouseEvent) => void;
         "showGutterTooltip": (e: GutterTooltip) => void;
         "hideGutterTooltip": (e: GutterTooltip) => void;
+        "compositionStart": () => void;
     }
 
     interface AcePopupEvents {
@@ -1334,6 +1335,7 @@ declare module "./src/editor" {
         showSettingsMenu?: () => void,
         searchBox?: Ace.SearchBox,
         _eventRegistry?: any,
+        $textInputAriaLabel?: string
     }
 }
 

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -422,7 +422,9 @@ declare module "ace-code" {
             /**
              * Emitted when text is pasted.
              **/
-            "paste": (text: string, event: any) => void;
+            "paste": (e: {
+                text: string;
+            }) => void;
             /**
              * Emitted when the selection style changes, via [[Editor.setSelectionStyle]].
              * @param data Contains one property, `data`, which indicates the new selection style

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -446,6 +446,7 @@ declare module "ace-code" {
             "gutterclick": (e: MouseEvent) => void;
             "showGutterTooltip": (e: GutterTooltip) => void;
             "hideGutterTooltip": (e: GutterTooltip) => void;
+            "compositionStart": () => void;
         }
         interface AcePopupEvents {
             "click": (e: MouseEvent) => void;

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -424,6 +424,7 @@ declare module "ace-code" {
              **/
             "paste": (e: {
                 text: string;
+                event?: ClipboardEvent;
             }) => void;
             /**
              * Emitted when the selection style changes, via [[Editor.setSelectionStyle]].

--- a/demo/test_package/index.ts
+++ b/demo/test_package/index.ts
@@ -9,6 +9,7 @@ import {MarkerGroup, MarkerGroupItem} from "ace-code/src/marker_group";
 import {HoverTooltip} from "ace-code/src/tooltip";
 import {hardWrap} from "ace-code/src/ext/hardwrap";
 import {SearchBox} from "ace-code/src/ext/searchbox";
+import {themesByName} from 'ace-code/src/ext/themelist';
 
 import("ace-code/src/ext/language_tools");
 import "../../src/test/mockdom.js";
@@ -142,3 +143,5 @@ editor.on("paste", (e) => {
         e.text = htmlString
     }
 })
+
+themesByName.textmate?.theme;

--- a/demo/test_package/index.ts
+++ b/demo/test_package/index.ts
@@ -137,7 +137,7 @@ editor.session.startOperation();
 editor.session.endOperation();
 
 editor.on("paste", (e) => {
-    var htmlString = e.event?.clipboardData.getData("text/html")
+    var htmlString = e.event?.clipboardData?.getData("text/html")
     if (htmlString) {
         e.text = htmlString
     }

--- a/demo/test_package/index.ts
+++ b/demo/test_package/index.ts
@@ -137,5 +137,8 @@ editor.session.startOperation();
 editor.session.endOperation();
 
 editor.on("paste", (e) => {
-    e.text;
+    var htmlString = e.event?.clipboardData.getData("text/html")
+    if (htmlString) {
+        e.text = htmlString
+    }
 })

--- a/demo/test_package/index.ts
+++ b/demo/test_package/index.ts
@@ -135,3 +135,7 @@ filter.setFilter("test");
 
 editor.session.startOperation();
 editor.session.endOperation();
+
+editor.on("paste", (e) => {
+    e.text;
+})

--- a/src/editor.js
+++ b/src/editor.js
@@ -863,7 +863,7 @@ class Editor {
 
     /**
      *
-     * @param e
+     * @param {string | {text: string}} e
      * @returns {boolean}
      */
     $handlePaste(e) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -853,7 +853,7 @@ class Editor {
     /**
      * Called whenever a text "paste" happens.
      * @param {String} text The pasted text
-     * @param {any} event
+     * @param {ClipboardEvent} [event]
      * @internal
      **/
     onPaste(text, event) {
@@ -863,7 +863,7 @@ class Editor {
 
     /**
      *
-     * @param {string | {text: string}} e
+     * @param {string | {text: string, event?: ClipboardEvent}} e
      * @returns {boolean}
      */
     $handlePaste(e) {

--- a/src/ext/themelist.js
+++ b/src/ext/themelist.js
@@ -8,6 +8,14 @@
 
 "use strict";
 
+/**
+ * @typedef {Object} Theme
+ * @property {string} caption - The display caption of the theme.
+ * @property {string} theme   - The path or identifier for the ACE theme.
+ * @property {boolean} isDark - Indicates whether the theme is dark or light.
+ * @property {string} name    - The normalized name used as the key.
+ */
+
 var themeData = [
     ["Chrome"         ],
     ["Clouds"         ],
@@ -54,11 +62,14 @@ var themeData = [
     ["CloudEditor Dark"     ,"cloud_editor_dark"       ,  "dark"]
 ];
 
-
+/**
+ * @type {Object<string, Theme>}
+ */
 exports.themesByName = {};
 
 /**
  * An array containing information about available themes.
+ * @type {Theme[]}
  */
 exports.themes = themeData.map(function(data) {
     var name = data[1] || data[0].replace(/ /g, "_").toLowerCase();

--- a/src/keyboard/textinput.js
+++ b/src/keyboard/textinput.js
@@ -22,7 +22,7 @@ var valueResetRegex = isIOS ? /\s/ : /\n/;
 var isMobile = useragent.isMobile;
 
 var TextInput;
-TextInput= function(parentNode, host) {
+TextInput= function(/**@type{HTMLTextAreaElement} */parentNode, /**@type{import("../editor").Editor} */host) {
     /**@type {HTMLTextAreaElement & {msGetInputContext?: () => {compositionStartOffset: number}, getInputContext?: () => {compositionStartOffset: number}}}*/
     var text = dom.createElement("textarea");
     text.className = "ace_text-input";
@@ -35,7 +35,7 @@ TextInput= function(parentNode, host) {
     text.style.opacity = "0";
     parentNode.insertBefore(text, parentNode.firstChild);
 
-    var copied = false;
+    /**@type{boolean|string}*/var copied = false;
     var pasted = false;
     /**@type {(boolean|Object) & {context?: any, useTextareaForIME?: boolean, selectionStart?: number, markerRange?: any}}} */
     var inComposition = false;
@@ -62,7 +62,7 @@ TextInput= function(parentNode, host) {
 
     // Set number of extra lines in textarea, some screenreaders
     // perform better with extra lines above and below in the textarea.
-    this.setNumberOfExtraLines = function(number) {
+    this.setNumberOfExtraLines = function(/**@type{number}*/number) {
         rowStart = Number.MAX_SAFE_INTEGER;
         rowEnd =  Number.MIN_SAFE_INTEGER;
 
@@ -695,7 +695,7 @@ TextInput= function(parentNode, host) {
         var rect = host.container.getBoundingClientRect();
         var style = dom.computedStyle(host.container);
         var top = rect.top + (parseInt(style.borderTopWidth) || 0);
-        var left = rect.left + (parseInt(rect.borderLeftWidth) || 0);
+        var left = rect.left + (parseInt(style.borderLeftWidth) || 0);
         var maxTop = rect.bottom - top - text.clientHeight -2;
         var move = function(e) {
             dom.translate(text, e.clientX - left - 2, Math.min(e.clientY - top - 2, maxTop));

--- a/types/ace-ext.d.ts
+++ b/types/ace-ext.d.ts
@@ -404,13 +404,28 @@ declare module "ace-code/src/ext/modelist" {
     }
 }
 declare module "ace-code/src/ext/themelist" {
-    export const themesByName: {};
-    export const themes: {
+    export const themesByName: {
+        [x: string]: Theme;
+    };
+    export const themes: Theme[];
+    export type Theme = {
+        /**
+         * - The display caption of the theme.
+         */
         caption: string;
+        /**
+         * - The path or identifier for the ACE theme.
+         */
         theme: string;
+        /**
+         * - Indicates whether the theme is dark or light.
+         */
         isDark: boolean;
+        /**
+         * - The normalized name used as the key.
+         */
         name: string;
-    }[];
+    };
 }
 declare module "ace-code/src/ext/options" {
     export class OptionPanel {

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -890,7 +890,7 @@ declare module "ace-code/src/virtual_renderer" {
          * @param {EditSession} session The session to associate with
          **/
         setSession(session: EditSession): void;
-        session: import("ace-code").Ace.EditSession;
+        session: import("ace-code/src/edit_session").EditSession;
         /**
          * Triggers a partial update of the text, from the range given by the two parameters.
          * @param {Number} firstRow The first row to update

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -890,7 +890,7 @@ declare module "ace-code/src/virtual_renderer" {
          * @param {EditSession} session The session to associate with
          **/
         setSession(session: EditSession): void;
-        session: import("ace-code/src/edit_session").EditSession;
+        session: import("ace-code").Ace.EditSession;
         /**
          * Triggers a partial update of the text, from the range given by the two parameters.
          * @param {Number} firstRow The first row to update


### PR DESCRIPTION
*Issue #, if available:* #5723

*Description of changes:*
- provide type for paste event 
- fix bug in `moveToMouse` 
- provide types for themelist

Could be further improved by listing theme names in types, but it would involve either manual writing those theme names, or rewriting `themeData` to have nice object structure with theme name as a key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

