### PR TITLE
fix: calling setMode just before destroy causes error reading getLength

### DIFF
--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -934,6 +934,9 @@ class EditSession {
         // load on demand
         this.$modeId = path;
         config.loadModule(["mode", path], function(m) {
+            if (this.destroyed) {
+                return;
+            }
             if (this.$modeId !== path)
                 return cb && cb();
             if (this.$modes[path] && !options) {


### PR DESCRIPTION
Issue #, if available:
https://github.com/ajaxorg/ace/issues/5681

Description of changes:
When the editor is destroyed the pending callback(due to some async network request) created with editor.getSession.setMode causes an error which is avoided by aborting the callback in case if editor is destroyed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:

 No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (ace.d.ts) and its references:
https://github.com/ajaxorg/ace/blob/master/ace.d.ts
https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts
https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

