### PR TITLE
fix: the text completer didn't export its id

### DIFF
--- a/src/autocomplete/text_completer.js
+++ b/src/autocomplete/text_completer.js
@@ -36,6 +36,8 @@ function wordDistance(doc, pos) {
     return wordScores;
 }
 
+exports.id = "textCompleter";
+
 exports.getCompletions = function (editor, session, pos, prefix, callback) {
     var wordScore = wordDistance(session, pos);
     var wordList = Object.keys(wordScore);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The text completer in text `src/autocomplete/text_completer.js` now has an ID, which makes things easier to debug. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

