### PR TITLE
Expose Autocomplete on enableBasicAutocompletion

### DIFF
--- a/src/ext/language_tools.js
+++ b/src/ext/language_tools.js
@@ -181,6 +181,8 @@ require("../config").defineOptions(Editor.prototype, "editor", {
          */
         set: function(val) {
             if (val) {
+                Autocomplete.for(this);
+
                 if (!this.completers)
                     this.completers = Array.isArray(val)? val: completers;
                 this.commands.addCommand(Autocomplete.startCommand);


### PR DESCRIPTION
*Issue #, if available:* #5730

*Description of changes:*
This update enhances the editor's autocompletion API by exposing the `editor.completer` instance immediately after `enableBasicAutocompletion` is enabled. Previously, accessing autocomplete properties required triggering the completion popup, which limited early configuration and customization. Now, developers can immediately set up and adjust autocomplete behaviors as soon as autocompletion is activated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

