### PR TITLE
Add canvas context check in $updateDecorators method

### DIFF
--- a/src/ext/diff/scroll_diff_decorator.js
+++ b/src/ext/diff/scroll_diff_decorator.js
@@ -41,6 +41,9 @@ class ScrollDiffDecorator extends Decorator {
     }
 
     $updateDecorators(config) {
+        if (typeof this.canvas.getContext !== "function") {
+            return;
+        }
         super.$updateDecorators(config);
         if (this.$zones.length > 0) {
             var colors = (this.renderer.theme.isDark === true) ? this.colors.dark : this.colors.light;

--- a/src/layer/decorators.js
+++ b/src/layer/decorators.js
@@ -48,6 +48,9 @@ class Decorator {
     }
 
     $updateDecorators(config) {
+        if (typeof this.canvas.getContext !== "function") {
+            return;
+        }
         var colors = (this.renderer.theme.isDark === true) ? this.colors.dark : this.colors.light;
         this.setDimensions(config);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Guard check for environments where canvas doesn't have `getContext` method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

