### PR TITLE
Fix: missing documents for modes

### DIFF
--- a/demo/kitchen-sink/docs/jsoniq.jq
+++ b/demo/kitchen-sink/docs/jsoniq.jq
@@ -1,1 +1,100 @@
-TODO
+(: Single line comment :)
+
+(:
+ : Multi-line comment block
+ : JSONiq uses XQuery-style comments
+ :)
+
+let $string := "Hello, JSONiq!"
+let $number := 42
+let $decimal := 3.14159
+let $scientific := 1.5e10
+let $boolean_true := true
+
+let $person := {
+    "name": "John Doe",
+    "age": 30,
+    "email": "john@example.com",
+    "active": true,
+    "balance": 1250.50,
+    "metadata": null
+}
+
+let $result :=
+    for $i in 1 to 10
+    let $squared := $i * $i
+    where $i mod 2 eq 0
+    order by $squared descending
+    return { "number": $i, "squared": $squared }
+
+let $admins :=
+    for $user in $data.users[]
+    where $user.roles[] = "admin"
+    order by $user.name ascending
+    return $user.name
+
+(: Conditional Expressions :)
+let $status :=
+    if ($person.age >= 18)
+    then "adult"
+    else "minor"
+
+let $tier :=
+    if ($person.balance >= 1000) then "gold"
+    else if ($person.balance >= 500) then "silver"
+    else "bronze"
+
+(: Quantified Expressions :)
+let $has_admin :=
+    some $user in $data.users[]
+    satisfies $user.roles[] = "admin"
+
+let $all_active :=
+    every $user in $data.users[]
+    satisfies exists($user.name)
+
+(: Type Expressions :)
+let $typed_value := 42 cast as string
+let $check := $person.name instance of string
+let $treated := $number treat as integer
+
+let $eq := 5 eq 5
+let $ne := 5 ne 3
+let $lt := 3 lt 5
+let $le := 3 le 5
+let $gt := 5 gt 3
+let $ge := 5 ge 3
+
+let $concat := "Hello" || " " || "World"
+let $contains := contains("JSONiq", "JSON")
+let $substring := substring("Hello World", 1, 5)
+let $upper := upper-case("hello")
+let $lower := lower-case("HELLO")
+let $length := string-length("JSONiq")
+
+(: User-Defined Function :)
+declare function local:greet($name as string) as string {
+    "Hello, " || $name || "!"
+};
+
+declare function local:factorial($n as integer) as integer {
+    if ($n le 1)
+    then 1
+    else $n * local:factorial($n - 1)
+};
+
+declare function local:filter-by-age($users, $min-age as integer) {
+    for $user in $users[]
+    where $user.age >= $min-age
+    return $user
+};
+
+return {
+    "greeting": local:greet("World"),
+    "factorial_5": local:factorial(5),
+    "admins": $admins,
+    "status": $status,
+    "tier": $tier,
+    "has_admin": $has_admin,
+    "grouped": $grouped
+}

