### PR TITLE
Improve JSDoc annotations for code lens

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -317,7 +317,7 @@ export namespace Ace {
         fullWidth?: boolean,
         screenWidth?: number,
         rowsAbove?: number,
-        lenses?: any[],
+        lenses?: CodeLenseCommand[],
     }
 
     type NewLineMode = 'auto' | 'unix' | 'windows';
@@ -1084,13 +1084,48 @@ export namespace Ace {
         $blockSelectEnabled?: boolean,
     }
 
+    /**
+     * Provider interface for code lens functionality
+     */
     interface CodeLenseProvider {
+        /**
+         * Compute code lenses for the given edit session
+         * @param session The edit session to provide code lenses for
+         * @param callback Callback function that receives errors and code lenses
+         */
         provideCodeLenses: (session: EditSession, callback: (err: any, payload: CodeLense[]) => void) => void;
     }
 
+    /**
+     * Represents a command associated with a code lens
+     */
+    interface CodeLenseCommand {
+        /**
+         * Command identifier that will be executed
+         */
+        id?: string,
+        /**
+         * Display title for the code lens
+         */
+        title: string,
+        /**
+         * Argument(s) to pass to the command when executed
+         */
+        arguments?: any,
+    }
+
+    /**
+     * Represents a code lens - an actionable UI element displayed above a code line
+     */
     interface CodeLense {
+        /**
+         * Starting position where the code lens should be displayed
+         */
         start: Point,
-        command: any
+        /**
+         * Command to execute when the code lens is activated
+         */
+        command?: CodeLenseCommand
     }
 
     interface CodeLenseEditorExtension {

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -222,7 +222,7 @@ declare module "ace-code" {
             fullWidth?: boolean;
             screenWidth?: number;
             rowsAbove?: number;
-            lenses?: any[];
+            lenses?: CodeLenseCommand[];
         }
         type NewLineMode = "auto" | "unix" | "windows";
         interface EditSessionOptions {
@@ -875,12 +875,46 @@ declare module "ace-code" {
             alignCursors: () => void;
             multiSelect?: any;
         }
+        /**
+         * Provider interface for code lens functionality
+         */
         interface CodeLenseProvider {
+            /**
+             * Compute code lenses for the given edit session
+             * @param session The edit session to provide code lenses for
+             * @param callback Callback function that receives errors and code lenses
+             */
             provideCodeLenses: (session: EditSession, callback: (err: any, payload: CodeLense[]) => void) => void;
         }
+        /**
+         * Represents a command associated with a code lens
+         */
+        interface CodeLenseCommand {
+            /**
+             * Command identifier that will be executed
+             */
+            id?: string;
+            /**
+             * Display title for the code lens
+             */
+            title: string;
+            /**
+             * Argument(s) to pass to the command when executed
+             */
+            arguments?: any;
+        }
+        /**
+         * Represents a code lens - an actionable UI element displayed above a code line
+         */
         interface CodeLense {
+            /**
+             * Starting position where the code lens should be displayed
+             */
             start: Point;
-            command: any;
+            /**
+             * Command to execute when the code lens is activated
+             */
+            command?: CodeLenseCommand;
         }
         interface CodeLenseEditorExtension {
             codeLensProviders?: CodeLenseProvider[];

--- a/types/ace-ext.d.ts
+++ b/types/ace-ext.d.ts
@@ -250,6 +250,8 @@ declare module "ace-code/src/ext/code_lens" {
     export type EditSession = import("ace-code/src/edit_session").EditSession;
     export type VirtualRenderer = import("ace-code/src/virtual_renderer").VirtualRenderer & {
     };
+    export type CodeLenseCommand = import("ace-code").Ace.CodeLenseCommand;
+    export type CodeLense = import("ace-code").Ace.CodeLense;
     import { Editor } from "ace-code/src/editor";
 }
 declare module "ace-code/src/ext/emmet" {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds JSDocs to provide typescript support for the codelens functionality

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

