### PR TITLE
Expose `keyCodeToString` in `lib/keys`

### DIFF
--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -147,12 +147,15 @@ Keys.del = Keys["delete"];
 Keys.KEY_MODS[0] = "";
 Keys.KEY_MODS[-1] = "input-";
 
-
+/**@deprecated*/
 oop.mixin(exports, Keys);
 
 exports.default = exports;
 
-// @ts-ignore
+/**
+ * @param {number} keyCode
+ * @return {string}
+ */
 exports.keyCodeToString = function(keyCode) {
     // Language-switching keystroke in Chrome/Linux emits keyCode 0.
     var keyString = Keys[keyCode];

--- a/tool/ace_declaration_generator.js
+++ b/tool/ace_declaration_generator.js
@@ -157,8 +157,13 @@ function updateMainAceModule(node) {
  */
 function updateKeysAndLinksStatements(node, internalStatements) {
     let statements = [];
+    if (node.body && ts.isModuleBlock(node.body)) {
+        statements = node.body.statements.filter(statement =>
+            ts.isFunctionDeclaration(statement)
+        );
+    }
     if (internalStatements[node.name.text]) {
-        statements = internalStatements[node.name.text];
+        statements = [...internalStatements[node.name.text]];
     }
     const newBody = ts.factory.createModuleBlock(statements);
     return ts.factory.updateModuleDeclaration(node, node.modifiers, node.name, newBody);

--- a/types/ace-lib.d.ts
+++ b/types/ace-lib.d.ts
@@ -101,7 +101,9 @@ declare module "ace-code/src/lib/lang" {
     export function supportsLookbehind(): boolean;
     export function skipEmptyMatch(line: any, last: any, supportsUnicodeFlag: any): 1 | 2;
 }
-declare module "ace-code/src/lib/keys" { }
+declare module "ace-code/src/lib/keys" {
+    export function keyCodeToString(keyCode: number): string;
+}
 declare module "ace-code/src/lib/event" {
     export function addListener(elem: any, type: string, callback: any, destroyer?: any): void;
     export function removeListener(elem: any, type: any, callback: any): void;


### PR DESCRIPTION
*Issue #, if available:* #5706

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