--- a/demo/kitchen-sink/docs/mysql.mysql
+++ b/demo/kitchen-sink/docs/mysql.mysql
@@ -1,1 +1,161 @@
-TODO
+-- Single line comment
+
+/*
+ * Multi-line comment block
+ *
+ */
+
+# Hash-style comment (MySQL specific)
+
+-- Database and Table Operations
+CREATE DATABASE IF NOT EXISTS demo_db
+    CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+
+USE demo_db;
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    email VARCHAR(100) NOT NULL,
+    password_hash CHAR(64),
+    balance DECIMAL(10, 2) DEFAULT 0.00,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME ON UPDATE CURRENT_TIMESTAMP,
+    profile_data JSON,
+    INDEX idx_email (email),
+    FULLTEXT INDEX idx_username (username)
+) ENGINE=InnoDB;
+
+-- Insert Statements
+INSERT INTO users (username, email, password_hash)
+VALUES
+    ('john_doe', 'john@example.com', SHA2('password123', 256)),
+    ('jane_smith', 'jane@example.com', SHA2('secure456', 256));
+
+-- Select with Various Clauses
+SELECT
+    u.id,
+    u.username,
+    CONCAT(UPPER(LEFT(u.username, 1)), LOWER(SUBSTRING(u.username, 2))) AS formatted_name,
+    COALESCE(u.balance, 0) AS balance,
+    DATE_FORMAT(u.created_at, '%Y-%m-%d') AS join_date
+FROM users u
+WHERE u.is_active = TRUE
+    AND u.created_at >= '2024-01-01'
+    AND u.email LIKE '%@example.com'
+    AND u.id BETWEEN 1 AND 1000
+    AND u.username IN ('john_doe', 'jane_smith')
+    AND u.profile_data IS NOT NULL
+GROUP BY u.id
+HAVING COUNT(*) > 0
+ORDER BY u.created_at DESC
+LIMIT 10 OFFSET 0;
+
+-- Update Statement
+UPDATE users
+SET balance = balance + 100.50,
+    updated_at = NOW()
+WHERE username = 'john_doe';
+
+-- Delete Statement
+DELETE FROM users
+WHERE is_active = FALSE
+    AND created_at < DATE_SUB(NOW(), INTERVAL 1 YEAR);
+
+-- Join Example
+SELECT
+    u.username,
+    o.order_id,
+    o.total_amount
+FROM users u
+INNER JOIN orders o ON u.id = o.user_id
+LEFT JOIN order_items oi ON o.order_id = oi.order_id
+WHERE o.status != 'cancelled';
+
+-- Subquery and EXISTS
+SELECT * FROM users
+WHERE EXISTS (
+    SELECT 1 FROM orders
+    WHERE orders.user_id = users.id
+    AND orders.total_amount > 500
+);
+
+-- CASE Expression
+SELECT
+    username,
+    CASE
+        WHEN balance >= 1000 THEN 'Premium'
+        WHEN balance >= 100 THEN 'Standard'
+        ELSE 'Basic'
+    END AS tier
+FROM users;
+
+-- Window Functions
+SELECT
+    username,
+    balance,
+    ROW_NUMBER() OVER (ORDER BY balance DESC) AS rank,
+    SUM(balance) OVER (PARTITION BY is_active) AS total_by_status
+FROM users;
+
+-- Variables
+SET @user_count = (SELECT COUNT(*) FROM users);
+SET @tax_rate = 0.08;
+
+SELECT @user_count AS total_users;
+
+-- Stored Procedure
+DELIMITER //
+CREATE PROCEDURE GetUserByEmail(IN user_email VARCHAR(100))
+BEGIN
+    DECLARE user_exists INT DEFAULT 0;
+
+    SELECT COUNT(*) INTO user_exists
+    FROM users WHERE email = user_email;
+
+    IF user_exists > 0 THEN
+        SELECT * FROM users WHERE email = user_email;
+    ELSE
+        SELECT 'User not found' AS message;
+    END IF;
+END //
+DELIMITER ;
+
+-- Function
+CREATE FUNCTION CalculateDiscount(price DECIMAL(10,2), discount_pct INT)
+RETURNS DECIMAL(10,2)
+DETERMINISTIC
+BEGIN
+    RETURN price * (1 - discount_pct / 100);
+END;
+
+-- Trigger
+CREATE TRIGGER before_user_update
+BEFORE UPDATE ON users
+FOR EACH ROW
+BEGIN
+    SET NEW.updated_at = NOW();
+END;
+
+-- Transaction
+START TRANSACTION;
+    UPDATE users SET balance = balance - 50 WHERE id = 1;
+    UPDATE users SET balance = balance + 50 WHERE id = 2;
+COMMIT;
+
+-- Common Table Expression (CTE)
+WITH active_users AS (
+    SELECT * FROM users WHERE is_active = TRUE
+)
+SELECT * FROM active_users WHERE balance > 100;
+
+-- EXPLAIN for query analysis
+EXPLAIN SELECT * FROM users WHERE email = 'test@example.com';
+
+-- Numeric literals
+SELECT 42, 3.14159, 1e10, 0x1A2B, b'101010';
+
+-- String literals
+SELECT 'single quotes', "double quotes", `backtick identifiers`;

