### PR TITLE
fix: replace NodeList.foreach with for loop

### DIFF
--- a/src/layer/text.js
+++ b/src/layer/text.js
@@ -512,9 +512,9 @@ class Text {
 
     $clearActiveIndentGuide() {
         var activeIndentGuides = this.element.querySelectorAll(".ace_indent-guide-active");
-        activeIndentGuides.forEach(el => {
-            el.classList.remove("ace_indent-guide-active");
-        });
+        for (var i = 0; i < activeIndentGuides.length; i++) {
+            activeIndentGuides[i].classList.remove("ace_indent-guide-active");
+        };
     }
 
     $setIndentGuideActive(cell, indentLevel) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/ajaxorg/ace/issues/5766

*Description of changes:*
Fix for old browsers. Replace NodeList.forEach() with for loop, since forEach is not available before Firefox 50 (see [docs](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#browser_compatibility)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

