### PR TITLE
Fix: types for setTimeout/setInterval calls

### DIFF
--- a/src/background_tokenizer.js
+++ b/src/background_tokenizer.js
@@ -20,7 +20,7 @@ class BackgroundTokenizer {
      * @param {EditSession} [session] The editor session to associate with
      **/
     constructor(tokenizer, session) {
-        /**@type {false|number}*/
+        /**@type {false | ReturnType<typeof setTimeout>}*/
         this.running = false;
         this.lines = [];
         /**@type {string[]|string[][]}*/

--- a/src/ext/emmet.js
+++ b/src/ext/emmet.js
@@ -324,7 +324,7 @@ var editorProxy = new AceEmmetEditor();
 exports.commands = new HashHandler();
 /**
  * @param {Editor} editor
- * @return {number|boolean}
+ * @return {ReturnType<typeof setTimeout> | boolean}
  */
 exports.runEmmetCommand = function runEmmetCommand(editor) {
     if (this.action == "expand_abbreviation_with_tab") {

--- a/src/layer/cursor.js
+++ b/src/layer/cursor.js
@@ -157,11 +157,13 @@ class Cursor {
             this.$startCssAnimation();
         } else {
             var blink = /**@this{Cursor}*/function(){
+                /**@type{ReturnType<typeof setTimeout>}*/
                 this.timeoutId = setTimeout(function() {
                     update(false);
                 }, 0.6 * this.blinkInterval);
             }.bind(this);
-    
+
+            /**@type{ReturnType<typeof setInterval>}*/
             this.intervalId = setInterval(function() {
                 update(true);
                 blink();

--- a/src/lib/event.js
+++ b/src/lib/event.js
@@ -322,6 +322,12 @@ if (typeof window == "object" && window.postMessage && !useragent.isOldIE) {
 }
 
 exports.$idleBlocked = false;
+/**
+ *
+ * @param {CallableFunction} cb
+ * @param {number} timeout
+ * @return {ReturnType<typeof setTimeout>}
+ */
 exports.onIdle = function(cb, timeout) {
     return setTimeout(function handler() {
         if (!exports.$idleBlocked) {

--- a/src/mouse/mouse_handler.js
+++ b/src/mouse/mouse_handler.js
@@ -117,6 +117,12 @@ class MouseHandler {
         this.state = state;
     }
 
+    /**
+     *
+     * @param {MouseEvent} ev
+     * @param [mouseMoveHandler]
+     * @return {ReturnType<typeof setTimeout> | undefined}
+     */
     captureMouse(ev, mouseMoveHandler) {
         this.x = ev.x;
         this.y = ev.y;

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -193,6 +193,7 @@ class HoverTooltip extends Tooltip {
     constructor(parentNode=document.body) {
         super(parentNode);
 
+        /**@type{ReturnType<typeof setTimeout> | undefined}*/
         this.timeout = undefined;
         this.lastT = 0;
         this.idleTime = 350;

--- a/types/ace-ext.d.ts
+++ b/types/ace-ext.d.ts
@@ -252,7 +252,7 @@ declare module "ace-code/src/ext/code_lens" {
 }
 declare module "ace-code/src/ext/emmet" {
     export const commands: HashHandler;
-    export function runEmmetCommand(editor: Editor): number | boolean;
+    export function runEmmetCommand(editor: Editor): ReturnType<typeof setTimeout> | boolean;
     export function updateCommands(editor: Editor, enabled?: boolean): void;
     export function isSupportedMode(mode: any): boolean;
     export function isAvailable(editor: Editor, command: string): boolean;

--- a/types/ace-lib.d.ts
+++ b/types/ace-lib.d.ts
@@ -106,7 +106,7 @@ declare module "ace-code/src/lib/event" {
     export function addCommandKeyListener(el: EventTarget, callback: (e: KeyboardEvent, hashId: number, keyCode: number) => void, destroyer?: any): void;
     export function nextTick(callback: any, win: any): void;
     export const $idleBlocked: boolean;
-    export function onIdle(cb: any, timeout: any): number;
+    export function onIdle(cb: CallableFunction, timeout: number): ReturnType<typeof setTimeout>;
     export const $idleBlockId: number;
     export function blockIdle(delay: any): void;
     export const nextFrame: any;

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -536,7 +536,7 @@ declare module "ace-code/src/layer/cursor" {
         hideCursor(): void;
         showCursor(): void;
         restartTimer(): void;
-        intervalId: number;
+        intervalId: ReturnType<typeof setInterval>;
         getPixelPosition(position?: import("ace-code").Ace.Point, onScreen?: boolean): {
             left: number;
             top: number;
@@ -1625,7 +1625,7 @@ declare module "ace-code/src/mouse/default_handlers" {
 declare module "ace-code/src/tooltip" {
     export class HoverTooltip extends Tooltip {
         constructor(parentNode?: HTMLElement);
-        timeout: number;
+        timeout: ReturnType<typeof setTimeout> | undefined;
         lastT: number;
         idleTime: number;
         lastEvent: import("ace-code/src/mouse/mouse_event").MouseEvent;
@@ -1740,7 +1740,7 @@ declare module "ace-code/src/mouse/mouse_handler" {
         }): void;
         setState(state: any): void;
         state: any;
-        captureMouse(ev: any, mouseMoveHandler: any): number;
+        captureMouse(ev: MouseEvent, mouseMoveHandler?: any): ReturnType<typeof setTimeout> | undefined;
         x: any;
         y: any;
         isMousePressed: boolean;
@@ -3582,7 +3582,7 @@ declare module "ace-code/src/background_tokenizer" {
          * @param {EditSession} [session] The editor session to associate with
          **/
         constructor(tokenizer: Tokenizer, session?: EditSession);
-        running: false | number;
+        running: false | ReturnType<typeof setTimeout>;
         lines: any[];
         states: string[] | string[][];
         currentLine: number;


### PR DESCRIPTION
*Issue #, if available:*

When `@types/node` is installed (for example, in a parent folder), TypeScript may interpret calls to `setInterval` (and similar timers) as returning `NodeJS.Timeout` instead of `number`. This leads to inconsistent types across different environments and can cause issues in generated `.d.ts` files.

*Description of changes:*
To ensure a consistent approach that works regardless of whether Node types are present, we use `ReturnType<typeof setInterval>` (and similarly for `setTimeout`). This way, even if the compiler sees both the DOM and Node definitions, it will correctly infer a union type when necessary without unexpectedly locking us to `NodeJS.Timeout` alone. This approach also future‑proofs code by not relying on environment-specific declarations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