--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -162,7 +162,6 @@ var supportedModes = {
     Liquid:      ["liquid"],
     Lisp:        ["lisp"],
     LiveScript:  ["ls"],
-    Log:         ["log"],
     LogiQL:      ["logic|lql"],
     Logtalk:     ["lgt"],
     LSL:         ["lsl"],

--- a/src/mode/_test/tokens_mysql.json
+++ b/src/mode/_test/tokens_mysql.json
@@ -1,4 +1,1364 @@
 [[
    "start",
-  ["identifier","TODO"]
+  ["comment","-- Single line comment"]
+],[
+   "start"
+],[
+   "comment",
+  ["comment","/*"]
+],[
+   "comment",
+  ["comment"," * Multi-line comment block"]
+],[
+   "comment",
+  ["comment"," *"]
+],[
+   "start",
+  ["comment"," */"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","# Hash-style comment (MySQL specific)"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Database and Table Operations"]
+],[
+   "start",
+  ["keyword","CREATE"],
+  ["text"," "],
+  ["keyword","DATABASE"],
+  ["text"," "],
+  ["keyword","IF"],
+  ["text"," "],
+  ["keyword","NOT"],
+  ["text"," "],
+  ["keyword","EXISTS"],
+  ["text"," "],
+  ["identifier","demo_db"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","CHARACTER"],
+  ["text"," "],
+  ["keyword","SET"],
+  ["text"," "],
+  ["identifier","utf8mb4"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","COLLATE"],
+  ["text"," "],
+  ["identifier","utf8mb4_unicode_ci"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["keyword","USE"],
+  ["text"," "],
+  ["identifier","demo_db"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["keyword","CREATE"],
+  ["text"," "],
+  ["keyword","TABLE"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["paren.lparen","("]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","id"],
+  ["text"," "],
+  ["storage.type","INT"],
+  ["text"," "],
+  ["keyword","AUTO_INCREMENT"],
+  ["text"," "],
+  ["keyword","PRIMARY"],
+  ["text"," "],
+  ["keyword","KEY"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","username"],
+  ["text"," "],
+  ["storage.type","VARCHAR"],
+  ["paren.lparen","("],
+  ["constant.numeric","50"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","NOT"],
+  ["text"," "],
+  ["constant","NULL"],
+  ["text"," "],
+  ["keyword","UNIQUE"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","email"],
+  ["text"," "],
+  ["storage.type","VARCHAR"],
+  ["paren.lparen","("],
+  ["constant.numeric","100"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","NOT"],
+  ["text"," "],
+  ["constant","NULL"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","password_hash"],
+  ["text"," "],
+  ["storage.type","CHAR"],
+  ["paren.lparen","("],
+  ["constant.numeric","64"],
+  ["paren.rparen",")"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["storage.type","DECIMAL"],
+  ["paren.lparen","("],
+  ["constant.numeric","10"],
+  ["text",", "],
+  ["constant.numeric","2"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","DEFAULT"],
+  ["text"," "],
+  ["constant.numeric","0.00"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","is_active"],
+  ["text"," "],
+  ["storage.type","BOOLEAN"],
+  ["text"," "],
+  ["keyword","DEFAULT"],
+  ["text"," "],
+  ["constant","TRUE"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","created_at"],
+  ["text"," "],
+  ["storage.type","TIMESTAMP"],
+  ["text"," "],
+  ["keyword","DEFAULT"],
+  ["text"," "],
+  ["keyword","CURRENT_TIMESTAMP"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","updated_at"],
+  ["text"," "],
+  ["storage.type","DATETIME"],
+  ["text"," "],
+  ["keyword","ON"],
+  ["text"," "],
+  ["keyword","UPDATE"],
+  ["text"," "],
+  ["keyword","CURRENT_TIMESTAMP"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","profile_data"],
+  ["text"," "],
+  ["identifier","JSON"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","INDEX"],
+  ["text"," "],
+  ["identifier","idx_email"],
+  ["text"," "],
+  ["paren.lparen","("],
+  ["identifier","email"],
+  ["paren.rparen",")"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","FULLTEXT"],
+  ["text"," "],
+  ["keyword","INDEX"],
+  ["text"," "],
+  ["identifier","idx_username"],
+  ["text"," "],
+  ["paren.lparen","("],
+  ["identifier","username"],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","ENGINE"],
+  ["keyword.operator","="],
+  ["keyword","InnoDB"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Insert Statements"]
+],[
+   "start",
+  ["keyword","INSERT"],
+  ["text"," "],
+  ["keyword","INTO"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["paren.lparen","("],
+  ["identifier","username"],
+  ["text",", "],
+  ["identifier","email"],
+  ["text",", "],
+  ["identifier","password_hash"],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["keyword","VALUES"]
+],[
+   "start",
+  ["text","    "],
+  ["paren.lparen","("],
+  ["string.start","'"],
+  ["string","john_doe"],
+  ["string.end","'"],
+  ["text",", "],
+  ["string.start","'"],
+  ["string","john@example.com"],
+  ["string.end","'"],
+  ["text",", "],
+  ["identifier","SHA2"],
+  ["paren.lparen","("],
+  ["string.start","'"],
+  ["string","password123"],
+  ["string.end","'"],
+  ["text",", "],
+  ["constant.numeric","256"],
+  ["paren.rparen","))"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["paren.lparen","("],
+  ["string.start","'"],
+  ["string","jane_smith"],
+  ["string.end","'"],
+  ["text",", "],
+  ["string.start","'"],
+  ["string","jane@example.com"],
+  ["string.end","'"],
+  ["text",", "],
+  ["identifier","SHA2"],
+  ["paren.lparen","("],
+  ["string.start","'"],
+  ["string","secure456"],
+  ["string.end","'"],
+  ["text",", "],
+  ["constant.numeric","256"],
+  ["paren.rparen","))"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Select with Various Clauses"]
+],[
+   "start",
+  ["keyword","SELECT"]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","id"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","username"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["support.function","CONCAT"],
+  ["paren.lparen","("],
+  ["support.function","UPPER"],
+  ["paren.lparen","("],
+  ["keyword","LEFT"],
+  ["paren.lparen","("],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","username"],
+  ["text",", "],
+  ["constant.numeric","1"],
+  ["paren.rparen","))"],
+  ["text",", "],
+  ["support.function","LOWER"],
+  ["paren.lparen","("],
+  ["support.function","SUBSTRING"],
+  ["paren.lparen","("],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","username"],
+  ["text",", "],
+  ["constant.numeric","2"],
+  ["paren.rparen",")))"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["identifier","formatted_name"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["support.function","COALESCE"],
+  ["paren.lparen","("],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","balance"],
+  ["text",", "],
+  ["constant.numeric","0"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["support.function","DATE_FORMAT"],
+  ["paren.lparen","("],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","created_at"],
+  ["text",", "],
+  ["string.start","'"],
+  ["string","%Y-%m-%d"],
+  ["string.end","'"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["identifier","join_date"]
+],[
+   "start",
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["identifier","u"]
+],[
+   "start",
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","is_active"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant","TRUE"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","AND"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","created_at"],
+  ["text"," "],
+  ["keyword.operator",">="],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","2024-01-01"],
+  ["string.end","'"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","AND"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","email"],
+  ["text"," "],
+  ["keyword","LIKE"],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","%@example.com"],
+  ["string.end","'"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","AND"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","id"],
+  ["text"," "],
+  ["keyword","BETWEEN"],
+  ["text"," "],
+  ["constant.numeric","1"],
+  ["text"," "],
+  ["keyword","AND"],
+  ["text"," "],
+  ["constant.numeric","1000"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","AND"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","username"],
+  ["text"," "],
+  ["keyword","IN"],
+  ["text"," "],
+  ["paren.lparen","("],
+  ["string.start","'"],
+  ["string","john_doe"],
+  ["string.end","'"],
+  ["text",", "],
+  ["string.start","'"],
+  ["string","jane_smith"],
+  ["string.end","'"],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","AND"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","profile_data"],
+  ["text"," "],
+  ["keyword","IS"],
+  ["text"," "],
+  ["keyword","NOT"],
+  ["text"," "],
+  ["constant","NULL"]
+],[
+   "start",
+  ["keyword","GROUP"],
+  ["text"," "],
+  ["keyword","BY"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","id"]
+],[
+   "start",
+  ["keyword","HAVING"],
+  ["text"," "],
+  ["keyword","COUNT"],
+  ["paren.lparen","("],
+  ["text","*"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword.operator",">"],
+  ["text"," "],
+  ["constant.numeric","0"]
+],[
+   "start",
+  ["keyword","ORDER"],
+  ["text"," "],
+  ["keyword","BY"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","created_at"],
+  ["text"," "],
+  ["keyword","DESC"]
+],[
+   "start",
+  ["keyword","LIMIT"],
+  ["text"," "],
+  ["constant.numeric","10"],
+  ["text"," "],
+  ["keyword","OFFSET"],
+  ["text"," "],
+  ["constant.numeric","0"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Update Statement"]
+],[
+   "start",
+  ["keyword","UPDATE"],
+  ["text"," "],
+  ["identifier","users"]
+],[
+   "start",
+  ["keyword","SET"],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator","+"],
+  ["text"," "],
+  ["constant.numeric","100.50"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","updated_at"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["support.function","NOW"],
+  ["paren.lparen","("],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","username"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","john_doe"],
+  ["string.end","'"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Delete Statement"]
+],[
+   "start",
+  ["keyword","DELETE"],
+  ["text"," "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"]
+],[
+   "start",
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","is_active"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant","FALSE"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","AND"],
+  ["text"," "],
+  ["identifier","created_at"],
+  ["text"," "],
+  ["keyword.operator","<"],
+  ["text"," "],
+  ["support.function","DATE_SUB"],
+  ["paren.lparen","("],
+  ["support.function","NOW"],
+  ["paren.lparen","("],
+  ["paren.rparen",")"],
+  ["text",", "],
+  ["keyword","INTERVAL"],
+  ["text"," "],
+  ["constant.numeric","1"],
+  ["text"," "],
+  ["storage.type","YEAR"],
+  ["paren.rparen",")"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Join Example"]
+],[
+   "start",
+  ["keyword","SELECT"]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","username"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","o"],
+  ["text","."],
+  ["identifier","order_id"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","o"],
+  ["text","."],
+  ["identifier","total_amount"]
+],[
+   "start",
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["identifier","u"]
+],[
+   "start",
+  ["keyword","INNER"],
+  ["text"," "],
+  ["keyword","JOIN"],
+  ["text"," "],
+  ["identifier","orders"],
+  ["text"," "],
+  ["identifier","o"],
+  ["text"," "],
+  ["keyword","ON"],
+  ["text"," "],
+  ["identifier","u"],
+  ["text","."],
+  ["identifier","id"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["identifier","o"],
+  ["text","."],
+  ["identifier","user_id"]
+],[
+   "start",
+  ["keyword","LEFT"],
+  ["text"," "],
+  ["keyword","JOIN"],
+  ["text"," "],
+  ["identifier","order_items"],
+  ["text"," "],
+  ["identifier","oi"],
+  ["text"," "],
+  ["keyword","ON"],
+  ["text"," "],
+  ["identifier","o"],
+  ["text","."],
+  ["identifier","order_id"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["identifier","oi"],
+  ["text","."],
+  ["identifier","order_id"]
+],[
+   "start",
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","o"],
+  ["text","."],
+  ["variable.language","status"],
+  ["text"," "],
+  ["keyword.operator","!="],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","cancelled"],
+  ["string.end","'"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Subquery and EXISTS"]
+],[
+   "start",
+  ["keyword","SELECT"],
+  ["text"," * "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"]
+],[
+   "start",
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["keyword","EXISTS"],
+  ["text"," "],
+  ["paren.lparen","("]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","SELECT"],
+  ["text"," "],
+  ["constant.numeric","1"],
+  ["text"," "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","orders"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","orders"],
+  ["text","."],
+  ["identifier","user_id"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["identifier","users"],
+  ["text","."],
+  ["identifier","id"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","AND"],
+  ["text"," "],
+  ["identifier","orders"],
+  ["text","."],
+  ["identifier","total_amount"],
+  ["text"," "],
+  ["keyword.operator",">"],
+  ["text"," "],
+  ["constant.numeric","500"]
+],[
+   "start",
+  ["paren.rparen",")"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- CASE Expression"]
+],[
+   "start",
+  ["keyword","SELECT"]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","username"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","CASE"]
+],[
+   "start",
+  ["text","        "],
+  ["keyword","WHEN"],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator",">="],
+  ["text"," "],
+  ["constant.numeric","1000"],
+  ["text"," "],
+  ["keyword","THEN"],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","Premium"],
+  ["string.end","'"]
+],[
+   "start",
+  ["text","        "],
+  ["keyword","WHEN"],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator",">="],
+  ["text"," "],
+  ["constant.numeric","100"],
+  ["text"," "],
+  ["keyword","THEN"],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","Standard"],
+  ["string.end","'"]
+],[
+   "start",
+  ["text","        "],
+  ["keyword","ELSE"],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","Basic"],
+  ["string.end","'"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","END"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["identifier","tier"]
+],[
+   "start",
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Window Functions"]
+],[
+   "start",
+  ["keyword","SELECT"]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","username"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","balance"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","ROW_NUMBER"],
+  ["paren.lparen","("],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["identifier","OVER"],
+  ["text"," "],
+  ["paren.lparen","("],
+  ["keyword","ORDER"],
+  ["text"," "],
+  ["keyword","BY"],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword","DESC"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["support.function","rank"],
+  ["text",","]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","SUM"],
+  ["paren.lparen","("],
+  ["identifier","balance"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["identifier","OVER"],
+  ["text"," "],
+  ["paren.lparen","("],
+  ["keyword","PARTITION"],
+  ["text"," "],
+  ["keyword","BY"],
+  ["text"," "],
+  ["identifier","is_active"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["identifier","total_by_status"]
+],[
+   "start",
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Variables"]
+],[
+   "start",
+  ["keyword","SET"],
+  ["text"," "],
+  ["constant.class","@user_count"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["paren.lparen","("],
+  ["keyword","SELECT"],
+  ["text"," "],
+  ["keyword","COUNT"],
+  ["paren.lparen","("],
+  ["text","*"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["paren.rparen",")"],
+  ["text",";"]
+],[
+   "start",
+  ["keyword","SET"],
+  ["text"," "],
+  ["constant.class","@tax_rate"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant.numeric","0.08"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["keyword","SELECT"],
+  ["text"," "],
+  ["constant.class","@user_count"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["identifier","total_users"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Stored Procedure"]
+],[
+   "start",
+  ["keyword","DELIMITER"],
+  ["text"," "],
+  ["keyword.operator","//"]
+],[
+   "start",
+  ["keyword","CREATE"],
+  ["text"," "],
+  ["keyword","PROCEDURE"],
+  ["text"," "],
+  ["identifier","GetUserByEmail"],
+  ["paren.lparen","("],
+  ["keyword","IN"],
+  ["text"," "],
+  ["identifier","user_email"],
+  ["text"," "],
+  ["storage.type","VARCHAR"],
+  ["paren.lparen","("],
+  ["constant.numeric","100"],
+  ["paren.rparen","))"]
+],[
+   "start",
+  ["keyword","BEGIN"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","DECLARE"],
+  ["text"," "],
+  ["identifier","user_exists"],
+  ["text"," "],
+  ["storage.type","INT"],
+  ["text"," "],
+  ["keyword","DEFAULT"],
+  ["text"," "],
+  ["constant.numeric","0"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["text","    "],
+  ["keyword","SELECT"],
+  ["text"," "],
+  ["keyword","COUNT"],
+  ["paren.lparen","("],
+  ["text","*"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword","INTO"],
+  ["text"," "],
+  ["identifier","user_exists"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","email"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["identifier","user_email"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["text","    "],
+  ["keyword","IF"],
+  ["text"," "],
+  ["identifier","user_exists"],
+  ["text"," "],
+  ["keyword.operator",">"],
+  ["text"," "],
+  ["constant.numeric","0"],
+  ["text"," "],
+  ["keyword","THEN"]
+],[
+   "start",
+  ["text","        "],
+  ["keyword","SELECT"],
+  ["text"," * "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","email"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["identifier","user_email"],
+  ["text",";"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","ELSE"]
+],[
+   "start",
+  ["text","        "],
+  ["keyword","SELECT"],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","User not found"],
+  ["string.end","'"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["identifier","message"],
+  ["text",";"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","END"],
+  ["text"," "],
+  ["keyword","IF"],
+  ["text",";"]
+],[
+   "start",
+  ["keyword","END"],
+  ["text"," "],
+  ["keyword.operator","//"]
+],[
+   "start",
+  ["keyword","DELIMITER"],
+  ["text"," ;"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Function"]
+],[
+   "start",
+  ["keyword","CREATE"],
+  ["text"," "],
+  ["keyword","FUNCTION"],
+  ["text"," "],
+  ["identifier","CalculateDiscount"],
+  ["paren.lparen","("],
+  ["identifier","price"],
+  ["text"," "],
+  ["storage.type","DECIMAL"],
+  ["paren.lparen","("],
+  ["constant.numeric","10"],
+  ["text",","],
+  ["constant.numeric","2"],
+  ["paren.rparen",")"],
+  ["text",", "],
+  ["identifier","discount_pct"],
+  ["text"," "],
+  ["storage.type","INT"],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["keyword","RETURNS"],
+  ["text"," "],
+  ["storage.type","DECIMAL"],
+  ["paren.lparen","("],
+  ["constant.numeric","10"],
+  ["text",","],
+  ["constant.numeric","2"],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["keyword","DETERMINISTIC"]
+],[
+   "start",
+  ["keyword","BEGIN"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","RETURN"],
+  ["text"," "],
+  ["identifier","price"],
+  ["text"," * "],
+  ["paren.lparen","("],
+  ["constant.numeric","1"],
+  ["text"," "],
+  ["keyword.operator","-"],
+  ["text"," "],
+  ["identifier","discount_pct"],
+  ["text"," "],
+  ["keyword.operator","/"],
+  ["text"," "],
+  ["constant.numeric","100"],
+  ["paren.rparen",")"],
+  ["text",";"]
+],[
+   "start",
+  ["keyword","END"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Trigger"]
+],[
+   "start",
+  ["keyword","CREATE"],
+  ["text"," "],
+  ["keyword","TRIGGER"],
+  ["text"," "],
+  ["identifier","before_user_update"]
+],[
+   "start",
+  ["keyword","BEFORE"],
+  ["text"," "],
+  ["keyword","UPDATE"],
+  ["text"," "],
+  ["keyword","ON"],
+  ["text"," "],
+  ["identifier","users"]
+],[
+   "start",
+  ["keyword","FOR"],
+  ["text"," "],
+  ["keyword","EACH"],
+  ["text"," "],
+  ["keyword","ROW"]
+],[
+   "start",
+  ["keyword","BEGIN"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","SET"],
+  ["text"," "],
+  ["identifier","NEW"],
+  ["text","."],
+  ["identifier","updated_at"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["support.function","NOW"],
+  ["paren.lparen","("],
+  ["paren.rparen",")"],
+  ["text",";"]
+],[
+   "start",
+  ["keyword","END"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Transaction"]
+],[
+   "start",
+  ["keyword","START"],
+  ["text"," "],
+  ["keyword","TRANSACTION"],
+  ["text",";"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","UPDATE"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["keyword","SET"],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator","-"],
+  ["text"," "],
+  ["constant.numeric","50"],
+  ["text"," "],
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","id"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant.numeric","1"],
+  ["text",";"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","UPDATE"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["keyword","SET"],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator","+"],
+  ["text"," "],
+  ["constant.numeric","50"],
+  ["text"," "],
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","id"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant.numeric","2"],
+  ["text",";"]
+],[
+   "start",
+  ["keyword","COMMIT"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Common Table Expression (CTE)"]
+],[
+   "start",
+  ["keyword","WITH"],
+  ["text"," "],
+  ["identifier","active_users"],
+  ["text"," "],
+  ["keyword","AS"],
+  ["text"," "],
+  ["paren.lparen","("]
+],[
+   "start",
+  ["text","    "],
+  ["keyword","SELECT"],
+  ["text"," * "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","is_active"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["constant","TRUE"]
+],[
+   "start",
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["keyword","SELECT"],
+  ["text"," * "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","active_users"],
+  ["text"," "],
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","balance"],
+  ["text"," "],
+  ["keyword.operator",">"],
+  ["text"," "],
+  ["constant.numeric","100"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- EXPLAIN for query analysis"]
+],[
+   "start",
+  ["keyword","EXPLAIN"],
+  ["text"," "],
+  ["keyword","SELECT"],
+  ["text"," * "],
+  ["keyword","FROM"],
+  ["text"," "],
+  ["identifier","users"],
+  ["text"," "],
+  ["keyword","WHERE"],
+  ["text"," "],
+  ["identifier","email"],
+  ["text"," "],
+  ["keyword.operator","="],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","test@example.com"],
+  ["string.end","'"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- Numeric literals"]
+],[
+   "start",
+  ["keyword","SELECT"],
+  ["text"," "],
+  ["constant.numeric","42"],
+  ["text",", "],
+  ["constant.numeric","3.14159"],
+  ["text",", "],
+  ["constant.numeric","1e10"],
+  ["text",", "],
+  ["constant.numeric","0x1A2B"],
+  ["text",", "],
+  ["constant.numeric","b'101010'"],
+  ["text",";"]
+],[
+   "start"
+],[
+   "start",
+  ["comment","-- String literals"]
+],[
+   "start",
+  ["keyword","SELECT"],
+  ["text"," "],
+  ["string.start","'"],
+  ["string","single quotes"],
+  ["string.end","'"],
+  ["text",", "],
+  ["string.start","\""],
+  ["string","double quotes"],
+  ["string.end","\""],
+  ["text",", "],
+  ["constant.buildin","`backtick identifiers`"],
+  ["text",";"]
 ]]


### PR DESCRIPTION
*Issue #, if available:* #5895

*Description of changes:*
- Remove non-existing "log" mode from modelist
- Add examples for MySQL and JSONiq

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

