### PR TITLE
Add a safety check for undefined `line` in `getFoldWidgetRange` funct…

### DIFF
--- a/src/mode/folding/sqlserver.js
+++ b/src/mode/folding/sqlserver.js
@@ -9,27 +9,27 @@ var FoldMode = exports.FoldMode = function() {};
 oop.inherits(FoldMode, BaseFoldMode);
 
 (function() {
-    /** 
-     * Inheriting cstyle folding because it handles the region comment folding 
+    /**
+     * Inheriting cstyle folding because it handles the region comment folding
      * and special block comment folding appropriately.
-     * 
+     *
      * Cstyle's getCommentRegionBlock() contains the sql comment characters '--' for end region block.
      */
-    
+
     this.foldingStartMarker = /(\bCASE\b|\bBEGIN\b)|^\s*(\/\*)/i;
     // this.foldingStopMarker = /(\bEND\b)|^[\s\*]*(\*\/)/i;
     this.startRegionRe = /^\s*(\/\*|--)#?region\b/;
-    
+
     this.getFoldWidgetRange = function(session, foldStyle, row, forceMultiline) {
         var line = session.getLine(row);
-    
+
         if (this.startRegionRe.test(line)) return this.getCommentRegionBlock(session, line, row);
-    
+
         var match = line.match(this.foldingStartMarker);
         if (match) {
             var i = match.index;
             if (match[1]) return this.getBeginEndBlock(session, row, i, match[1]);
-    
+
             var range = session.getCommentFoldRange(row, i + match[0].length, 1);
             if (range && !range.isMultiLine()) {
                 if (forceMultiline) {
@@ -37,15 +37,15 @@ oop.inherits(FoldMode, BaseFoldMode);
                 }
                 else if (foldStyle != "all") range = null;
             }
-    
+
             return range;
         }
-    
+
         if (foldStyle === "markbegin") return;
         //TODO: add support for end folding markers
         return;
     };
-    
+
     /**
      * @returns {Range} folding block for sequence that starts with 'CASE' or 'BEGIN' and ends with 'END'
      * @param {string} matchSequence - the sequence of charaters that started the fold widget, which should remain visible when the fold widget is folded
@@ -57,7 +57,7 @@ oop.inherits(FoldMode, BaseFoldMode);
         };
         var maxRow = session.getLength();
         var line;
-    
+
         var depth = 1;
         var re = /(\bCASE\b|\bBEGIN\b)|(\bEND\b)/i;
         while (++row < maxRow) {
@@ -66,11 +66,11 @@ oop.inherits(FoldMode, BaseFoldMode);
             if (!m) continue;
             if (m[1]) depth++;
             else depth--;
-    
+
             if (!depth) break;
         }
         var endRow = row;
-        if (endRow > start.row) {
+        if (endRow > start.row && line) {
             return new Range(start.row, start.column, endRow, line.length);
         }
     };


### PR DESCRIPTION
If you start typing 'CASE', an error occurs because there is no 'END' and the line variable is undefined.

Add a safety check for undefined `line` in `getFoldWidgetRange` funct…


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

