### PR TITLE
Fix wrong event types and missing ace.require for ace-builds

### DIFF
--- a/Makefile.dryice.js
+++ b/Makefile.dryice.js
@@ -185,6 +185,10 @@ function correctDeclarationsForBuild(path, additionalDeclarations) {
     if (additionalDeclarations) {
         newDefinitions = newDefinitions + '\n' + additionalDeclarations;
     }
+    if (/ace\.d\.ts$/.test(path)) {
+        var aceRequire = "$1\n    export function require(name: string): any;";
+        newDefinitions = newDefinitions.replace(/(declare\smodule\s"ace\-builds"\s{)/, aceRequire);
+    }
     fs.writeFileSync(path, newDefinitions);
 }
 

--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -946,9 +946,8 @@ export namespace Ace {
     }) => void;
 
     interface CommandManagerEvents {
-        on(name: 'exec', callback: execEventHandler): Function;
-
-        on(name: 'afterExec', callback: execEventHandler): Function;
+        "exec": execEventHandler
+        "afterExec": execEventHandler;
     }
 
     type CommandManager = import("./src/commands/command_manager").CommandManager;
@@ -1236,6 +1235,24 @@ export namespace Ace {
         docChanged?: boolean;
         selectionChanged?: boolean;
     }
+
+    export interface CommandBarEvents {
+        "hide": () => void;
+        "show": () => void;
+        "alwaysShow": (e: boolean) => void;
+    }
+
+    export interface FontMetricsEvents {
+        "changeCharacterSize": (e: { data: { height: number, width: number } }) => void;
+    }
+
+    export interface OptionPanelEvents {
+        "setOption": (e: { name: string, value: any }) => void;
+    }
+
+    export interface ScrollbarEvents {
+        "scroll": (e: { data: number }) => void;
+    }
 }
 
 
