### PR TITLE
feat(mode): Add Cedar and CedarSchema language modes for Ace Editor

### DIFF
--- a/ace-modes.d.ts
+++ b/ace-modes.d.ts
@@ -191,6 +191,22 @@ declare module "ace-code/src/mode/c9search" {
     export const Mode: new () => import("ace-code").Ace.SyntaxMode;
 }
 
+declare module "ace-code/src/mode/cedar_highlight_rules" {
+    export const CedarHighlightRules: new () => import("ace-code").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/cedar" {
+    export const Mode: new () => import("ace-code").Ace.SyntaxMode;
+}
+
+declare module "ace-code/src/mode/cedarschema_highlight_rules" {
+    export const CedarSchemaHighlightRules: new () => import("ace-code").Ace.HighlightRules;
+}
+
+declare module "ace-code/src/mode/cedarschema" {
+    export const Mode: new () => import("ace-code").Ace.SyntaxMode;
+}
+
 declare module "ace-code/src/mode/cirru_highlight_rules" {
     export const CirruHighlightRules: new () => import("ace-code").Ace.HighlightRules;
 }

--- a/demo/kitchen-sink/docs/cedar.cedar
+++ b/demo/kitchen-sink/docs/cedar.cedar
@@ -1,0 +1,59 @@
+// Cedar Policy Language
+// Cedar is used to define authorization policies for AWS Verified Permissions
+
+@id("photo-access")
+permit (
+    principal == User::"alice",
+    action == Action::"viewPhoto",
+    resource == Photo::"vacation"
+)
+when { resource.tags.contains("public") && context.authenticated == true };
+
+// Forbid access unless in admin group
+forbid (principal, action, resource)
+unless { principal in Group::"admins" };
+
+// Template policy with IP restriction
+permit (
+    principal == ?principal,
+    action,
+    resource
+)
+when {
+    ip(context.sourceIp).isLoopback() ||
+    ip(context.sourceIp).isInRange(ip("10.0.0.0/8"))
+};
+
+// Policy using decimal and datetime extensions
+permit (
+    principal,
+    action == Action::"purchase",
+    resource
+)
+when {
+    decimal(resource.price).lessThanOrEqual(decimal("100.00")) &&
+    datetime(context.timestamp).toDate() == datetime("2025-01-01")
+};
+
+// Conditional logic with has and like
+permit (
+    principal is User in Group::"employees",
+    action == Action::"read",
+    resource
+)
+when {
+    resource has department &&
+    principal.email like "*@example.com" &&
+    if resource.confidential then principal in Group::"managers" else true
+};
+
+@annotation("example")
+forbid (
+    principal,
+    action,
+    resource
+)
+when {
+    context.riskScore > 80 ||
+    [Action::"delete", Action::"modify"].contains(action)
+};

--- a/demo/kitchen-sink/docs/cedarschema.cedarschema
+++ b/demo/kitchen-sink/docs/cedarschema.cedarschema
@@ -1,0 +1,87 @@
+// Cedar Schema Language
+// Defines the entity model for a photo sharing application
+
+namespace PhotoApp::Auth {
+    // Custom types
+    type Context = {
+        authenticated: Bool,
+        sourceIp?: String,
+        timestamp?: String,
+        riskScore?: Long,
+    };
+
+    // Entity hierarchy
+    entity User in [Group] {
+        name: String,
+        email: String,
+        department?: String,
+    };
+
+    entity Group in [Group] {
+        description?: String,
+    };
+
+    entity Photo {
+        owner: User,
+        confidential: Bool,
+        department?: String,
+        price?: String,
+    } tags Set<String>;
+
+    entity Album in [Album] {
+        name: String,
+        photos: Set<Photo>,
+    };
+
+    // Actions
+    action "viewPhoto" appliesTo {
+        principal: [User, Group],
+        resource: [Photo],
+        context: Context,
+    };
+
+    action "editPhoto" in [action "managePhoto"] appliesTo {
+        principal: [User],
+        resource: [Photo],
+        context: Context,
+    };
+
+    action "deletePhoto" in [action "managePhoto"] appliesTo {
+        principal: [User],
+        resource: [Photo],
+        context: Context,
+    };
+
+    action "managePhoto" appliesTo {
+        principal: [User, Group],
+        resource: [Photo],
+        context: Context,
+    };
+
+    action "purchase" appliesTo {
+        principal: [User],
+        resource: [Photo],
+        context: Context,
+    };
+
+    action "read" appliesTo {
+        principal: [User, Group],
+        resource: [Photo, Album],
+        context: Context,
+    };
+
+    action "delete" appliesTo {
+        principal: [User],
+        resource: [Photo, Album],
+        context: Context,
+    };
+
+    action "modify" appliesTo {
+        principal: [User],
+        resource: [Photo, Album],
+        context: Context,
+    };
+
+    // Enum type example
+    type Permission = enum ["read", "write", "admin"];
+}

