### PR TITLE
feat(rust): Include `raw` borrow operator in keyword list

### DIFF
--- a/src/mode/rust_highlight_rules.js
+++ b/src/mode/rust_highlight_rules.js
@@ -14,7 +14,7 @@ var RustHighlightRules = function() {
     var keywordMapper = this.createKeywordMapper({
         "keyword.source.rust": "abstract|alignof|as|async|await|become|box|break|catch|continue|const|crate|"
             + "default|do|dyn|else|enum|extern|for|final|if|impl|in|let|loop|macro|match|mod|move|mut|offsetof|"
-            + "override|priv|proc|pub|pure|ref|return|self|sizeof|static|struct|super|trait|type|typeof|union|"
+            + "override|priv|proc|pub|pure|raw|ref|return|self|sizeof|static|struct|super|trait|type|typeof|union|"
             + "unsafe|unsized|use|virtual|where|while|yield|try",
         "storage.type.source.rust": "Self|isize|usize|char|bool|u8|u16|u32|u64|u128|f16|f32|f64|i8|i16|i32|i64|"
             + "i128|str|option|either|c_float|c_double|c_void|FILE|fpos_t|DIR|dirent|c_char|c_schar|c_uchar|c_short|"


### PR DESCRIPTION
*Issue #, if available:* No

*Description of changes:*
Includes rust's raw borrow operator in the keywords list, for highlighting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts



[Open kitchen-sink @ dec931b9275ee9df75d4c305b8088b12a3a0a4c1](https://raw.githack.com/skr4n/ace/dec931b9275ee9df75d4c305b8088b12a3a0a4c1/kitchen-sink.html)