### PR TITLE
Fix search box initialization for multi-line selection

### DIFF
--- a/src/ext/searchbox.js
+++ b/src/ext/searchbox.js
@@ -314,7 +314,7 @@ class SearchBox {
         if (this.editor.$search.$options.regExp)
             value = lang.escapeRegExp(value);
 
-        if (value)
+        if (value != undefined)
             this.searchInput.value = value;
 
         this.searchInput.focus();
@@ -434,7 +434,9 @@ exports.SearchBox = SearchBox;
  */
 exports.Search = function(editor, isReplace) {
     var sb = editor.searchBox || new SearchBox(editor);
-    sb.show(editor.session.getTextRange(), isReplace);
+    var range = editor.session.selection.getRange();
+    var value = range.isMultiLine() ? "" : editor.session.getTextRange(range);
+    sb.show(value, isReplace);
 };
 
 


### PR DESCRIPTION
*Issue #, if available:* #5791

*Description of changes:*
This fix should fix bug with too big RegExp in searchBox input value

[screen-capture (87).webm](https://github.com/user-attachments/assets/63908622-def2-4330-afb2-b0431ca0b69d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

