### PR TITLE
Add GROQ highlighting model

### DIFF
--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -660,6 +660,14 @@ declare module "ace-code/src/mode/groovy" {
     export const Mode: new () => import("ace-code").Ace.SyntaxMode;
 }
 
+declare module "ace-code/src/mode/groq_highlight_rules" {
+    export const GroqHighlightRules: new () => import("ace-code").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/groq" {
+    export const Mode: new () => import("ace-code").Ace.SyntaxMode;
+}
+
 declare module "ace-code/src/mode/haml_highlight_rules" {
     export const HamlHighlightRules: new () => import("ace-code").Ace.HighlightRules;
 }

--- a/demo/kitchen-sink/docs/groq.groq
+++ b/demo/kitchen-sink/docs/groq.groq
@@ -1,0 +1,67 @@
+// Fetch all published articles, ordered by date
+*[_type == "article" && !(_id in path("drafts.**"))] | order(publishedAt desc) {
+  _id,
+  title,
+  "slug": slug.current,
+  publishedAt,
+  "authorName": author->name,
+  "categoryTitles": categories[]->title,
+  body[]{
+    ...,
+    _type == "image" => {
+      "url": asset->url
+    }
+  }
+}
+
+// Count documents by type
+{
+  "articles": count(*[_type == "article"]),
+  "authors": count(*[_type == "author"]),
+  "total": count(*[])
+}
+
+// Text search with scoring and boosting
+*[_type == "article" && title match "serverless"] | score(boost(title match "serverless", 3), body match "serverless") | order(_score desc) [0..9] {
+  title,
+  _score,
+  "excerpt": string::split(pt::text(body), ".")[0]
+}
+
+// Using parameters
+*[_type == $type && defined(publishedAt)] {
+  ...,
+  "relatedCount": count(*[_type == ^._type && references(^._id)])
+}
+
+// Conditional projections with select
+*[_type == "product"] {
+  title,
+  "label": select(
+    price < 10 => "budget",
+    price >= 10 && price < 100 => "mid-range",
+    price >= 100 => "premium"
+  ),
+  "discount": round(price * 0.85, 2)
+}
+
+// Boolean, null, and numeric literals
+*[_type == "post" && featured == true && deletedAt == null] {
+  title,
+  "views": coalesce(viewCount, 0),
+  "rating": round(score * 100) / 100
+}
+
+// Date filtering
+*[_type == "event" && dateTime(startDate) > dateTime(now()) - 60 * 60 * 24 * 7] | order(startDate asc)
+
+// String functions
+*[_type == "author"] {
+  "displayName": upper(name[0]) + lower(name[1..])
+}
+
+// Dereference and identity
+*[_type == "comment" && post->author._ref == identity()] {
+  text,
+  "postTitle": post->title
+}

