### PR TITLE
fixes for cloudEditor

### DIFF
--- a/src/ext/diff/inline_diff_view.js
+++ b/src/ext/diff/inline_diff_view.js
@@ -282,6 +282,9 @@ class InlineDiffView extends BaseDiffView {
         this.otherSession.setOption("wrap", session.getOption("wrap"));
         this.otherSession.adjustWrapLimit(session.$wrapLimit);
         this.scheduleRealign();
+        // todo, this is needed because editor.onChangeWrapMode
+        // calls resize(true) instead of waiting for the renderloop
+        this.activeEditor.renderer.updateFull();
     }
 
     $attachSessionsEventHandlers() {

--- a/src/layer/gutter.js
+++ b/src/layer/gutter.js
@@ -184,7 +184,7 @@ class Gutter{
         this._signal("afterRender");
         this.$updateGutterWidth(config);
         
-        if (this.$showCursorMarker)
+        if (this.$showCursorMarker && this.$highlightGutterLine)
             this.$updateCursorMarker();
     }
 
@@ -266,6 +266,7 @@ class Gutter{
         if (!this.$highlightElement) {
             this.$highlightElement = dom.createElement("div");
             this.$highlightElement.className = "ace_gutter-cursor";
+            this.$highlightElement.style.pointerEvents = "none";
             this.element.appendChild(this.$highlightElement);
         }
         var pos = session.selection.cursor;
@@ -605,6 +606,10 @@ class Gutter{
      */
     setHighlightGutterLine(highlightGutterLine) {
         this.$highlightGutterLine = highlightGutterLine;
+        if (!highlightGutterLine && this.$highlightElement) {
+            this.$highlightElement.remove();
+            this.$highlightElement = null;
+        }
     }
 
     /**


### PR DESCRIPTION
- changing wrap mode did not update rendered code of the other diff editor until user interaction
-  ace_gutter-cursor was not being removed when highlightGutterLIne was being set to false, and it was blocking mouse interaction with custom widget 