### PR TITLE
chore: don't autoclose p1 issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -25,7 +25,7 @@ jobs:
 
           # These labels are required
           stale-issue-label: closing-soon
-          exempt-issue-labels: no-autoclose
+          exempt-issue-labels: no-autoclose, p1
           response-requested-label: response-requested
 
           # Don't set closed-for-staleness label to skip closing very old issues


### PR DESCRIPTION
*Issue #, if available:* na

*Description of changes:* issues marked as `p1` are issues which have been manually marked by maintainers as important. As such, we want to keep them open regardless of their staleness.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