--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -130,6 +130,7 @@ var supportedModes = {
     Gobstones:   ["gbs"],
     golang:      ["go"],
     GraphQLSchema: ["gql"],
+    GROQ:        ["groq"],
     Groovy:      ["groovy"],
     HAML:        ["haml"],
     Handlebars:  ["hbs|handlebars|tpl|mustache"],

--- a/src/mode/_test/tokens_groq.json
+++ b/src/mode/_test/tokens_groq.json
@@ -1,0 +1,655 @@
+[[
+   "start",
+  ["comment.line","// Fetch all published articles, ordered by date"]
+],[
+   "start",
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"article\""],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["keyword.operator","!"],
+  ["paren.lparen","("],
+  ["identifier","_id"],
+  ["text"," "],
+  ["keyword.control","in"],
+  ["text"," "],
+  ["support.function","path"],
+  ["paren.lparen","("],
+  ["string.quoted.double","\"drafts.**\""],
+  ["paren.rparen","))]"],
+  ["text"," "],
+  ["keyword.operator.pipe","|"],
+  ["text"," "],
+  ["support.function","order"],
+  ["paren.lparen","("],
+  ["identifier","publishedAt"],
+  ["text"," "],
+  ["keyword.control","desc"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","_id"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","title"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"slug\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["identifier","slug"],
+  ["punctuation.accessor","."],
+  ["identifier","current"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","publishedAt"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"authorName\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["identifier","author"],
+  ["keyword.operator.dereference","->"],
+  ["identifier","name"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"categoryTitles\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["identifier","categories"],
+  ["paren.lparen","["],
+  ["paren.rparen","]"],
+  ["keyword.operator.dereference","->"],
+  ["identifier","title"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","body"],
+  ["paren.lparen","["],
+  ["paren.rparen","]"],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","    "],
+  ["keyword.operator.spread","..."],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"image\""],
+  ["text"," "],
+  ["keyword.operator.arrow","=>"],
+  ["text"," "],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","      "],
+  ["string.quoted.double","\"url\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["identifier","asset"],
+  ["keyword.operator.dereference","->"],
+  ["identifier","url"]
+],[
+   "start",
+  ["text","    "],
+  ["paren.rparen","}"]
+],[
+   "start",
+  ["text","  "],
+  ["paren.rparen","}"]
+],[
+   "start",
+  ["paren.rparen","}"]
+],[
+   "start"
+],[
+   "start",
+  ["comment.line","// Count documents by type"]
+],[
+   "start",
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"articles\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","count"],
+  ["paren.lparen","("],
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"article\""],
+  ["paren.rparen","])"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"authors\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","count"],
+  ["paren.lparen","("],
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"author\""],
+  ["paren.rparen","])"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"total\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","count"],
+  ["paren.lparen","("],
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["paren.rparen","])"]
+],[
+   "start",
+  ["paren.rparen","}"]
+],[
+   "start"
+],[
+   "start",
+  ["comment.line","// Text search with scoring and boosting"]
+],[
+   "start",
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"article\""],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["identifier","title"],
+  ["text"," "],
+  ["keyword.control","match"],
+  ["text"," "],
+  ["string.quoted.double","\"serverless\""],
+  ["paren.rparen","]"],
+  ["text"," "],
+  ["keyword.operator.pipe","|"],
+  ["text"," "],
+  ["support.function","score"],
+  ["paren.lparen","("],
+  ["support.function","boost"],
+  ["paren.lparen","("],
+  ["identifier","title"],
+  ["text"," "],
+  ["keyword.control","match"],
+  ["text"," "],
+  ["string.quoted.double","\"serverless\""],
+  ["punctuation",","],
+  ["text"," "],
+  ["constant.numeric","3"],
+  ["paren.rparen",")"],
+  ["punctuation",","],
+  ["text"," "],
+  ["identifier","body"],
+  ["text"," "],
+  ["keyword.control","match"],
+  ["text"," "],
+  ["string.quoted.double","\"serverless\""],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword.operator.pipe","|"],
+  ["text"," "],
+  ["support.function","order"],
+  ["paren.lparen","("],
+  ["identifier","_score"],
+  ["text"," "],
+  ["keyword.control","desc"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["paren.lparen","["],
+  ["constant.numeric","0"],
+  ["keyword.operator.range",".."],
+  ["constant.numeric","9"],
+  ["paren.rparen","]"],
+  ["text"," "],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","title"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","_score"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"excerpt\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["entity.name.tag","string"],
+  ["punctuation.namespace","::"],
+  ["support.function","split"],
+  ["paren.lparen","("],
+  ["entity.name.tag","pt"],
+  ["punctuation.namespace","::"],
+  ["support.function","text"],
+  ["paren.lparen","("],
+  ["identifier","body"],
+  ["paren.rparen",")"],
+  ["punctuation",","],
+  ["text"," "],
+  ["string.quoted.double","\".\""],
+  ["paren.rparen",")"],
+  ["paren.lparen","["],
+  ["constant.numeric","0"],
+  ["paren.rparen","]"]
+],[
+   "start",
+  ["paren.rparen","}"]
+],[
+   "start"
+],[
+   "start",
+  ["comment.line","// Using parameters"]
+],[
+   "start",
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["variable","$type"],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["support.function","defined"],
+  ["paren.lparen","("],
+  ["identifier","publishedAt"],
+  ["paren.rparen",")]"],
+  ["text"," "],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","  "],
+  ["keyword.operator.spread","..."],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"relatedCount\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","count"],
+  ["paren.lparen","("],
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["variable.language","^"],
+  ["punctuation.accessor","."],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["support.function","references"],
+  ["paren.lparen","("],
+  ["variable.language","^"],
+  ["punctuation.accessor","."],
+  ["identifier","_id"],
+  ["paren.rparen",")])"]
+],[
+   "start",
+  ["paren.rparen","}"]
+],[
+   "start"
+],[
+   "start",
+  ["comment.line","// Conditional projections with select"]
+],[
+   "start",
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"product\""],
+  ["paren.rparen","]"],
+  ["text"," "],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","title"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"label\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","select"],
+  ["paren.lparen","("]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","price"],
+  ["text"," < "],
+  ["constant.numeric","10"],
+  ["text"," "],
+  ["keyword.operator.arrow","=>"],
+  ["text"," "],
+  ["string.quoted.double","\"budget\""],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","price"],
+  ["text"," "],
+  ["keyword.operator",">="],
+  ["text"," "],
+  ["constant.numeric","10"],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["identifier","price"],
+  ["text"," < "],
+  ["constant.numeric","100"],
+  ["text"," "],
+  ["keyword.operator.arrow","=>"],
+  ["text"," "],
+  ["string.quoted.double","\"mid-range\""],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","    "],
+  ["identifier","price"],
+  ["text"," "],
+  ["keyword.operator",">="],
+  ["text"," "],
+  ["constant.numeric","100"],
+  ["text"," "],
+  ["keyword.operator.arrow","=>"],
+  ["text"," "],
+  ["string.quoted.double","\"premium\""]
+],[
+   "start",
+  ["text","  "],
+  ["paren.rparen",")"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"discount\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","round"],
+  ["paren.lparen","("],
+  ["identifier","price"],
+  ["text"," "],
+  ["keyword.operator","*"],
+  ["text"," "],
+  ["constant.numeric","0.85"],
+  ["punctuation",","],
+  ["text"," "],
+  ["constant.numeric","2"],
+  ["paren.rparen",")"]
+],[
+   "start",
+  ["paren.rparen","}"]
+],[
+   "start"
+],[
+   "start",
+  ["comment.line","// Boolean, null, and numeric literals"]
+],[
+   "start",
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"post\""],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["identifier","featured"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["constant.language","true"],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["identifier","deletedAt"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["constant.language","null"],
+  ["paren.rparen","]"],
+  ["text"," "],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","title"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"views\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","coalesce"],
+  ["paren.lparen","("],
+  ["identifier","viewCount"],
+  ["punctuation",","],
+  ["text"," "],
+  ["constant.numeric","0"],
+  ["paren.rparen",")"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"rating\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","round"],
+  ["paren.lparen","("],
+  ["identifier","score"],
+  ["text"," "],
+  ["keyword.operator","*"],
+  ["text"," "],
+  ["constant.numeric","100"],
+  ["paren.rparen",")"],
+  ["text"," "],
+  ["keyword.operator","/"],
+  ["text"," "],
+  ["constant.numeric","100"]
+],[
+   "start",
+  ["paren.rparen","}"]
+],[
+   "start"
+],[
+   "start",
+  ["comment.line","// Date filtering"]
+],[
+   "start",
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"event\""],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["support.function","dateTime"],
+  ["paren.lparen","("],
+  ["identifier","startDate"],
+  ["paren.rparen",")"],
+  ["text"," > "],
+  ["support.function","dateTime"],
+  ["paren.lparen","("],
+  ["support.function","now"],
+  ["paren.lparen","("],
+  ["paren.rparen","))"],
+  ["text"," "],
+  ["keyword.operator","-"],
+  ["text"," "],
+  ["constant.numeric","60"],
+  ["text"," "],
+  ["keyword.operator","*"],
+  ["text"," "],
+  ["constant.numeric","60"],
+  ["text"," "],
+  ["keyword.operator","*"],
+  ["text"," "],
+  ["constant.numeric","24"],
+  ["text"," "],
+  ["keyword.operator","*"],
+  ["text"," "],
+  ["constant.numeric","7"],
+  ["paren.rparen","]"],
+  ["text"," "],
+  ["keyword.operator.pipe","|"],
+  ["text"," "],
+  ["support.function","order"],
+  ["paren.lparen","("],
+  ["identifier","startDate"],
+  ["text"," "],
+  ["keyword.control","asc"],
+  ["paren.rparen",")"]
+],[
+   "start"
+],[
+   "start",
+  ["comment.line","// String functions"]
+],[
+   "start",
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"author\""],
+  ["paren.rparen","]"],
+  ["text"," "],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"displayName\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["support.function","upper"],
+  ["paren.lparen","("],
+  ["identifier","name"],
+  ["paren.lparen","["],
+  ["constant.numeric","0"],
+  ["paren.rparen","])"],
+  ["text"," "],
+  ["keyword.operator","+"],
+  ["text"," "],
+  ["support.function","lower"],
+  ["paren.lparen","("],
+  ["identifier","name"],
+  ["paren.lparen","["],
+  ["constant.numeric","1"],
+  ["keyword.operator.range",".."],
+  ["paren.rparen","])"]
+],[
+   "start",
+  ["paren.rparen","}"]
+],[
+   "start"
+],[
+   "start",
+  ["comment.line","// Dereference and identity"]
+],[
+   "start",
+  ["constant.language.wildcard","*"],
+  ["paren.lparen","["],
+  ["identifier","_type"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["string.quoted.double","\"comment\""],
+  ["text"," "],
+  ["keyword.operator","&&"],
+  ["text"," "],
+  ["identifier","post"],
+  ["keyword.operator.dereference","->"],
+  ["identifier","author"],
+  ["punctuation.accessor","."],
+  ["identifier","_ref"],
+  ["text"," "],
+  ["keyword.operator","=="],
+  ["text"," "],
+  ["support.function","identity"],
+  ["paren.lparen","("],
+  ["paren.rparen",")]"],
+  ["text"," "],
+  ["paren.lparen","{"]
+],[
+   "start",
+  ["text","  "],
+  ["identifier","text"],
+  ["punctuation",","]
+],[
+   "start",
+  ["text","  "],
+  ["string.quoted.double","\"postTitle\""],
+  ["punctuation",":"],
+  ["text"," "],
+  ["identifier","post"],
+  ["keyword.operator.dereference","->"],
+  ["identifier","title"]
+],[
+   "start",
+  ["paren.rparen","}"]
+],[
+   "start"
+]]