@@ -1394,18 +1411,18 @@ declare module "./src/placeholder" {
 }
 
 declare module "./src/scrollbar" {
-    export interface VScrollBar extends Ace.EventEmitter<any> {
+    export interface VScrollBar extends Ace.EventEmitter<Ace.ScrollbarEvents> {
     }
 
-    export interface HScrollBar extends Ace.EventEmitter<any> {
+    export interface HScrollBar extends Ace.EventEmitter<Ace.ScrollbarEvents> {
     }
 }
 
 declare module "./src/scrollbar_custom" {
-    export interface VScrollBar extends Ace.EventEmitter<any> {
+    export interface VScrollBar extends Ace.EventEmitter<Ace.ScrollbarEvents> {
     }
 
-    export interface HScrollBar extends Ace.EventEmitter<any> {
+    export interface HScrollBar extends Ace.EventEmitter<Ace.ScrollbarEvents> {
     }
 }
 
@@ -1466,13 +1483,13 @@ declare module "./src/snippets" {
 }
 
 declare module "./src/ext/command_bar" {
-    export interface CommandBarTooltip extends Ace.EventEmitter<any> {
+    export interface CommandBarTooltip extends Ace.EventEmitter<Ace.CommandBarEvents> {
         $shouldHideMoreOptions?: boolean,
     }
 }
 
 declare module "./src/commands/command_manager" {
-    export interface CommandManager extends Ace.EventEmitter<any> {
+    export interface CommandManager extends Ace.EventEmitter<Ace.CommandManagerEvents> {
         $checkCommandState?: boolean
     }
 }
@@ -1552,12 +1569,12 @@ declare module "./src/mouse/mouse_handler" {
 }
 
 declare module "./src/ext/options" {
-    export interface OptionPanel extends Ace.EventEmitter<any> {
+    export interface OptionPanel extends Ace.EventEmitter<Ace.OptionPanelEvents> {
     }
 }
 
 declare module "./src/layer/font_metrics" {
-    export interface FontMetrics extends Ace.EventEmitter<any> {
+    export interface FontMetrics extends Ace.EventEmitter<Ace.FontMetricsEvents> {
     }
 }
 

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -759,8 +759,8 @@ declare module "ace-code" {
             args: any[];
         }) => void;
         interface CommandManagerEvents {
-            on(name: "exec", callback: execEventHandler): Function;
-            on(name: "afterExec", callback: execEventHandler): Function;
+            "exec": execEventHandler;
+            "afterExec": execEventHandler;
         }
         type CommandManager = import("ace-code/src/commands/command_manager").CommandManager;
         interface SavedSelection {
@@ -969,6 +969,30 @@ declare module "ace-code" {
             selectionAfter?: Range | Range[];
             docChanged?: boolean;
             selectionChanged?: boolean;
+        }
+        export interface CommandBarEvents {
+            "hide": () => void;
+            "show": () => void;
+            "alwaysShow": (e: boolean) => void;
+        }
+        export interface FontMetricsEvents {
+            "changeCharacterSize": (e: {
+                data: {
+                    height: number;
+                    width: number;
+                };
+            }) => void;
+        }
+        export interface OptionPanelEvents {
+            "setOption": (e: {
+                name: string;
+                value: any;
+            }) => void;
+        }
+        export interface ScrollbarEvents {
+            "scroll": (e: {
+                data: number;
+            }) => void;
         }
     }
     export const config: typeof import("ace-code/src/config");

--- a/demo/test_ace_builds/index.ts
+++ b/demo/test_ace_builds/index.ts
@@ -1,0 +1,37 @@
+import * as ace from "ace-builds";
+import {Range, Ace} from "ace-builds";
+import "ace-builds/src-noconflict/ext-language_tools";
+import "../../src/test/mockdom.js";
+var HoverTooltip = ace.require("ace/tooltip").HoverTooltip;
+import "ace-builds/src-noconflict/mode-javascript";
+import "ace-builds/src-noconflict/theme-monokai";
+
+const editor = ace.edit(null); // should not be an error
+editor.setTheme("ace/theme/monokai");
+editor.session.setMode("ace/mode/javascript");
+
+function configure(config: Ace.Config) {
+    config.setDefaultValues("editor", {
+        fontSize: 14,
+        showPrintMargin: false,
+    })
+}
+
+configure(ace.config) // should not be a error
+
+const hover = new HoverTooltip();
+hover.setDataProvider((e: any, editor: Ace.Editor) => {
+    const domNode = document.createElement("div");
+    hover.showForRange(editor, new Range(1, 3, 3, 1), domNode, e);
+});
+hover.addToEditor(editor);
+
+editor.commands.on('afterExec', ({editor, command}) => {
+    console.log(editor.getValue(), command.name);
+});
+
+editor.commands.on('exec', ({editor, command}) => {
+    console.log(editor.getValue(), command.name);
+});
+
+editor.destroy && editor.destroy();

--- a/demo/test_ace_builds/package.json
+++ b/demo/test_ace_builds/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ace-test-package",
+  "version": "1.0.0",
+  "description": "Test package for Ace builds",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node index.js"
+  },
+  "dependencies": {
+    "ace-builds": "file:../../ace-builds-latest.tgz"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3"
+  }
+}

--- a/demo/test_ace_builds/tsconfig.json
+++ b/demo/test_ace_builds/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    // "noUncheckedIndexedAccess": true,
+    // "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "target": "es2020",
+    "moduleResolution": "node"
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/demo/test_package/index.ts
+++ b/demo/test_package/index.ts
@@ -148,3 +148,11 @@ editor.on("paste", (e) => {
 
 if (themesByName.textmate)
     console.log(themesByName.textmate.theme);
+
+editor.commands.on('afterExec', ({editor, command}) => {
+    console.log(editor.getValue(), command.name);
+});
+
+editor.commands.on('exec', ({editor, command}) => {
+    console.log(editor.getValue(), command.name);
+});

--- a/src/layer/font_metrics.js
+++ b/src/layer/font_metrics.js
@@ -56,7 +56,7 @@ class FontMetrics {
     }
 
     /**
-     * @param size
+     * @param {{height: number, width: number} | null} [size]
      */
     checkForSizeChanges(size) {
         if (size === undefined)

--- a/tool/test-ace-builds-package.sh
+++ b/tool/test-ace-builds-package.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euxo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+npm install
+
+rm -rf ../ace-builds
+node ./Makefile.dryice.js full --target ../ace-builds
+
+cat > ../ace-builds/package.json <<'EOF'
+{
+    "name": "ace-builds",
+    "main": "./src-noconflict/ace.js",
+    "typings": "ace.d.ts",
+    "version": "1.38.0",
+    "description": "Ace (Ajax.org Cloud9 Editor)",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ajaxorg/ace-builds.git"
+    },
+    "author": "",
+    "license": "BSD-3-Clause",
+    "bugs": {
+        "url": "https://github.com/ajaxorg/ace-builds/issues"
+    },
+    "homepage": "https://github.com/ajaxorg/ace-builds"
+}
+EOF
+
+cd ../ace-builds
+npm pack
+
+rm -f "$REPO_ROOT/ace-builds-latest.tgz"
+
+PACKAGE_FILE=$(ls ace-builds-*.tgz | sort -V | tail -n 1)
+
+mv "$PACKAGE_FILE" "$REPO_ROOT/ace-builds-latest.tgz"
+
+cd "$REPO_ROOT/demo/test_ace_builds"
+
+rm -rf node_modules
+rm -f package-lock.json
+
+npm install "$REPO_ROOT/ace-builds-latest.tgz"
+
+npm i typescript@latest
+
+rm -f index.js
+npm run build
+npm run test
+
+cd "$REPO_ROOT"
+rm -f ace-builds-latest.tgz

--- a/types/ace-ext.d.ts
+++ b/types/ace-ext.d.ts
@@ -74,8 +74,9 @@ declare module "ace-code/src/ext/command_bar" {
         type EventEmitter<T extends {
             [K in keyof T]: (...args: any[]) => any;
         }> = import("ace-code").Ace.EventEmitter<T>;
+        type CommandBarEvents = import("ace-code").Ace.CommandBarEvents;
     }
-    export interface CommandBarTooltip extends Ace.EventEmitter<any> {
+    export interface CommandBarTooltip extends Ace.EventEmitter<Ace.CommandBarEvents> {
     }
 }
 declare module "ace-code/src/ext/language_tools" {
@@ -449,8 +450,9 @@ declare module "ace-code/src/ext/options" {
         type EventEmitter<T extends {
             [K in keyof T]: (...args: any[]) => any;
         }> = import("ace-code").Ace.EventEmitter<T>;
+        type OptionPanelEvents = import("ace-code").Ace.OptionPanelEvents;
     }
-    export interface OptionPanel extends Ace.EventEmitter<any> {
+    export interface OptionPanel extends Ace.EventEmitter<Ace.OptionPanelEvents> {
     }
 }
 declare module "ace-code/src/ext/prompt" {

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -4,7 +4,10 @@ declare module "ace-code/src/layer/font_metrics" {
     export class FontMetrics {
         constructor(parentEl: HTMLElement);
         el: HTMLDivElement;
-        checkForSizeChanges(size: any): void;
+        checkForSizeChanges(size?: {
+            height: number;
+            width: number;
+        } | null): void;
         charSizes: any;
         allowBoldFonts: boolean;
         setPolling(val: boolean): void;
@@ -17,8 +20,9 @@ declare module "ace-code/src/layer/font_metrics" {
         type EventEmitter<T extends {
             [K in keyof T]: (...args: any[]) => any;
         }> = import("ace-code").Ace.EventEmitter<T>;
+        type FontMetricsEvents = import("ace-code").Ace.FontMetricsEvents;
     }
-    export interface FontMetrics extends Ace.EventEmitter<any> {
+    export interface FontMetrics extends Ace.EventEmitter<Ace.FontMetricsEvents> {
     }
 }
 declare module "ace-code/src/apply_delta" {
@@ -655,10 +659,11 @@ declare module "ace-code/src/scrollbar" {
         type EventEmitter<T extends {
             [K in keyof T]: (...args: any[]) => any;
         }> = import("ace-code").Ace.EventEmitter<T>;
+        type ScrollbarEvents = import("ace-code").Ace.ScrollbarEvents;
     }
-    export interface VScrollBar extends Ace.EventEmitter<any> {
+    export interface VScrollBar extends Ace.EventEmitter<Ace.ScrollbarEvents> {
     }
-    export interface HScrollBar extends Ace.EventEmitter<any> {
+    export interface HScrollBar extends Ace.EventEmitter<Ace.ScrollbarEvents> {
     }
 }
 declare module "ace-code/src/scrollbar_custom" {
@@ -785,10 +790,11 @@ declare module "ace-code/src/scrollbar_custom" {
         type EventEmitter<T extends {
             [K in keyof T]: (...args: any[]) => any;
         }> = import("ace-code").Ace.EventEmitter<T>;
+        type ScrollbarEvents = import("ace-code").Ace.ScrollbarEvents;
     }
-    export interface VScrollBar extends Ace.EventEmitter<any> {
+    export interface VScrollBar extends Ace.EventEmitter<Ace.ScrollbarEvents> {
     }
-    export interface HScrollBar extends Ace.EventEmitter<any> {
+    export interface HScrollBar extends Ace.EventEmitter<Ace.ScrollbarEvents> {
     }
 }
 declare module "ace-code/src/renderloop" {
@@ -1904,8 +1910,9 @@ declare module "ace-code/src/commands/command_manager" {
         type EventEmitter<T extends {
             [K in keyof T]: (...args: any[]) => any;
         }> = import("ace-code").Ace.EventEmitter<T>;
+        type CommandManagerEvents = import("ace-code").Ace.CommandManagerEvents;
     }
-    export interface CommandManager extends Ace.EventEmitter<any> {
+    export interface CommandManager extends Ace.EventEmitter<Ace.CommandManagerEvents> {
     }
 }
 declare module "ace-code/src/commands/default_commands" {


### PR DESCRIPTION
*Issue #, if available:* #5743 #5742

*Description of changes:*
- fix missing event types 
- fix `ace.require` for ace-builds
- add `ace-builds` test package and script to test `ace-builds` with generated types

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

