### PR TITLE
fix: set score completion item when skipfilter true

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -1057,6 +1057,7 @@ class FilteredList {
         var lower = needle.toLowerCase();
         loop: for (var i = 0, item; item = items[i]; i++) {
             if (item.skipFilter) {
+                item.$score = item.score;
                 results.push(item);
                 continue;
             }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* When we set `skipFilter` for a completion item to true, the filtering logic skips the part where `$score` is set which results in the `score` property of the item being ignored, resulting in unexpected ordering of items.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