--- a/src/mode/groq.js
+++ b/src/mode/groq.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var HighlightRules = require("./groq_highlight_rules").GroqHighlightRules;
+var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutdent;
+var CStyleFoldMode = require("./folding/cstyle").FoldMode;
+
+var Mode = function() {
+    this.HighlightRules = HighlightRules;
+    this.$outdent = new MatchingBraceOutdent();
+    this.$behaviour = this.$defaultBehaviour;
+    this.foldingRules = new CStyleFoldMode();
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.lineCommentStart = "//";
+
+    this.checkOutdent = function(state, line, input) {
+        return this.$outdent.checkOutdent(line, input);
+    };
+
+    this.autoOutdent = function(state, doc, row) {
+        this.$outdent.autoOutdent(doc, row);
+    };
+
+    this.$id = "ace/mode/groq";
+}).call(Mode.prototype);
+
+exports.Mode = Mode;

--- a/src/mode/groq_highlight_rules.js
+++ b/src/mode/groq_highlight_rules.js
@@ -1,0 +1,117 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var KNOWN_FUNCTIONS =
+    "after|before|boost|coalesce|count|dateTime|defined|identity|length|lower|now|order|path|references|round|score|select|string|upper";
+
+var KEYWORD_OPERATORS = "in|match|asc|desc";
+
+var GroqHighlightRules = function() {
+    this.$rules = {
+        "start": [
+            {
+                token : "comment.line",
+                regex : /\/\/.*$/
+            }, {
+                token : "string.quoted.double",
+                regex : /"/,
+                next  : "string_double"
+            }, {
+                token : "string.quoted.single",
+                regex : /'/,
+                next  : "string_single"
+            }, {
+                token : "constant.numeric",
+                regex : /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?(?!\w)/
+            }, {
+                token : "constant.language",
+                regex : /\b(?:true|false|null)\b/
+            }, {
+                token : "keyword.control",
+                regex : new RegExp("\\b(?:" + KEYWORD_OPERATORS + ")\\b")
+            }, {
+                token : ["entity.name.tag", "punctuation.namespace", "support.function"],
+                regex : /(\b[a-zA-Z_]\w*)(::)([a-zA-Z_]\w*(?=\s*\())/
+            }, {
+                token : "support.function",
+                regex : new RegExp("\\b(?:" + KNOWN_FUNCTIONS + ")\\b(?=\\s*\\()")
+            }, {
+                token : "variable",
+                regex : /\$[a-zA-Z_]\w*/
+            }, {
+                token : "variable.language",
+                regex : /@|\^+/
+            }, {
+                token : "constant.language.wildcard",
+                regex : /\*(?=\s*[\[{|)\],}]|\s*$)/
+            }, {
+                token : "keyword.operator.spread",
+                regex : /\.\.\./
+            }, {
+                token : "keyword.operator.dereference",
+                regex : /->/
+            }, {
+                token : "keyword.operator.range",
+                regex : /\.\.(?!\.)/
+            }, {
+                token : "keyword.operator.pipe",
+                regex : /\|(?!\|)/
+            }, {
+                token : "keyword.operator.arrow",
+                regex : /=>/
+            }, {
+                token : "keyword.operator",
+                regex : /[!=<>]=|&&|\|\||[!+\-*/%]|\*\*/
+            }, {
+                token : "punctuation.accessor",
+                regex : /\.(?!\.)/
+            }, {
+                token : "paren.lparen",
+                regex : /[\[{(]/
+            }, {
+                token : "paren.rparen",
+                regex : /[\]})]/
+            }, {
+                token : "punctuation",
+                regex : /[,:;]/
+            }, {
+                token : "identifier",
+                regex : /[a-zA-Z_]\w*/
+            }
+        ],
+
+        "string_double": [
+            {
+                token : "constant.character.escape",
+                regex : /\\(?:[\\/"'bfnrt]|u[0-9a-fA-F]{4}|u\{[0-9a-fA-F]+\})/
+            }, {
+                token : "string.quoted.double",
+                regex : /"/,
+                next  : "start"
+            }, {
+                defaultToken : "string.quoted.double"
+            }
+        ],
+
+        "string_single": [
+            {
+                token : "constant.character.escape",
+                regex : /\\(?:[\\/"'bfnrt]|u[0-9a-fA-F]{4}|u\{[0-9a-fA-F]+\})/
+            }, {
+                token : "string.quoted.single",
+                regex : /'/,
+                next  : "start"
+            }, {
+                defaultToken : "string.quoted.single"
+            }
+        ]
+    };
+
+    this.normalizeRules();
+};
+
+oop.inherits(GroqHighlightRules, TextHighlightRules);
+
+exports.GroqHighlightRules = GroqHighlightRules;


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Adds a new syntax highlighting mode for [GROQ](https://spec.groq.dev/GROQ-1.revision5/) (Graph-Relational Object Queries), a query language used by the Sanity content platform, amongst others.

It is getting quite popular - it's a little hard to see the full extent of the ecosystem - but a search for the Sanity clients' `.fetch()` is a [fairly good indicator](https://github.com/search?q=sanity+client.fetch&type=code). 

The mode includes highlighting for:
- Line comments (`//`)
- Single and double-quoted strings with escape sequences
- Numeric literals (integer, decimal, scientific notation)
- Boolean and null literals
- Keyword operators (`in`, `match`, `asc`, `desc`)
- Built-in functions (`count`, `select`, `coalesce`, `defined`, `order`, etc.)
- Namespaced function calls (`string::split`, `pt::text`, etc.)
- Parameter variables (`$name`)
- Special variables (`@`, `^`)
- Operators: dereference (`->`), spread (`...`), range (`..`), pipe (`|`), arrow (`=>`)
- Comparison and logical operators
- Brace matching, auto-outdent, and C-style code folding

**Pull Request Checklist:**

* [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

[Open kitchen-sink @ 09e8558aae17cd8c21326df71f90796c85a52bb6](https://raw.githack.com/rexxars/ace/09e8558aae17cd8c21326df71f90796c85a52bb6/kitchen-sink.html)