### PR TITLE
Fix: Django highlight embedded rules 

### DIFF
--- a/demo/kitchen-sink/docs/django.djt
+++ b/demo/kitchen-sink/docs/django.djt
@@ -5,3 +5,11 @@
 {% block content %}
   <h1>Hello, {{ name|default:"World" }}!</h1>
 {% endblock %}
+
+<p id="formatted" class="test-class-1 {{ variable_class }} test-class-2" data-attribute="unformatted"></p>
+
+{% comment %}
+    This content should be green.
+{% endcomment %}
+
+<p>{#line comment#}</p>

--- a/src/mode/_test/tokens_django.json
+++ b/src/mode/_test/tokens_django.json
@@ -63,4 +63,52 @@
   ["constant.language","%}"]
 ],[
    "start"
+],[
+   "start",
+  ["meta.tag.punctuation.tag-open.xml","<"],
+  ["meta.tag.tag-name.xml","p"],
+  ["text.tag-whitespace.xml"," "],
+  ["entity.other.attribute-name.xml","id"],
+  ["keyword.operator.attribute-equals.xml","="],
+  ["string.attribute-value.xml","\"formatted\""],
+  ["text.tag-whitespace.xml"," "],
+  ["entity.other.attribute-name.xml","class"],
+  ["keyword.operator.attribute-equals.xml","="],
+  ["string.attribute-value.xml","\"test-class-1 "],
+  ["constant.language","{{"],
+  ["text"," "],
+  ["variable","variable_class"],
+  ["text"," "],
+  ["constant.language","}}"],
+  ["string.attribute-value.xml"," test-class-2\""],
+  ["text.tag-whitespace.xml"," "],
+  ["entity.other.attribute-name.xml","data-attribute"],
+  ["keyword.operator.attribute-equals.xml","="],
+  ["string.attribute-value.xml","\"unformatted\""],
+  ["meta.tag.punctuation.tag-close.xml",">"],
+  ["meta.tag.punctuation.end-tag-open.xml","</"],
+  ["meta.tag.tag-name.xml","p"],
+  ["meta.tag.punctuation.tag-close.xml",">"]
+],[
+   "start"
+],[
+   "comment.block",
+  ["comment.block","{% comment %}"]
+],[
+   "comment.block",
+  ["comment.block","    This content should be green."]
+],[
+   "start",
+  ["comment.block","{% endcomment %}"]
+],[
+   "start"
+],[
+   "start",
+  ["meta.tag.punctuation.tag-open.xml","<"],
+  ["meta.tag.tag-name.xml","p"],
+  ["meta.tag.punctuation.tag-close.xml",">"],
+  ["comment.line","{#line comment#}"],
+  ["meta.tag.punctuation.end-tag-open.xml","</"],
+  ["meta.tag.tag-name.xml","p"],
+  ["meta.tag.punctuation.tag-close.xml",">"]
 ]]

--- a/src/mode/django.js
+++ b/src/mode/django.js
@@ -29,41 +29,46 @@ var DjangoHighlightRules = function(){
 oop.inherits(DjangoHighlightRules, TextHighlightRules);
 
 var DjangoHtmlHighlightRules = function() {
-    this.$rules = new HtmlHighlightRules().getRules();
-
-    for (var i in this.$rules) {
-        this.$rules[i].unshift({
+    HtmlHighlightRules.call(this);
+    var startRules = [
+        {
             token: "comment.line",
             regex: "\\{#.*?#\\}"
         }, {
             token: "comment.block",
             regex: "\\{\\%\\s*comment\\s*\\%\\}",
-            merge: true,
-            next: "django-comment"
+            push: [{
+                token: "comment.block",
+                regex: "\\{\\%\\s*endcomment\\s*\\%\\}",
+                next: "pop"
+            }, {
+                defaultToken: "comment.block"
+            }]
         }, {
             token: "constant.language",
             regex: "\\{\\{",
-            next: "django-start"
+            push: "django-start"
         }, {
             token: "constant.language",
             regex: "\\{\\%",
-            next: "django-tag"
-        });
-        this.embedRules(DjangoHighlightRules, "django-", [{
-                token: "comment.block",
-                regex: "\\{\\%\\s*endcomment\\s*\\%\\}",
-                merge: true,
-                next: "start"
-            }, {
-                token: "constant.language",
-                regex: "\\%\\}",
-                next: "start"
-            }, {
-                token: "constant.language",
-                regex: "\\}\\}",
-                next: "start"
-        }]);
-    }
+            push: "django-tag"
+        }
+    ];
+    var endRules = [
+        {
+            token: "constant.language",
+            regex: "\\%\\}",
+            next: "pop"
+        }, {
+            token: "constant.language",
+            regex: "\\}\\}",
+            next: "pop"
+        }
+    ];
+    for (var key in this.$rules)
+        this.$rules[key].unshift.apply(this.$rules[key], startRules);
+    this.embedRules(DjangoHighlightRules, "django-", endRules, ["start"]);
+    this.normalizeRules();
 };
 
 oop.inherits(DjangoHtmlHighlightRules, HtmlHighlightRules);


### PR DESCRIPTION
*Issue #, if available:* #5898

*Description of changes:*
Solution is provided by @jsulgrove in #5898

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

