### PR TITLE
Feat: Add scroll diff decorators

### DIFF
--- a/src/ext/diff/base_diff_view.js
+++ b/src/ext/diff/base_diff_view.js
@@ -297,7 +297,7 @@ class BaseDiffView {
         const setupScrollBar = (renderer) => {
             setTimeout(() => {
                 renderer.$scrollDecorator.destroy();
-                renderer.$scrollDecorator = new ScrollDiffDecorator(renderer.scrollBarV, renderer);
+                renderer.$scrollDecorator = new ScrollDiffDecorator(renderer.scrollBarV, renderer, this.inlineDiffEditor);
                 renderer.$scrollDecorator.setSessions(this.sessionA, this.sessionB);
                 renderer.scrollBarV.setVisible(true);
                 renderer.scrollBarV.element.style.bottom = renderer.scrollBarH.getHeight() + "px";

--- a/src/ext/diff/base_diff_view.js
+++ b/src/ext/diff/base_diff_view.js
@@ -142,10 +142,6 @@ class BaseDiffView {
         });
 
         this.setupScrollbars();
-
-        setTimeout(() => {
-            this.updateScrollBarDecorators();
-        }, 1);
     }
 
     addGutterDecorators() { 
@@ -162,7 +158,6 @@ class BaseDiffView {
     $setupModel(session, value) {
         var editor = new Editor(new Renderer(), session);
         editor.session.setUndoManager(new UndoManager());
-        // editor.renderer.setOption("decoratorType", "diff");
         if (value) {
             editor.setValue(value, -1);
         }
@@ -296,11 +291,14 @@ class BaseDiffView {
          */
         const setupScrollBar = (renderer) => {
             setTimeout(() => {
-                renderer.$scrollDecorator.destroy();
+                if (renderer.$scrollDecorator) {
+                    renderer.$scrollDecorator.destroy();
+                }
                 renderer.$scrollDecorator = new ScrollDiffDecorator(renderer.scrollBarV, renderer, this.inlineDiffEditor);
                 renderer.$scrollDecorator.setSessions(this.sessionA, this.sessionB);
                 renderer.scrollBarV.setVisible(true);
                 renderer.scrollBarV.element.style.bottom = renderer.scrollBarH.getHeight() + "px";
+                this.updateScrollBarDecorators();
             }, 0);
         };
 
@@ -316,9 +314,15 @@ class BaseDiffView {
 
     updateScrollBarDecorators() {
         if (this.inlineDiffEditor) {
+            if (!this.activeEditor) {
+                return;
+            }
             this.activeEditor.renderer.$scrollDecorator.zones = [];
         }
         else {
+            if (!this.editorA || !this.editorB) {
+                return;
+            }
             this.editorA.renderer.$scrollDecorator.zones = [];
             this.editorB.renderer.$scrollDecorator.zones = [];
         }

--- a/src/ext/diff/providers/default.js
+++ b/src/ext/diff/providers/default.js
@@ -2462,6 +2462,7 @@ var {DiffChunk} = require("../base_diff_view");
 /**
  * VSCode’s computeDiff provider
  */
+
 class DiffProvider {
     compute(originalLines, modifiedLines, opts) {
         if (!opts) opts = {};

--- a/src/ext/diff/scroll_diff_decorator.js
+++ b/src/ext/diff/scroll_diff_decorator.js
@@ -16,13 +16,17 @@ class ScrollDiffDecorator extends Decorator {
         this.zones = [];
     }
 
-    addZone(startRow, endRow, type, logicalLines) {
+    addZone(startRow, endRow, type) {
         this.zones.push({
             startRow,
             endRow,
-            type,
-            logicalLines
+            type
         });
+    }
+
+    setSessions(sessionA, sessionB) {
+        this.sessionA = sessionA;
+        this.sessionB = sessionB;
     }
 
     $updateDecorators(config) {
@@ -31,6 +35,14 @@ class ScrollDiffDecorator extends Decorator {
             var colors = (this.renderer.theme.isDark === true) ? this.colors.dark : this.colors.light;
             var ctx = this.canvas.getContext("2d");
             this.$setDiffDecorators(ctx, colors);
+        }
+    }
+
+    $transformPosition(row, type) {
+        if (type == "delete") {
+            return this.sessionA.documentToScreenRow(row, 0);
+        } else {
+            return this.sessionB.documentToScreenRow(row, 0);
         }
     }
 
@@ -51,8 +63,8 @@ class ScrollDiffDecorator extends Decorator {
 
             [deleteZones, insertZones].forEach((typeZones, columnIndex) => {
                 typeZones.forEach((zone, i) => {
-                    const offset1 = this.getVerticalOffsetForRow(zone.startRow);
-                    const offset2 = this.getVerticalOffsetForRow(zone.endRow) + this.lineHeight;
+                    const offset1 = this.$transformPosition(zone.startRow, zone.type) * this.lineHeight;
+                    let offset2 = this.$transformPosition(zone.endRow, zone.type) * this.lineHeight + this.lineHeight;
 
                     const y1 = Math.round(this.heightRatio * offset1);
                     const y2 = Math.round(this.heightRatio * offset2);

--- a/src/ext/diff/scroll_diff_decorator.js
+++ b/src/ext/diff/scroll_diff_decorator.js
@@ -1,0 +1,116 @@
+var Decorator = require("../../layer/decorators").Decorator;
+
+class ScrollDiffDecorator extends Decorator {
+    /**
+     * @param {import("../../../ace-internal").Ace.VScrollbar} scrollbarV
+     * @param {import("../../virtual_renderer").VirtualRenderer} renderer
+     */
+    constructor(scrollbarV, renderer) {
+        super(scrollbarV, renderer);
+
+        this.colors.dark["delete"] = "rgba(255, 18, 18, 1)";
+        this.colors.dark["insert"] = "rgba(18, 136, 18, 1)";
+        this.colors.light["delete"] = "rgb(255,51,51)";
+        this.colors.light["insert"] = "rgb(32,133,72)";
+
+        this.zones = [];
+    }
+
+    addZone(startRow, endRow, type, logicalLines) {
+        this.zones.push({
+            startRow,
+            endRow,
+            type,
+            logicalLines
+        });
+    }
+
+    $updateDecorators(config) {
+        super.$updateDecorators(config);
+        if (this.zones.length > 0) {
+            var colors = (this.renderer.theme.isDark === true) ? this.colors.dark : this.colors.light;
+            var ctx = this.canvas.getContext("2d");
+            this.$setDiffDecorators(ctx, colors);
+        }
+    }
+
+    $setDiffDecorators(ctx, colors) {
+        function compare(a, b) {
+            if (a.from === b.from) {
+                return a.to - b.to;
+            }
+            return a.from - b.from;
+        }
+
+        var zones = this.zones;
+        if (zones) {
+            var resolvedZones = [];
+
+            const deleteZones = zones.filter(z => z.type === "delete");
+            const insertZones = zones.filter(z => z.type === "insert");
+
+            [deleteZones, insertZones].forEach((typeZones, columnIndex) => {
+                typeZones.forEach((zone, i) => {
+                    const offset1 = this.getVerticalOffsetForRow(zone.startRow);
+                    const offset2 = this.getVerticalOffsetForRow(zone.endRow) + this.lineHeight;
+
+                    const y1 = Math.round(this.heightRatio * offset1);
+                    const y2 = Math.round(this.heightRatio * offset2);
+
+                    const padding = 1;
+
+                    let ycenter = Math.round((y1 + y2) / 2);
+                    let halfHeight = (y2 - ycenter);
+
+                    if (halfHeight < this.halfMinDecorationHeight) {
+                        halfHeight = this.halfMinDecorationHeight;
+                    }
+
+                    const previousZone = resolvedZones[resolvedZones.length - 1];
+
+                    if (i > 0 && previousZone && previousZone.type === zone.type && ycenter - halfHeight < previousZone.to + padding) {
+                        ycenter = resolvedZones[resolvedZones.length - 1].to + padding + halfHeight;
+                    }
+
+                    if (ycenter - halfHeight < 0) {
+                        ycenter = halfHeight;
+                    }
+                    if (ycenter + halfHeight > this.canvasHeight) {
+                        ycenter = this.canvasHeight - halfHeight;
+                    }
+
+                    resolvedZones.push({
+                        type: zone.type,
+                        from: ycenter - halfHeight,
+                        to: ycenter + halfHeight,
+                        color: colors[zone.type] || null
+                    });
+                });
+            });
+
+            resolvedZones = resolvedZones.sort(compare);
+
+            for (const zone of resolvedZones) {
+                ctx.fillStyle = zone.color || null;
+
+                const zoneFrom = zone.from;
+                const zoneTo = zone.to;
+                const zoneHeight = zoneTo - zoneFrom;
+
+                if (zone.type == "delete") {
+                    ctx.fillRect(this.oneZoneWidth, zoneFrom, this.oneZoneWidth, zoneHeight);
+                }
+                else {
+                    ctx.fillRect(2 * this.oneZoneWidth, zoneFrom, this.oneZoneWidth, zoneHeight);
+                }
+            }
+
+        }
+    }
+
+    setZoneWidth() {
+        this.oneZoneWidth = Math.round(this.canvasWidth / 3);
+    }
+}
+
+exports.ScrollDiffDecorator = ScrollDiffDecorator;

--- a/src/ext/diff/scroll_diff_decorator.js
+++ b/src/ext/diff/scroll_diff_decorator.js
@@ -4,8 +4,9 @@ class ScrollDiffDecorator extends Decorator {
     /**
      * @param {import("../../../ace-internal").Ace.VScrollbar} scrollbarV
      * @param {import("../../virtual_renderer").VirtualRenderer} renderer
+     * @param {boolean} [forInlineDiff]
      */
-    constructor(scrollbarV, renderer) {
+    constructor(scrollbarV, renderer, forInlineDiff) {
         super(scrollbarV, renderer);
 
         this.colors.dark["delete"] = "rgba(255, 18, 18, 1)";
@@ -14,8 +15,14 @@ class ScrollDiffDecorator extends Decorator {
         this.colors.light["insert"] = "rgb(32,133,72)";
 
         this.zones = [];
+        this.forInlineDiff = forInlineDiff;
     }
 
+    /**
+     * @param {number} startRow
+     * @param {number} endRow
+     * @param {"delete"|"insert"} type
+     */
     addZone(startRow, endRow, type) {
         this.zones.push({
             startRow,
@@ -61,7 +68,7 @@ class ScrollDiffDecorator extends Decorator {
             const deleteZones = zones.filter(z => z.type === "delete");
             const insertZones = zones.filter(z => z.type === "insert");
 
-            [deleteZones, insertZones].forEach((typeZones, columnIndex) => {
+            [deleteZones, insertZones].forEach((typeZones) => {
                 typeZones.forEach((zone, i) => {
                     const offset1 = this.$transformPosition(zone.startRow, zone.type) * this.lineHeight;
                     let offset2 = this.$transformPosition(zone.endRow, zone.type) * this.lineHeight + this.lineHeight;
@@ -108,12 +115,15 @@ class ScrollDiffDecorator extends Decorator {
                 const zoneFrom = zone.from;
                 const zoneTo = zone.to;
                 const zoneHeight = zoneTo - zoneFrom;
-
-                if (zone.type == "delete") {
-                    ctx.fillRect(this.oneZoneWidth, zoneFrom, this.oneZoneWidth, zoneHeight);
-                }
-                else {
-                    ctx.fillRect(2 * this.oneZoneWidth, zoneFrom, this.oneZoneWidth, zoneHeight);
+                if (this.forInlineDiff) {
+                    ctx.fillRect(this.oneZoneWidth, zoneFrom, 2 * this.oneZoneWidth, zoneHeight);
+                } else {
+                    if (zone.type == "delete") {
+                        ctx.fillRect(this.oneZoneWidth, zoneFrom, this.oneZoneWidth, zoneHeight);
+                    }
+                    else {
+                        ctx.fillRect(2 * this.oneZoneWidth, zoneFrom, this.oneZoneWidth, zoneHeight);
+                    }
                 }
             }
 

--- a/src/layer/decorators.js
+++ b/src/layer/decorators.js
@@ -60,7 +60,7 @@ class Decorator {
                 "error": 3
             };
             annotations.forEach(function (item) {
-                item.priority = priorities[item.type] || null;
+                item["priority"] = priorities[item.type] || null;
             });
             annotations = annotations.sort(compare);
 

--- a/src/layer/decorators.js
+++ b/src/layer/decorators.js
@@ -95,7 +95,7 @@ class Decorator {
         var cursor = this.renderer.session.selection.getCursor();
         if (cursor) {
             let currentY = Math.round(this.getVerticalOffsetForRow(cursor.row) * this.heightRatio);
-            ctx.fillStyle = "rgba(0, 0, 0, 0.8)";
+            ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
             ctx.fillRect(0, currentY, this.canvasWidth, 2);
         }
 

--- a/src/test/mockdom.js
+++ b/src/test/mockdom.js
@@ -136,7 +136,7 @@ function Context2d(w, h) {
     this.getImageData = function(sx, sy, sw, sh) {
         var data = new Uint8ClampedArray(sw * sh * 4);
         var newIndex = 0;
-        for (var i = sx; i < sw + sy; i++) {
+        for (var i = sx; i < sw + sx; i++) {
             for (var j = sy; j < sh + sy; j++) {
                 var index = (this.width * j + i) * 4;
                 for (var k = 0; k < 4; k++)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Improve placement of error decorators (now they would better reflect folds/wraps and lineWidgets)
- Add diff decorators for both inline/split diff views
![image](https://github.com/user-attachments/assets/5fe0edb5-1895-411d-9b16-fc5811a938c8)
![image](https://github.com/user-attachments/assets/54203fa1-c797-4b99-99c8-76e40dae1606)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

