### PR TITLE
Handle editor unregistration when languageProvider is unset

### DIFF
--- a/demo/kitchen-sink/demo.js
+++ b/demo/kitchen-sink/demo.js
@@ -74,7 +74,9 @@ require("ace/config").defineOptions(Editor.prototype, "editor", {
             else if (val) {
                 window.languageProvider.registerEditor(this);
             } else {
-                // todo unregister
+                if (window.languageProvider) {
+                    window.languageProvider.unregisterEditor(editor, true);
+                }
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts



[Open kitchen-sink @ 59d5e5cee213dcc3302f7c03e376650248df6bcc](https://raw.githack.com/mkslanc/ace/59d5e5cee213dcc3302f7c03e376650248df6bcc/kitchen-sink.html)