### PR TITLE
feat(popup): add support for skipping filtering with prefix by introducing skipFilter flag

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -28,6 +28,7 @@ var preventParentScroll = require("./lib/scroll").preventParentScroll;
  * @property {string} [docText] - a plain text that would be displayed as an additional popup. If `docHTML` exists,
  * it would be used instead of `docText`.
  * @property {string} [completerId] - the identifier of the completer
+ * @property {boolean} [skipFilter] - a boolean value to decide if the popup item is going to skip the filtering process done using prefix text.
  * @property {import("../ace-internal").Ace.IRange} [range] - An object specifying the range of text to be replaced with the new completion value (experimental)
  * @property {any} [command] - A command to be executed after the completion is inserted (experimental)
  * @property {string} [snippet] - a text snippet that would be inserted when the completion is selected
@@ -1055,6 +1056,10 @@ class FilteredList {
         var upper = needle.toUpperCase();
         var lower = needle.toLowerCase();
         loop: for (var i = 0, item; item = items[i]; i++) {
+            if (item.skipFilter) {
+                results.push(item);
+                continue;
+            }
             var caption = (!this.ignoreCaption && item.caption) || item.value || item.snippet;
             if (!caption) continue;
             var lastIndex = -1;

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -944,6 +944,58 @@ module.exports = {
         user.type(" value");
         assert.equal(completer.popup.isOpen, true);   
     },
+    "test: should skip filter if skipFilter flag is set to true in completion": function() {
+        var editor = initEditor("hello world\n");
+
+        var completer = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        value: "example value",
+                        skipFilter: true
+                    }
+                ];
+                callback(null, completions);
+            }
+        };
+
+        editor.completers = [completer];
+
+        var completer = Autocomplete.for(editor);
+        // should not do filter out the completion item where skipFilter is true
+        user.type("notMatchingText");
+        assert.equal(completer.popup.data.length, 1);
+        assert.equal(completer.popup.isOpen, true);
+    },
+    "test: should use filter if skipFilter flag is set to false in completion": function() {
+        var editor = initEditor("hello world\n");
+
+        var completer = {
+            getCompletions: function (editor, session, pos, prefix, callback) {
+                var completions = [
+                    {
+                        value: "example value",
+                        skipFilter: false
+                    }
+                ];
+                callback(null, completions);
+            }
+        };
+
+        editor.completers = [completer];
+
+        var completer = Autocomplete.for(editor);
+        
+        // should do filter out the completion item where skipFilter is false
+        user.type("notMatchingText");
+        assert.equal(completer.popup, undefined);
+        
+        // normal filtering mechanism should work fine
+        user.type(" ex");
+        assert.equal(completer.popup.isOpen, true);
+        assert.equal(completer.popup.data.length, 1); 
+    },
+    
     "test: should add inline preview content to aria-describedby": function(done) {
         var editor = initEditor("fun");
         

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -3225,6 +3225,10 @@ declare module "ace-code/src/autocomplete" {
          */
         completerId?: string;
         /**
+         * - a boolean value to decide if the popup item is going to skip the filtering process done using prefix text.
+         */
+        skipFilter?: boolean;
+        /**
          * - An object specifying the range of text to be replaced with the new completion value (experimental)
          */
         range?: import("ace-code").Ace.IRange;


### PR DESCRIPTION
*Description of changes:*
Add support for skipping filtering with prefix by introducing skipFilter flag which will all the popup item to not get filtered out incase if the popup item value is not matching the prefix.



Pull Request Checklist:
* [ yes] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

