### PR TITLE
Update drools folding to include 'global' and 'import'

### DIFF
--- a/src/mode/folding/drools.js
+++ b/src/mode/folding/drools.js
@@ -8,18 +8,36 @@ var TokenIterator = require("../../token_iterator").TokenIterator;
 var FoldMode = exports.FoldMode = function() {};
 oop.inherits(FoldMode, BaseFoldMode);
 
-(function() {
+(function () {
 
     // regular expressions that identify starting and stopping points
-    this.foldingStartMarker = /\b(rule|declare|query|when|then)\b/; 
+    this.foldingStartMarker = /\b(rule|declare|query|when|then)\b/;
     this.foldingStopMarker = /\bend\b/;
+    this.importRegex = /^import /;
+    this.globalRegex = /^global /;
+    this.getBaseFoldWidget = this.getFoldWidget;
 
-    this.getFoldWidgetRange = function(session, foldStyle, row) {
+    this.getFoldWidget = function (session, foldStyle, row) {
+        if (foldStyle === "markbegin") {
+            var line = session.getLine(row);
+            if (this.importRegex.test(line)) {
+                if (row === 0 || !this.importRegex.test(session.getLine(row - 1)))
+                    return "start";
+            }
+            if (this.globalRegex.test(line)) {
+                if (row === 0 || !this.globalRegex.test(session.getLine(row - 1)))
+                    return "start";
+            }
+        }
+
+        return this.getBaseFoldWidget(session, foldStyle, row);
+    };
+
+    this.getFoldWidgetRange = function (session, foldStyle, row) {
         var line = session.getLine(row);
         var match = line.match(this.foldingStartMarker);
-        if (match) {
-            var i = match.index;
 
+        if (match) {
             if (match[1]) {
                 var position = {row: row, column: line.length};
                 var iterator = new TokenIterator(session, position.row, position.column);
@@ -29,7 +47,7 @@ oop.inherits(FoldMode, BaseFoldMode);
                     seek = "then";
                 }
                 while (token) {
-                    if (token.value == seek) { 
+                    if (token.value == seek) {
                         return Range.fromPoints(position ,{
                             row: iterator.getCurrentTokenRow(),
                             column: iterator.getCurrentTokenColumn()
@@ -40,7 +58,38 @@ oop.inherits(FoldMode, BaseFoldMode);
             }
 
         }
+        match = line.match(this.importRegex);
+        if (match) {
+            return getMatchedFoldRange(session, this.importRegex, match, row);
+        }
+        match = line.match(this.globalRegex);
+        if (match) {
+            return getMatchedFoldRange(session, this.globalRegex, match, row);
+        }
         // test each line, and return a range of segments to collapse
     };
 
 }).call(FoldMode.prototype);
+
+function getMatchedFoldRange(session, regex, match, row) {
+    let startColumn = match[0].length;
+    let maxRow = session.getLength();
+    let startRow = row;
+    let endRow = row;
+
+    while (++row < maxRow) {
+        let line = session.getLine(row);
+        if (line.match(/^\s*$/))
+            continue;
+
+        if (!line.match(regex))
+            break;
+
+        endRow = row;
+    }
+
+    if (endRow > startRow) {
+        let endColumn = session.getLine(endRow).length;
+        return new Range(startRow, startColumn, endRow, endColumn);
+    }
+}

--- a/src/mode/folding/drools_test.js
+++ b/src/mode/folding/drools_test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const DroolsMode = require("../drools").Mode;
+const EditSession = require("../../edit_session").EditSession;
+const assert = require("../../test/assertions");
+
+module.exports = {
+
+  "test: drools folds": function () {
+    const session = new EditSession([
+      'package com.example.ace',
+      'import java.math.BigDecimal',
+      'import function my.package.Foo.hello',
+      '',
+      'global org.slf4j.Logger logger',
+      'global java.lang.Boolean checkFlag',
+      '',
+      'declare trait GoldenCustomer',
+      '    balance : long @Alias( "org.acme.foo.accountBalance" )',
+      'end',
+      'query isContainedIn( String x, String y )',
+      '    Location( z, y; ) and isContainedIn( x, z;)',
+      'end',
+      'rule "go1"',
+      '    String( this == "go1" )',
+      '    isContainedIn("Office", "House"; )',
+      'then',
+      '    System.out.println( "office is in the house" );',
+      'end'
+    ]);
+
+    const mode = new DroolsMode();
+    session.setMode(mode);
+    session.setFoldStyle("markbegin");
+
+    assert.equal(session.getFoldWidget(0), "");
+    assert.equal(session.getFoldWidget(1), "start"); // import
+    assert.equal(session.getFoldWidget(2), "");
+    assert.equal(session.getFoldWidget(3), "");
+    assert.equal(session.getFoldWidget(4), "start"); // global
+    assert.equal(session.getFoldWidget(5), "");
+    assert.equal(session.getFoldWidget(6), "");
+    assert.equal(session.getFoldWidget(7), "start"); // declare
+    assert.equal(session.getFoldWidget(8), "");
+    assert.equal(session.getFoldWidget(9), "");
+    assert.equal(session.getFoldWidget(10), "start");  // query
+    assert.equal(session.getFoldWidget(11), "");
+    assert.equal(session.getFoldWidget(12), "");
+    assert.equal(session.getFoldWidget(13), "start"); // rule
+    assert.equal(session.getFoldWidget(14), "");
+    assert.equal(session.getFoldWidget(15), "");
+    assert.equal(session.getFoldWidget(16), "start"); // then
+    assert.equal(session.getFoldWidget(17), "");
+    assert.equal(session.getFoldWidget(18), "");
+
+    assert.range(session.getFoldWidgetRange(1), 1, 7, 2, 36); // import
+    assert.range(session.getFoldWidgetRange(4), 4, 7, 5, 34); // global
+    assert.range(session.getFoldWidgetRange(7), 7, 28, 9, 0); // declare
+    assert.range(session.getFoldWidgetRange(10), 10, 41, 12, 0); // query
+    assert.range(session.getFoldWidgetRange(13), 13, 10, 18, 0); // rule
+    assert.range(session.getFoldWidgetRange(16), 16, 4, 18, 0); // then
+  }
+};
+
+
+if (typeof module !== "undefined" && module === require.main)
+  require("asyncjs").test.testcase(module.exports).exec();


### PR DESCRIPTION
*Issue #, if available:* N/A

Updated the drools mode's folding so that both `global` and `import` can be also be folded as well. I have also added in a test as there was not one included beforehand.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

