### PR TITLE
Add modern C++ language feature support to syntax highlighting

### DIFF
--- a/src/mode/c_cpp_highlight_rules.js
+++ b/src/mode/c_cpp_highlight_rules.js
@@ -17,24 +17,27 @@ var c_cppHighlightRules = function(extraKeywords) {
     var storageType = (
         "asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|" +
         "_Imaginary|int|int8_t|int16_t|int32_t|int64_t|long|short|signed|size_t|struct|typedef|uint8_t|uint16_t|uint32_t|uint64_t|union|unsigned|void|" +
-        "class|wchar_t|template|char16_t|char32_t"
+        "class|wchar_t|template|char16_t|char32_t|char8_t"
     );
 
     var storageModifiers = (
         "const|extern|register|restrict|static|volatile|inline|private|" +
         "protected|public|friend|explicit|virtual|export|mutable|typename|" +
-        "constexpr|new|delete|alignas|alignof|decltype|noexcept|thread_local"
+        "constexpr|new|delete|alignas|alignof|decltype|noexcept|thread_local|" +
+        "constinit|consteval|concept|contexts|final|override|import|module|" +
+        "pre|post"
     );
 
     var keywordOperators = (
         "and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|" +
-        "const_cast|dynamic_cast|reinterpret_cast|static_cast|sizeof|namespace"
+        "const_cast|dynamic_cast|reinterpret_cast|static_cast|sizeof|namespace|"+
+        "co_yield|co_return|co_await|contract_assert"
     );
 
     var builtinConstants = (
         "NULL|true|false|TRUE|FALSE|nullptr"
     );
-
+    
     var keywordMapper = this.$keywords = this.createKeywordMapper(Object.assign({
         "keyword.control" : keywordControls,
         "storage.type" : storageType,
@@ -105,11 +108,11 @@ var c_cppHighlightRules = function(extraKeywords) {
                 regex : "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
             }, {
                 token : "keyword", // pre-compiler directives
-                regex : "#\\s*(?:include|import|pragma|line|define|undef)\\b",
+                regex : "#\\s*(?:include|pragma|line|define|defined|undef|embed|error|warning|__has_include|__has_cpp_attribute|__has_embed)\\b",
                 next  : "directive"
             }, {
                 token : "keyword", // special case pre-compiler directive
-                regex : "#\\s*(?:endif|if|ifdef|else|elif|ifndef)\\b"
+                regex : "#\\s*(?:endif|if|ifdef|else|elif|ifndef|elifdef|elifndef)\\b"
             }, {
                 token : keywordMapper,
                 regex : "[a-zA-Z_$][a-zA-Z0-9_$]*"


### PR DESCRIPTION
This commit updates the C++ syntax highlight rules to support:
- C++20 features: concepts, consteval, constinit, coroutines (co_await, co_yield, co_return)
- Modules support (import, module)
- Extended preprocessor directives (__has_include, __has_embed, etc.)
- Additional control flow directives (elifdef, elifndef)
- Newer type support (char8_t)
- Contract programming keywords (pre, post, contract_assert)

These changes ensure proper syntax highlighting for modern C++ codebases using recent language standards.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

