### PR TITLE
add editor.destroyed property

### DIFF
--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -468,6 +468,7 @@ function updateUIEditorOptions() {
 
 env.editor.on("changeSession", function() {
     for (var i in env.editor.session.$options) {
+        if (i == "mode") continue;
         var value = util.getOption(i);
         if (value != undefined) {
             env.editor.setOption(i, value);

--- a/demo/test_package/index.ts
+++ b/demo/test_package/index.ts
@@ -156,3 +156,8 @@ editor.commands.on('afterExec', ({editor, command}) => {
 editor.commands.on('exec', ({editor, command}) => {
     console.log(editor.getValue(), command.name);
 });
+
+editor.setSession(null);
+console.log(editor.destroyed);
+editor.destroy();
+console.log(editor.destroyed);

--- a/src/editor.js
+++ b/src/editor.js
@@ -242,7 +242,7 @@ class Editor {
 
     /**
      * Sets a new editsession to use. This method also emits the `'changeSession'` event.
-     * @param {EditSession} [session] The new session to use
+     * @param {EditSession|null} [session] The new session to use
      **/
     setSession(session) {
         if (this.session == session)
@@ -2689,11 +2689,12 @@ class Editor {
      * Cleans up the entire editor.
      **/
     destroy() {
+        this.destroyed = true;
         if (this.$toDestroy) {
             this.$toDestroy.forEach(function(el) {
                 el.destroy();
             });
-            this.$toDestroy = null;
+            this.$toDestroy = [];
         }
         if (this.$mouseHandler)
             this.$mouseHandler.destroy();
@@ -2840,12 +2841,16 @@ config.defineOptions(Editor.prototype, "editor", {
     readOnly: {
         set: function(/**@type{boolean}*/readOnly) {
             this.textInput.setReadOnly(readOnly);
+            if (this.destroyed) return;
             this.$resetCursorStyle();
             if (!this.$readOnlyCallback) {
                 this.$readOnlyCallback = (e) => {
                     var shouldShow = false;
                     if (e && e.type == "keydown") {
-                        shouldShow = e && e.key && e.key.length == 1 && !e.ctrlKey && !e.metaKey;
+                        if (e && e.key && !e.ctrlKey && !e.metaKey) {
+                            if (e.key == " ") e.preventDefault();
+                            shouldShow = e.key.length == 1;
+                        }
                         if (!shouldShow) return;
                     } else if (e && e.type !== "exec") {
                         shouldShow = true;

--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -196,6 +196,7 @@ class SearchBox {
      * @param {any} [preventScroll]
      */
     find(skipCurrent, backwards, preventScroll) {
+        if (!this.editor.session) return;
         var range = this.editor.find(this.searchInput.value, {
             skipCurrent: skipCurrent,
             backwards: backwards,

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -2072,9 +2072,9 @@ declare module "ace-code/src/editor" {
         getKeyboardHandler(): any;
         /**
          * Sets a new editsession to use. This method also emits the `'changeSession'` event.
-         * @param {EditSession} [session] The new session to use
+         * @param {EditSession|null} [session] The new session to use
          **/
-        setSession(session?: EditSession): void;
+        setSession(session?: EditSession | null): void;
         selection: import("ace-code/src/selection").Selection;
         /**
          * Returns the current session being used.
@@ -2676,6 +2676,10 @@ declare module "ace-code/src/editor" {
          * Cleans up the entire editor.
          **/
         destroy(): void;
+        /**
+         * true if editor is destroyed
+         */
+        destroyed: boolean;
         /**
          * Enables automatic scrolling of the cursor into view when editor itself is inside scrollable element
          * @param {Boolean} enable default true


### PR DESCRIPTION
- add editor.destroyed property
- keep $toDestroy as array even after destroying to prevent calling methods of destroyed editor from throwing errors
- prevent space scrolling editor out of view in readonly mode  