### PR TITLE
feature(gutter): add experimental ability to replace fold icon with custom for a specific row

### DIFF
--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -507,7 +507,7 @@ module.exports = `
     padding-right: 13px;
 }
 
-.ace_fold-widget {
+.ace_fold-widget, .ace_custom-widget {
     box-sizing: border-box;
 
     margin: 0 -12px 0 1px;

--- a/src/css/editor-css.js
+++ b/src/css/editor-css.js
@@ -525,6 +525,10 @@ module.exports = `
     cursor: pointer;
 }
 
+.ace_custom-widget {
+    background: none;
+}
+
 .ace_folding-enabled .ace_fold-widget {
     display: inline-block;   
 }

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -590,20 +590,21 @@ class EditSession {
      * @param {number} row The row number for which to hide the custom icon
      */
     removeGutterCustomWidget(row) {
-        this.$editor.renderer.$gutterLayer.removeCustomWidget(row);
+        this.$editor.renderer.$gutterLayer.$removeCustomWidget(row);
     }
 
     /**
      * Replaces the fold widget if present with the custom icon from a specific row in the gutter
      * @param {number} row - The row number where the widget will be displayed
-     * @param {Object} options - Configuration options for the widget
-     * @param {string} options.className - CSS class name for styling the widget
-     * @param {string} options.label - Text label to display in the widget
-     *  @param {string} options.title - Tooltip text for the widget
+     * @param {Object} attributes - Configuration attributes for the widget
+     * @param {string} attributes.className - CSS class name for styling the widget
+     * @param {string} attributes.label - Text label to display in the widget
+     * @param {string} attributes.title - Tooltip text for the widget
+     * @param {Object} attributes.callbacks - Event callback functions for the widget e.g onClick; 
      * @returns {void}
     */
     addGutterCustomWidget(row,attributes) {
-        this.$editor.renderer.$gutterLayer.addCustomWidget(row,attributes);
+        this.$editor.renderer.$gutterLayer.$addCustomWidget(row,attributes);
     }
 
     /**

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -594,7 +594,9 @@ class EditSession {
      * @experimental
      */
     removeGutterCustomWidget(row) {
-        this.$editor.renderer.$gutterLayer.$removeCustomWidget(row);
+        if(this.$editor) {
+            this.$editor.renderer.$gutterLayer.$removeCustomWidget(row);
+        }
     }
 
     /**
@@ -609,7 +611,9 @@ class EditSession {
      * @experimental
     */
     addGutterCustomWidget(row,attributes) {
-        this.$editor.renderer.$gutterLayer.$addCustomWidget(row,attributes);
+        if(this.$editor) {
+            this.$editor.renderer.$gutterLayer.$addCustomWidget(row,attributes);
+        }
     }
 
     /**

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -586,6 +586,27 @@ class EditSession {
     }
 
     /**
+     * Replaces the custom icon with the fold widget if present from a specific row in the gutter
+     * @param {number} row The row number for which to hide the custom icon
+     */
+    removeGutterCustomWidget(row) {
+        this.$editor.renderer.$gutterLayer.removeCustomWidget(row);
+    }
+
+    /**
+     * Replaces the fold widget if present with the custom icon from a specific row in the gutter
+     * @param {number} row - The row number where the widget will be displayed
+     * @param {Object} options - Configuration options for the widget
+     * @param {string} options.className - CSS class name for styling the widget
+     * @param {string} options.label - Text label to display in the widget
+     *  @param {string} options.title - Tooltip text for the widget
+     * @returns {void}
+    */
+    addGutterCustomWidget(row,attributes) {
+        this.$editor.renderer.$gutterLayer.addCustomWidget(row,attributes);
+    }
+
+    /**
      * Removes `className` from the `row`.
      * @param {Number} row The row number
      * @param {String} className The class to add

--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -57,6 +57,9 @@ class EditSession {
             return this.join("\n");
         };
 
+        // @experimental
+        this.$gutterCustomWidgets = {};
+
         // Set default background tokenizer with Text mode until editor session mode is set
         this.bgTokenizer = new BackgroundTokenizer((new TextMode()).getTokenizer(), this);
 
@@ -588,6 +591,7 @@ class EditSession {
     /**
      * Replaces the custom icon with the fold widget if present from a specific row in the gutter
      * @param {number} row The row number for which to hide the custom icon
+     * @experimental
      */
     removeGutterCustomWidget(row) {
         this.$editor.renderer.$gutterLayer.$removeCustomWidget(row);
@@ -602,6 +606,7 @@ class EditSession {
      * @param {string} attributes.title - Tooltip text for the widget
      * @param {Object} attributes.callbacks - Event callback functions for the widget e.g onClick; 
      * @returns {void}
+     * @experimental
     */
     addGutterCustomWidget(row,attributes) {
         this.$editor.renderer.$gutterLayer.$addCustomWidget(row,attributes);

--- a/src/layer/gutter.js
+++ b/src/layer/gutter.js
@@ -21,7 +21,6 @@ class Gutter{
         this.setShowFoldWidgets(this.$showFoldWidgets);
 
         this.gutterWidth = 0;
-        this.$customWidgets = {};
 
         this.$annotations = [];
         this.$updateAnnotations = this.$updateAnnotations.bind(this);
@@ -464,11 +463,11 @@ class Gutter{
             }
         }
         // fold logic ends here 
-        const customWidgetAttributes= this.$customWidgets[row];
-        if(customWidgetAttributes){
-            this.$addCustomWidget(row,customWidgetAttributes,cell);
+        const customWidgetAttributes = this.session.$gutterCustomWidgets[row];
+        if (customWidgetAttributes) {
+            this.$addCustomWidget(row, customWidgetAttributes,cell);
         }
-        else if(customWidget){
+        else if (customWidget){
             this.$removeCustomWidget(row,cell);
         }
 
@@ -604,6 +603,7 @@ class Gutter{
      * Hides the fold widget/icon from a specific row in the gutter
      * @param {number} row The row number from which to hide the fold icon
      * @param {any} cell - Gutter cell 
+     * @experimental
      */
     $hideFoldWidget(row, cell) {
         const rowCell = cell || this.$getGutterCell(row);
@@ -619,6 +619,7 @@ class Gutter{
      * Shows the fold widget/icon from a specific row in the gutter
      * @param {number} row The row number from which to show the fold icon
      * @param {any} cell - Gutter cell 
+     * @experimental
      */
     $showFoldWidget(row,cell) {
         const rowCell = cell || this.$getGutterCell(row);
@@ -629,13 +630,14 @@ class Gutter{
             }
         }
     }
-    
+
     /**
     * Retrieves the gutter cell element at the specified cursor row position.
     * @param {number} row - The row number in the editor where the gutter cell is located starts from 0
     * @returns {HTMLElement|null} The gutter cell element at the specified row, or null if not found
+    * @experimental
     */
-    $getGutterCell(row){
+    $getGutterCell(row) {
         // contains only visible rows
         const cells = this.$lines.cells;
         const visibileRow= this.session.documentToScreenRow(row,0);
@@ -653,9 +655,10 @@ class Gutter{
     * @param {Object} attributes.callbacks - Event callback functions for the widget e.g onClick; 
     * @param {any} cell - Gutter cell 
     * @returns {void}
+    * @experimental
     */
     $addCustomWidget(row, {className, label, title, callbacks}, cell) {
-        this.$customWidgets[row] = {className, label, title, callbacks};
+        this.session.$gutterCustomWidgets[row] = {className, label, title, callbacks};
         this.$hideFoldWidget(row,cell);
 
         // cell is required because when cached cell is used to render, $lines won't have that cell
@@ -692,9 +695,10 @@ class Gutter{
     * @param {number} row - The row number where the widget will be removed
     * @param {any} cell - Gutter cell 
     * @returns {void}
+    * @experimental
     */
-    $removeCustomWidget(row, cell){
-        delete this.$customWidgets[row];
+    $removeCustomWidget(row, cell) {
+        delete this.session.$gutterCustomWidgets[row];
         this.$showFoldWidget(row,cell);
 
         // cell is required because when cached cell is used to render, $lines won't have that cell

--- a/src/layer/gutter.js
+++ b/src/layer/gutter.js
@@ -663,8 +663,10 @@ class Gutter{
         const cell = cells[row];
         if (cell && cell.element) {
             const customWidget = cell.element.querySelector(".ace_custom-widget");
-            cell.element.removeChild(customWidget);
-            this.showFoldWidget(row);
+            if (customWidget) {
+                cell.element.removeChild(customWidget);
+                this.showFoldWidget(row);
+            }
         }
     }
 

--- a/src/layer/gutter.js
+++ b/src/layer/gutter.js
@@ -331,6 +331,7 @@ class Gutter{
         
         var textNode = element.childNodes[0];
         var foldWidget = element.childNodes[1];
+        var customWidget = element.childNodes[3];
         var annotationNode = element.childNodes[2];
         var annotationIconNode = annotationNode.firstChild;
 
@@ -418,6 +419,10 @@ class Gutter{
             // Set a11y properties.
             foldWidget.setAttribute("role", "button");
             foldWidget.setAttribute("tabindex", "-1");
+
+            if(customWidget && window.getComputedStyle(customWidget).getPropertyValue('display') !== 'none'){
+                this.hideFoldWidget(row);
+            }
             var foldRange = session.getFoldWidgetRange(row);
 
             // getFoldWidgetRange is optional to be implemented by fold modes, if not available we fall-back.
@@ -587,6 +592,80 @@ class Gutter{
     
     getShowFoldWidgets() {
         return this.$showFoldWidgets;
+    }
+    
+    /**
+     * Hides the fold widget/icon from a specific row in the gutter
+     * @param {number} row The row number from which to hide the fold icon
+     */
+    hideFoldWidget(row) {
+        const cells = this.$lines.cells;
+        const cell = cells[row];
+        if (cell && cell.element) {
+            const foldWidget = cell.element.childNodes[1];
+            if (foldWidget) {
+                dom.setStyle(foldWidget.style, "display", "none");
+            }
+        }
+    }
+
+    /**
+     * Shows the fold widget/icon from a specific row in the gutter
+     * @param {number} row The row number from which to show the fold icon
+     */
+    showFoldWidget(row) {
+        const cells = this.$lines.cells;
+        const cell = cells[row];
+        if (cell && cell.element) {
+            const foldWidget = cell.element.childNodes[1];
+            if (foldWidget) {
+                dom.setStyle(foldWidget.style, "display", "inline-block");
+            }
+        }
+    }
+
+    /**
+    * Displays a custom widget for a specific row
+    * @param {number} row - The row number where the widget will be displayed
+    * @param {Object} options - Configuration options for the widget
+    * @param {string} options.className - CSS class name for styling the widget
+    * @param {string} options.label - Text label to display in the widget
+    * @param {string} options.title - Tooltip text for the widget
+    * @returns {void}
+    */
+    addCustomWidget(row, {className, label, title}) {
+        const cells = this.$lines.cells;
+        const cell = cells[row];
+        if (cell && cell.element) {
+            this.hideFoldWidget(row);
+
+            const customWidget = dom.createElement("span");
+
+            customWidget.className = `ace_custom-widget ${className}`;
+            customWidget.setAttribute("tabindex", "-1");
+            customWidget.setAttribute("role", 'button');
+            customWidget.setAttribute("aria-label", label);
+            customWidget.setAttribute("title", title);
+            dom.setStyle(customWidget.style, "display", "inline-block");
+            dom.setStyle(customWidget.style, "height", "inherit");
+                
+            cell.element.appendChild(customWidget);
+        }
+    }
+    
+    /**
+    * Remove a custom widget for a specific row
+    * @param {number} row - The row number where the widget will be removed
+    * @returns {void}
+    */
+    removeCustomWidget(row){
+        const cells = this.$lines.cells;
+        const cell = cells[row];
+        if (cell && cell.element) {
+            const customWidget = cell.element.querySelector(".ace_custom-widget");
+            cell.element.removeChild(customWidget);
+            this.showFoldWidget(row);
+        }
     }
 
     $computePadding() {

--- a/src/layer/gutter_test.js
+++ b/src/layer/gutter_test.js
@@ -1,0 +1,172 @@
+if (typeof process !== "undefined") {
+    require("amd-loader");
+    require("../test/mockdom");
+}
+
+var keys = require("../lib/keys");
+
+("use strict");
+
+require("../multi_select");
+require("../theme/textmate");
+var Editor = require("../editor").Editor;
+var Mode = require("../mode/java").Mode;
+var VirtualRenderer = require("../virtual_renderer").VirtualRenderer;
+var assert = require("../test/assertions");
+
+function emit(keyCode) {
+    var data = {bubbles: true, keyCode};
+    var event = new KeyboardEvent("keydown", data);
+
+    var el = document.activeElement;
+    el.dispatchEvent(event);
+}
+
+module.exports = {
+    setUp: function (done) {
+        this.editor = new Editor(new VirtualRenderer());
+        this.editor.container.style.position = "absolute";
+        this.editor.container.style.height = "500px";
+        this.editor.container.style.width = "500px";
+        this.editor.container.style.left = "50px";
+        this.editor.container.style.top = "10px";
+        document.body.appendChild(this.editor.container);
+        done();
+    },
+    "test: custom icon replaces the fold icon sucessfully": function (done) {
+        var editor = this.editor;
+        var value = "x {" + "\n".repeat(50) + "}\n";
+        value = value.repeat(50);
+        editor.session.setMode(new Mode());
+        editor.setValue(value, -1);
+        editor.setOption("enableKeyboardAccessibility", true);
+        editor.renderer.$loop._flush();
+
+        var lines = editor.renderer.$gutterLayer.$lines;
+
+        // Set focus to the gutter div.
+        editor.renderer.$gutter.focus();
+        assert.equal(document.activeElement, editor.renderer.$gutter);
+
+        // Focus on the fold widget.
+        emit(keys["enter"]);
+        editor.renderer.$gutterLayer.addCustomWidget(13, {
+            className: "ace_users_css",
+            label: "Open_label",
+            title: "Open_title"
+        });
+
+        setTimeout(function () {
+            setTimeout(function () {
+                // Check that custom widget is shown
+                editor.renderer.$loop._flush();
+                console.log(lines.cells[13].element.children[2].className);
+                assert.ok(/ace_users_css/.test(lines.cells[13].element.children[3].className));
+                // fold widget is not shown
+                assert.equal(lines.cells[13].element.children[1].style.display, "none");
+
+                // After escape focus should be back to the gutter.
+                emit(keys["escape"]);
+                assert.equal(document.activeElement, editor.renderer.$gutter);
+
+                done();
+            }, 20);
+        }, 20);
+    },
+    "test: after hiding custom icon fold icon is visible automatically": function (done) {
+        var editor = this.editor;
+        var value = "x {" + "\n".repeat(50) + "}\n";
+        value = value.repeat(50);
+        editor.session.setMode(new Mode());
+        editor.setValue(value, -1);
+        editor.setOption("enableKeyboardAccessibility", true);
+        editor.renderer.$loop._flush();
+
+        var lines = editor.renderer.$gutterLayer.$lines;
+
+        // Set focus to the gutter div.
+        editor.renderer.$gutter.focus();
+        assert.equal(document.activeElement, editor.renderer.$gutter);
+
+        // Focus on the custom widget.
+        emit(keys["enter"]);
+        editor.renderer.$gutterLayer.addCustomWidget(0, {
+            className: "ace_users_css",
+            label: "Open_label",
+            title: "Open_title"
+        });
+        editor.renderer.$gutterLayer.removeCustomWidget(0);
+
+        setTimeout(function () {
+            assert.equal(document.activeElement, lines.cells[0].element.childNodes[1]);
+
+            setTimeout(function () {
+                // Check that custom widget is hidden.
+                editor.renderer.$loop._flush();
+                assert.equal(lines.cells[0].element.children[3], undefined);
+                assert.equal(lines.cells[0].element.children[1].style.display, "inline-block");
+                assert.ok(/ace_open/.test(lines.cells[0].element.children[1].className));
+
+                // After escape focus should be back to the gutter.
+                emit(keys["escape"]);
+                assert.equal(document.activeElement, editor.renderer.$gutter);
+
+                done();
+            }, 20);
+        }, 20);
+    },
+
+    "test: folding is kept consistent when custom widget is shown first and then hidden": function (done) {
+        var editor = this.editor;
+        var value = "x {" + "\n".repeat(50) + "}\n";
+        value = value.repeat(50);
+        editor.session.setMode(new Mode());
+        editor.setValue(value, -1);
+        editor.setOption("enableKeyboardAccessibility", true);
+        editor.renderer.$loop._flush();
+
+        var lines = editor.renderer.$gutterLayer.$lines;
+
+        // Set focus to the gutter div.
+        editor.renderer.$gutter.focus();
+        assert.equal(document.activeElement, editor.renderer.$gutter);
+
+        // Focus on the fold widget.
+        emit(keys["enter"]);
+
+        setTimeout(function () {
+            assert.equal(document.activeElement, lines.cells[0].element.childNodes[1]);
+
+            // Click the fold widget to fold the lines.
+            emit(keys["enter"]);
+            editor.renderer.$gutterLayer.addCustomWidget(0, {
+                className: "ace_users_css",
+                label: "Open_label",
+                title: "Open_title"
+            });
+            editor.renderer.$gutterLayer.removeCustomWidget(0);
+
+            setTimeout(function () {
+                // Check that custom widget is hidden.
+                editor.renderer.$loop._flush();
+                assert.equal(lines.cells[0].element.children[3], undefined);
+                assert.ok(/ace_closed/.test(lines.cells[0].element.children[1].className));
+
+                // After escape focus should be back to the gutter.
+                emit(keys["escape"]);
+                assert.equal(document.activeElement, editor.renderer.$gutter);
+
+                done();
+            }, 20);
+        }, 20);
+    },
+
+    tearDown: function () {
+        this.editor.destroy();
+        document.body.removeChild(this.editor.container);
+    }
+};
+
+if (typeof module !== "undefined" && module === require.main) {
+    require("asyncjs").test.testcase(module.exports).exec();
+}

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -422,6 +422,34 @@ declare module "ace-code/src/layer/gutter" {
         getShowLineNumbers(): boolean;
         setShowFoldWidgets(show?: boolean): void;
         getShowFoldWidgets(): boolean;
+        /**
+         * Hides the fold widget/icon from a specific row in the gutter
+         * @param {number} row The row number from which to hide the fold icon
+         */
+        hideFoldWidget(row: number): void;
+        /**
+         * Shows the fold widget/icon from a specific row in the gutter
+         * @param {number} row The row number from which to show the fold icon
+         */
+        showFoldWidget(row: number): void;
+        /**
+        * Displays a custom widget for a specific row
+        * @param {number} row - The row number where the widget will be displayed
+        * @param {Object} options - Configuration options for the widget
+        * @param {string} options.className - CSS class name for styling the widget
+        * @param {string} options.label - Text label to display in the widget
+        * @param {string} options.title - Tooltip text for the widget
+        */
+        addCustomWidget(row: number, { className, label, title }: {
+            className: string;
+            label: string;
+            title: string;
+        }): void;
+        /**
+        * Remove a custom widget for a specific row
+        * @param {number} row - The row number where the widget will be removed
+        */
+        removeCustomWidget(row: number): void;
         getRegion(point: {
             x: number;
         }): "markers" | "foldWidgets";
@@ -3948,6 +3976,20 @@ declare module "ace-code/src/edit_session" {
          * @param {String} className The class to add
          **/
         addGutterDecoration(row: number, className: string): void;
+        /**
+         * Replaces the custom icon with the fold widget if present from a specific row in the gutter
+         * @param {number} row The row number for which to hide the custom icon
+         */
+        removeGutterCustomWidget(row: number): void;
+        /**
+         * Replaces the fold widget if present with the custom icon from a specific row in the gutter
+         * @param {number} row - The row number where the widget will be displayed
+         * @param {Object} options - Configuration options for the widget
+         * @param {string} options.className - CSS class name for styling the widget
+         * @param {string} options.label - Text label to display in the widget
+         *  @param {string} options.title - Tooltip text for the widget
+        */
+        addGutterCustomWidget(row: number, attributes: any): void;
         /**
          * Removes `className` from the `row`.
          * @param {Number} row The row number

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -422,34 +422,6 @@ declare module "ace-code/src/layer/gutter" {
         getShowLineNumbers(): boolean;
         setShowFoldWidgets(show?: boolean): void;
         getShowFoldWidgets(): boolean;
-        /**
-         * Hides the fold widget/icon from a specific row in the gutter
-         * @param {number} row The row number from which to hide the fold icon
-         */
-        hideFoldWidget(row: number): void;
-        /**
-         * Shows the fold widget/icon from a specific row in the gutter
-         * @param {number} row The row number from which to show the fold icon
-         */
-        showFoldWidget(row: number): void;
-        /**
-        * Displays a custom widget for a specific row
-        * @param {number} row - The row number where the widget will be displayed
-        * @param {Object} options - Configuration options for the widget
-        * @param {string} options.className - CSS class name for styling the widget
-        * @param {string} options.label - Text label to display in the widget
-        * @param {string} options.title - Tooltip text for the widget
-        */
-        addCustomWidget(row: number, { className, label, title }: {
-            className: string;
-            label: string;
-            title: string;
-        }): void;
-        /**
-        * Remove a custom widget for a specific row
-        * @param {number} row - The row number where the widget will be removed
-        */
-        removeCustomWidget(row: number): void;
         getRegion(point: {
             x: number;
         }): "markers" | "foldWidgets";
@@ -3984,12 +3956,18 @@ declare module "ace-code/src/edit_session" {
         /**
          * Replaces the fold widget if present with the custom icon from a specific row in the gutter
          * @param {number} row - The row number where the widget will be displayed
-         * @param {Object} options - Configuration options for the widget
-         * @param {string} options.className - CSS class name for styling the widget
-         * @param {string} options.label - Text label to display in the widget
-         *  @param {string} options.title - Tooltip text for the widget
+         * @param {Object} attributes - Configuration attributes for the widget
+         * @param {string} attributes.className - CSS class name for styling the widget
+         * @param {string} attributes.label - Text label to display in the widget
+         * @param {string} attributes.title - Tooltip text for the widget
+         * @param {Object} attributes.callbacks - Event callback functions for the widget e.g onClick;
         */
-        addGutterCustomWidget(row: number, attributes: any): void;
+        addGutterCustomWidget(row: number, attributes: {
+            className: string;
+            label: string;
+            title: string;
+            callbacks: any;
+        }): void;
         /**
          * Removes `className` from the `row`.
          * @param {Number} row The row number

--- a/types/ace-modules.d.ts
+++ b/types/ace-modules.d.ts
@@ -3951,6 +3951,7 @@ declare module "ace-code/src/edit_session" {
         /**
          * Replaces the custom icon with the fold widget if present from a specific row in the gutter
          * @param {number} row The row number for which to hide the custom icon
+         * @experimental
          */
         removeGutterCustomWidget(row: number): void;
         /**
@@ -3961,6 +3962,7 @@ declare module "ace-code/src/edit_session" {
          * @param {string} attributes.label - Text label to display in the widget
          * @param {string} attributes.title - Tooltip text for the widget
          * @param {Object} attributes.callbacks - Event callback functions for the widget e.g onClick;
+         * @experimental
         */
         addGutterCustomWidget(row: number, attributes: {
             className: string;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding Experimental capability in gutter to replace the fold icon with the custom icon.
Custom widget Icon can be added which will hides the fold Icon and show custom widget icon.
And custom widget Icon can be removed which will remove the custom widget and displays the fold icon.