--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -90,6 +90,7 @@ var supportedModes = {
     C_Cpp:       ["cpp|c|cc|cxx|h|hh|hpp|ino"],
     C9Search:    ["c9search_results"],
     Cedar:       ["cedar"],
+    CedarSchema: ["cedarschema"],
     Cirru:       ["cirru|cr"],
     Clojure:     ["clj|cljs"],
     Clue:        ["clue"],

--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -89,6 +89,7 @@ var supportedModes = {
     BibTeX:      ["bib"],
     C_Cpp:       ["cpp|c|cc|cxx|h|hh|hpp|ino"],
     C9Search:    ["c9search_results"],
+    Cedar:       ["cedar"],
     Cirru:       ["cirru|cr"],
     Clojure:     ["clj|cljs"],
     Clue:        ["clue"],

--- a/src/mode/cedar.js
+++ b/src/mode/cedar.js
@@ -1,0 +1,39 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var CedarHighlightRules = require("./cedar_highlight_rules").CedarHighlightRules;
+var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutdent;
+var CStyleFoldMode = require("./folding/cstyle").FoldMode;
+
+var Mode = function() {
+    this.HighlightRules = CedarHighlightRules;
+    this.foldingRules = new CStyleFoldMode();
+    this.$outdent = new MatchingBraceOutdent();
+    this.$behaviour = this.$defaultBehaviour;
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.lineCommentStart = "//";
+    this.$id = "ace/mode/cedar";
+    this.snippetFileId = "ace/snippets/cedar";
+
+    this.getNextLineIndent = function(state, line, tab) {
+        var indent = this.$getIndent(line);
+        if (/[\{\(]\s*$/.test(line)) {
+            indent += tab;
+        }
+        return indent;
+    };
+
+    this.checkOutdent = function(state, line, input) {
+        return this.$outdent.checkOutdent(line, input);
+    };
+
+    this.autoOutdent = function(state, doc, row) {
+        this.$outdent.autoOutdent(doc, row);
+    };
+}).call(Mode.prototype);
+
+exports.Mode = Mode;

--- a/src/mode/cedar_highlight_rules.js
+++ b/src/mode/cedar_highlight_rules.js
@@ -1,0 +1,105 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var CedarHighlightRules = function() {
+    var keywordMapper = this.createKeywordMapper({
+        "keyword": "permit|forbid|when|unless|in|has|like|if|then|else|is",
+        "variable.other.constant": "principal|action|resource|context",
+        "constant.language.boolean": "true|false",
+        "support.function": "ip|decimal|datetime|duration"
+    }, "identifier");
+
+    this.$rules = {
+    "start": [
+        {
+            token: "comment.line.double-slash",
+            regex: /\/\/.*$/
+        },
+        {
+            token: ["meta.decorator", "paren.lparen"],
+            regex: /(@[_a-zA-Z][_a-zA-Z0-9]*)([\(])/
+        },
+        {
+            token: "variable.other",
+            regex: /\?(principal|resource)\b/
+        },
+        {
+            token: "string.quoted.double",
+            regex: '"',
+            next: "cedar-string"
+        },
+        {
+            token: "entity.name.type",
+            regex: /[_a-zA-Z][_a-zA-Z0-9]*(?:::[_a-zA-Z][_a-zA-Z0-9]*)*(?=::")/
+        },
+        {
+            token: "entity.name.type",
+            regex: /[_a-zA-Z][_a-zA-Z0-9]*(?:::[_a-zA-Z][_a-zA-Z0-9]*)+/
+        },
+        {
+            token: ["punctuation.operator", "entity.name.function.member", "paren.lparen"],
+            regex: /(\.)(contains|containsAll|containsAny|isEmpty|getTag|hasTag|isIpv4|isIpv6|isLoopback|isMulticast|isInRange|lessThan|lessThanOrEqual|greaterThan|greaterThanOrEqual|offset|durationSince|toDate|toTime|toMilliseconds|toSeconds|toMinutes|toHours|toDays)(\()/
+        },
+        {
+            token: ["support.function", "paren.lparen"],
+            regex: /(ip|decimal|datetime|duration)(\()/
+        },
+        {
+            token: "constant.numeric",
+            regex: /[1-9][0-9]*|0\b/
+        },
+        {
+            token: keywordMapper,
+            regex: /[a-zA-Z_][a-zA-Z0-9_]*\b/
+        },
+        {
+            token: "punctuation.operator",
+            regex: /::/
+        },
+        {
+            token: "keyword.operator",
+            regex: /==|!=|<=|>=|<|>|&&|\|\||!/
+        },
+        {
+            token: "keyword.operator",
+            regex: /[+\-*]/
+        },
+        {
+            token: "paren.lparen",
+            regex: /[\[({]/
+        },
+        {
+            token: "paren.rparen",
+            regex: /[\])}]/
+        },
+        {
+            token: "punctuation.operator",
+            regex: /[,;.]/
+        },
+        {
+            token: "text",
+            regex: /\s+/
+        }
+    ],
+    "cedar-string": [
+        {
+            token: "constant.character.escape",
+            regex: /\\./
+        },
+        {
+            token: "string.quoted.double",
+            regex: '"',
+            next: "start"
+        },
+        {
+            defaultToken: "string.quoted.double"
+        }
+    ]
+    };
+};
+
+oop.inherits(CedarHighlightRules, TextHighlightRules);
+
+exports.CedarHighlightRules = CedarHighlightRules;

--- a/src/mode/cedarschema.js
+++ b/src/mode/cedarschema.js
@@ -1,0 +1,39 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var CedarSchemaHighlightRules = require("./cedarschema_highlight_rules").CedarSchemaHighlightRules;
+var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutdent;
+var CStyleFoldMode = require("./folding/cstyle").FoldMode;
+
+var Mode = function() {
+    this.HighlightRules = CedarSchemaHighlightRules;
+    this.foldingRules = new CStyleFoldMode();
+    this.$outdent = new MatchingBraceOutdent();
+    this.$behaviour = this.$defaultBehaviour;
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.lineCommentStart = "//";
+    this.$id = "ace/mode/cedarschema";
+    this.snippetFileId = "ace/snippets/cedarschema";
+
+    this.getNextLineIndent = function(state, line, tab) {
+        var indent = this.$getIndent(line);
+        if (/[\{\[]\s*$/.test(line)) {
+            indent += tab;
+        }
+        return indent;
+    };
+
+    this.checkOutdent = function(state, line, input) {
+        return this.$outdent.checkOutdent(line, input);
+    };
+
+    this.autoOutdent = function(state, doc, row) {
+        this.$outdent.autoOutdent(doc, row);
+    };
+}).call(Mode.prototype);
+
+exports.Mode = Mode;

--- a/src/mode/cedarschema_highlight_rules.js
+++ b/src/mode/cedarschema_highlight_rules.js
@@ -1,0 +1,90 @@
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var CedarSchemaHighlightRules = function() {
+    this.$rules = {
+    "start": [
+        {
+            token: "comment.line.double-slash",
+            regex: /\/\/.*$/
+        },
+        {
+            token: ["keyword", "text", "entity.name.namespace"],
+            regex: /(namespace)(\s+)([_a-zA-Z][_a-zA-Z0-9]*(?:::[_a-zA-Z][_a-zA-Z0-9]*)*)/
+        },
+        {
+            token: "keyword",
+            regex: /^\s*(?:type|entity|action)(?=\s+)/
+        },
+        {
+            token: "keyword",
+            regex: /\b(appliesTo)\b/
+        },
+        {
+            token: ["keyword", "text", "paren.lparen"],
+            regex: /\b(enum|in)(\s*)(\[)/
+        },
+        {
+            token: ["paren.rparen", "text", "keyword"],
+            regex: /(\})(\s*)(tags)\b/
+        },
+        {
+            token: "variable.other.property",
+            regex: /\b[_a-zA-Z][_a-zA-Z0-9]*(?=[?]?:(?!:))/
+        },
+        {
+            token: "string.quoted.double",
+            regex: '"',
+            next: "schema-string"
+        },
+        {
+            token: "entity.name.type",
+            regex: /[_a-zA-Z][_a-zA-Z0-9]*(?:::[_a-zA-Z][_a-zA-Z0-9]*)+/
+        },
+        {
+            token: "punctuation.operator",
+            regex: /::/
+        },
+        {
+            token: "paren.lparen",
+            regex: /[\[({]/
+        },
+        {
+            token: "paren.rparen",
+            regex: /[\])}]/
+        },
+        {
+            token: "punctuation.operator",
+            regex: /[,;?:]/
+        },
+        {
+            token: "identifier",
+            regex: /[a-zA-Z_][a-zA-Z0-9_]*\b/
+        },
+        {
+            token: "text",
+            regex: /\s+/
+        }
+    ],
+    "schema-string": [
+        {
+            token: "constant.character.escape",
+            regex: /\\./
+        },
+        {
+            token: "string.quoted.double",
+            regex: '"',
+            next: "start"
+        },
+        {
+            defaultToken: "string.quoted.double"
+        }
+    ]
+    };
+};
+
+oop.inherits(CedarSchemaHighlightRules, TextHighlightRules);
+
+exports.CedarSchemaHighlightRules = CedarSchemaHighlightRules;

--- a/src/snippets/cedar.js
+++ b/src/snippets/cedar.js
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.snippetText = require("./cedar.snippets");
+exports.scope = "cedar";

--- a/src/snippets/cedar.snippets.js
+++ b/src/snippets/cedar.snippets.js
@@ -1,0 +1,22 @@
+module.exports = `snippet permit
+\tpermit (
+\t    principal == \${1:Principal}::"\${2:id}",
+\t    action == Action::"\${3:action}",
+\t    resource == \${4:Resource}::"\${5:id}"
+\t)\${0};
+snippet permit_when
+\tpermit (principal, action, resource)
+\twhen { \${0:condition} };
+snippet forbid
+\tforbid (principal, action, resource)
+\twhen { \${0:condition} };
+snippet forbid_unless
+\tforbid (principal, action, resource)
+\tunless { \${0:condition} };
+snippet when
+\twhen { \${0:condition} }
+snippet unless
+\tunless { \${0:condition} }
+snippet annotation
+\t@\${1:name}("\${2:value}")
+`;

--- a/src/snippets/cedarschema.js
+++ b/src/snippets/cedarschema.js
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.snippetText = require("./cedarschema.snippets");
+exports.scope = "cedarschema";

--- a/src/snippets/cedarschema.snippets.js
+++ b/src/snippets/cedarschema.snippets.js
@@ -1,0 +1,29 @@
+module.exports = `snippet namespace
+\tnamespace \${1:Namespace} {
+\t    \${0}
+\t}
+snippet entity
+\tentity \${1:EntityName} {
+\t    \${0}
+\t};
+snippet entity_in
+\tentity \${1:EntityName} in [\${2:Parent}] {
+\t    \${0}
+\t};
+snippet action
+\taction "\${1:actionName}" appliesTo {
+\t    principal: [\${2:Principal}],
+\t    resource: [\${3:Resource}],
+\t    context: {\${0}}
+\t};
+snippet action_in
+\taction "\${1:actionName}" in [\${2:ParentAction}] appliesTo {
+\t    principal: [\${3:Principal}],
+\t    resource: [\${4:Resource}],
+\t    context: {\${0}}
+\t};
+snippet type
+\ttype \${1:TypeName} = {
+\t    \${0}
+\t};
+`;

--- a/types/ace-lib.d.ts
+++ b/types/ace-lib.d.ts
@@ -99,6 +99,7 @@ declare module "ace-code/src/lib/lang" {
         cancel(): void;
         isPending(): any;
     };
+    export function sleep(ms: number): Promise<void>;
     export function supportsLookbehind(): boolean;
     export function skipEmptyMatch(line: any, last: any, supportsUnicodeFlag: any): 1 | 2;
 }

--- a/types/ace-snippets.d.ts
+++ b/types/ace-snippets.d.ts
@@ -24,6 +24,22 @@ declare module "ace-code/src/snippets/c_cpp" {
     export const snippetText: string;
     export const scope: "c_cpp";
 }
+declare module "ace-code/src/snippets/cedar.snippets" {
+    const _exports: string;
+    export = _exports;
+}
+declare module "ace-code/src/snippets/cedar" {
+    export const snippetText: string;
+    export const scope: "cedar";
+}
+declare module "ace-code/src/snippets/cedarschema.snippets" {
+    const _exports: string;
+    export = _exports;
+}
+declare module "ace-code/src/snippets/cedarschema" {
+    export const snippetText: string;
+    export const scope: "cedarschema";
+}
 declare module "ace-code/src/snippets/clojure.snippets" {
     const _exports: string;
     export = _exports;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add syntax highlighting for Cedar schema files (.cedarschema) based on the vscode-cedar extension's cedarschema TextMate grammar.
* Add syntax highlighting for Cedar policy files (.cedar) based on the vscode-cedar extension's cedarschema TextMate grammar.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [X] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts



[Open kitchen-sink @ a8d94f4c402485f018e026340ff7f4f9bd5b1bb8](https://raw.githack.com/Swolebrain/ace/a8d94f4c402485f018e026340ff7f4f9bd5b1bb8/kitchen-sink.html)

[Open kitchen-sink @ 4ea3b6a205ecb5988311d4c6477d3dfab45be7e9](https://raw.githack.com/Swolebrain/ace/4ea3b6a205ecb5988311d4c6477d3dfab45be7e9/kitchen-sink.html)

[Open kitchen-sink @ f211bf06a476303af8e0cb8fa33db51e20a3af2f](https://raw.githack.com/Swolebrain/ace/f211bf06a476303af8e0cb8fa33db51e20a3af2f/kitchen-sink.html)