### PR TITLE
allow changing diff view wrap option from editor too

### DIFF
--- a/src/ext/diff/diff_test.js
+++ b/src/ext/diff/diff_test.js
@@ -438,6 +438,36 @@ module.exports = {
         assert.ok(!diffView.otherEditor.destroyed);
         diffView.detach();
         assert.ok(diffView.otherEditor.destroyed);
+    },
+    "test: wrap stays in sync": function() {
+        editorA.setOption("wrap", "off");
+        diffView = new InlineDiffView({ editorA, inline: "a" });
+
+        assert.equal(diffView.editorB.getOption("wrap"), "off");
+        assert.equal(diffView.editorA.getOption("wrap"), "off");
+
+        editorA.setOption("wrap", "free");
+        assert.equal(diffView.editorB.getOption("wrap"), "free");
+        assert.equal(diffView.editorA.getOption("wrap"), "free");
+
+        diffView.detach();
+
+
+        editorB.setOption("wrap", 40);
+        diffView = new InlineDiffView({ editorB, inline: "b" });
+
+        assert.equal(diffView.editorB.getOption("wrap"), 40);
+        assert.equal(diffView.editorA.getOption("wrap"), 40);
+
+        editorB.setOption("wrap", "free");
+        assert.equal(diffView.editorB.getOption("wrap"), "free");
+        assert.equal(diffView.editorA.getOption("wrap"), "free");
+
+        editorB.setOption("wrap", 50);
+        assert.equal(diffView.editorB.getOption("wrap"), 50);
+        assert.equal(diffView.editorA.getOption("wrap"), 50);
+
+        diffView.detach();
     }
 };
 

--- a/src/ext/diff/inline_diff_view.js
+++ b/src/ext/diff/inline_diff_view.js
@@ -278,16 +278,18 @@ class InlineDiffView extends BaseDiffView {
         diffView.sessionB["_emit"]("changeFold", {data: {start: {row: 0}}});
     }
 
-    onChangeWrapLimit() {
-        this.sessionB.adjustWrapLimit(this.sessionA.$wrapLimit);
+    onChangeWrapLimit(e, session) {
+        this.otherSession.setOption("wrap", session.getOption("wrap"));
+        this.otherSession.adjustWrapLimit(session.$wrapLimit);
         this.scheduleRealign();
     }
 
     $attachSessionsEventHandlers() {
         this.$attachSessionEventHandlers(this.editorA, this.markerA);
         this.$attachSessionEventHandlers(this.editorB, this.markerB);
-        this.sessionA.on("changeWrapLimit", this.onChangeWrapLimit);
-        this.sessionA.on("changeWrapMode", this.onChangeWrapLimit);
+        var session = this.activeEditor.session;
+        session.on("changeWrapLimit", this.onChangeWrapLimit);
+        session.on("changeWrapMode", this.onChangeWrapLimit);
     }
 
     $attachSessionEventHandlers(editor, marker) {
@@ -301,8 +303,9 @@ class InlineDiffView extends BaseDiffView {
         this.$detachSessionHandlers(this.editorA, this.markerA);
         this.$detachSessionHandlers(this.editorB, this.markerB);
         this.otherSession.bgTokenizer.lines.fill(undefined);
-        this.sessionA.off("changeWrapLimit", this.onChangeWrapLimit);
-        this.sessionA.off("changeWrapMode", this.onChangeWrapLimit);
+        var session = this.activeEditor.session;
+        session.off("changeWrapLimit", this.onChangeWrapLimit);
+        session.off("changeWrapMode", this.onChangeWrapLimit);
     }
 
     $detachSessionHandlers(editor, marker) {


### PR DESCRIPTION
before this, when using `inline: "b"` mode wrapLimit was not kept in sync, and the wrap option was not synced 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [ ] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

