### PR TITLE
Add snippet support for LaTeX and custom macro completer.

### DIFF
--- a/ace-internal.d.ts
+++ b/ace-internal.d.ts
@@ -976,7 +976,7 @@ export namespace Ace {
 
     interface Completer {
         /** Regular expressions defining valid identifier characters for completion triggers */
-        identifierRegexps?: Array<RegExp>,
+        identifierRegexps?: Array<RegExp> | ((editor: Editor) => Array<RegExp>),
 
         /** Main completion method that provides suggestions for the given context */
         getCompletions(editor: Editor,
@@ -999,7 +999,7 @@ export namespace Ace {
         /** Unique identifier for this completer */
         id?: string;
         /** Characters that trigger autocompletion when typed */
-        triggerCharacters?: string[];
+        triggerCharacters?: string[] | ((editor: Editor) => string[]);
         /** Whether to hide inline preview text */
         hideInlinePreview?: boolean;
         /** Custom insertion handler for completion items */

--- a/ace.d.ts
+++ b/ace.d.ts
@@ -783,7 +783,7 @@ declare module "ace-code" {
         type CompleterCallback = (error: any, completions: Completion[]) => void;
         interface Completer {
             /** Regular expressions defining valid identifier characters for completion triggers */
-            identifierRegexps?: Array<RegExp>;
+            identifierRegexps?: Array<RegExp> | ((editor: Editor) => Array<RegExp>);
             /** Main completion method that provides suggestions for the given context */
             getCompletions(editor: Editor, session: EditSession, position: Point, prefix: string, callback: CompleterCallback): void;
             /** Returns documentation tooltip for a completion item */
@@ -797,7 +797,7 @@ declare module "ace-code" {
             /** Unique identifier for this completer */
             id?: string;
             /** Characters that trigger autocompletion when typed */
-            triggerCharacters?: string[];
+            triggerCharacters?: string[] | ((editor: Editor) => string[]);
             /** Whether to hide inline preview text */
             hideInlinePreview?: boolean;
             /** Custom insertion handler for completion items */

--- a/src/autocomplete/util.js
+++ b/src/autocomplete/util.js
@@ -54,10 +54,18 @@ exports.getCompletionPrefix = function (editor) {
     var prefix;
     editor.completers.forEach(function(completer) {
         if (completer.identifierRegexps) {
-            completer.identifierRegexps.forEach(function(identifierRegex) {
-                if (!prefix && identifierRegex)
-                    prefix = this.retrievePrecedingIdentifier(line, pos.column, identifierRegex);
-            }.bind(this));
+            var identifierRegexps;
+            if (completer.identifierRegexps instanceof Function) {
+                identifierRegexps = completer.identifierRegexps(editor);
+            } else {
+                identifierRegexps = completer.identifierRegexps;
+            }
+            if (identifierRegexps && Array.isArray(identifierRegexps)) {
+                identifierRegexps.forEach(function(identifierRegex) {
+                    if (!prefix && identifierRegex)
+                        prefix = this.retrievePrecedingIdentifier(line, pos.column, identifierRegex);
+                }.bind(this));
+            }
         }
     }.bind(this));
     return prefix || this.retrievePrecedingIdentifier(line, pos.column);
@@ -73,8 +81,17 @@ exports.triggerAutocomplete = function (editor, previousChar) {
         ? editor.session.getPrecedingCharacter()
         : previousChar;
     return editor.completers.some((completer) => {
-        if (completer.triggerCharacters && Array.isArray(completer.triggerCharacters)) {
-            return completer.triggerCharacters.includes(previousChar);
+        if (completer.triggerCharacters) {
+            var triggerCharacters;
+            if (completer.triggerCharacters instanceof Function) {
+                triggerCharacters = completer.triggerCharacters(editor);
+            } else {
+                triggerCharacters = completer.triggerCharacters;
+            }
+
+            if (triggerCharacters && Array.isArray(triggerCharacters)) {
+                return triggerCharacters.includes(previousChar);
+            }
         }
     });
 };

--- a/src/ext/language_tools.js
+++ b/src/ext/language_tools.js
@@ -37,6 +37,16 @@ var MarkerGroup = require("../marker_group").MarkerGroup;
 var textCompleter = require("../autocomplete/text_completer");
 /**@type {import("../../ace-internal").Ace.Completer}*/
 var keyWordCompleter = {
+    identifierRegexps(editor) {
+        var completer = editor.session.$mode.completer;
+        if (completer) {
+            if (completer.identifierRegexps instanceof Function) {
+                return completer.identifierRegexps(editor);
+            } else {
+                return completer.identifierRegexps;
+            }
+        }
+    },
     getCompletions: function(editor, session, pos, prefix, callback) {
         if (session.$mode.completer) {
             return session.$mode.completer.getCompletions(editor, session, pos, prefix, callback);
@@ -49,7 +59,17 @@ var keyWordCompleter = {
         });
         callback(null, completions);
     },
-    id: "keywordCompleter"
+    id: "keywordCompleter",
+    triggerCharacters(editor) {
+        var completer = editor.session.$mode.completer;
+        if (completer) {
+            if (completer.triggerCharacters instanceof Function) {
+                return completer.triggerCharacters(editor);
+            } else {
+                return completer.triggerCharacters;
+            }
+        }
+    }
 };
 
 var transformSnippetTooltip = function(str) {

--- a/src/snippets/latex.js
+++ b/src/snippets/latex.js
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.snippetText = require("./latex.snippets");
+exports.scope = "latex";

--- a/src/snippets/latex.snippets.js
+++ b/src/snippets/latex.snippets.js
@@ -1,0 +1,1 @@
+module.exports = require("./tex.snippets");


### PR DESCRIPTION
*Issue #, if available:*
Fix [#5834](https://github.com/ajaxorg/ace/issues/5834).

*Description of changes:*
The snippets are copied from the snippets for TeX. The default keywordCompleter is unused in LaTeX mode because the highlight rules do not give a list of keywords, but color every LaTeX macro, so the completer cannot use the rules to provide completion. This macro completer is inspired from the text completer, but complete only macros (the current text completer do not consider \ to be a part of a word).

The interface of Completer is changed so that the keywordCompleter can forward the triggerCharacters and identifiersRegexps of `session.$mode.completer`. I don't know if this change is backward compatible, but I do not see any other way to achieve this goal. Maybe we can provide a better way for a mode to propose a completer than using keywordCompleter ?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts
