### PR TITLE
prevent browsers from treating scrollbars as focusable

### DIFF
--- a/src/scrollbar.js
+++ b/src/scrollbar.js
@@ -21,6 +21,7 @@ class Scrollbar {
     constructor(parent, classSuffix) {
         this.element = dom.createElement("div");
         this.element.className = "ace_scrollbar ace_scrollbar" + classSuffix;
+        this.element.tabIndex = -1;
 
         this.inner = dom.createElement("div");
         this.inner.className = "ace_scrollbar-inner";


### PR DESCRIPTION
chrome recently made scrollable elements keyboard focusable https://issues.chromium.org/issues/337158524 which causes tab in our keyboard accessibility mode to focus editor scrollbar, which is not the behavior that users want, so this sets tabIndex -1 explicitly  

[Open kitchen-sink @ 4f874438fcac3add1a9b1d0885702621fd351ea7](https://raw.githack.com/ajaxorg/ace/4f874438fcac3add1a9b1d0885702621fd351ea7/kitchen-sink.html)