### PR TITLE
fix: allow string modes in createEditSession types

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -1059,7 +1059,7 @@ declare module "ace-code" {
         env?: any;
         value?: any;
     }) | null, options?: Partial<import("ace-code").Ace.EditorOptions>): Editor;
-    export function createEditSession(text: import("ace-code/src/document").Document | string, mode?: import("ace-code").Ace.SyntaxMode): EditSession;
+    export function createEditSession(text: import("ace-code/src/document").Document | string, mode?: import("ace-code").Ace.SyntaxMode | string): EditSession;
     import { Editor } from "ace-code/src/editor";
     import { EditSession } from "ace-code/src/edit_session";
     import { Range } from "ace-code/src/range";

--- a/demo/test_package/index.ts
+++ b/demo/test_package/index.ts
@@ -34,6 +34,7 @@ const editor = ace.edit(null, {
 }); // should not be an error
 editor.setTheme("ace/theme/monokai");
 editor.session.setMode("ace/mode/javascript");
+ace.createEditSession("", "ace/mode/rust"); // should not be an error
 
 function configure(config: ace.Ace.Config) {
     config.setDefaultValues("editor", {

--- a/src/ace.js
+++ b/src/ace.js
@@ -73,7 +73,7 @@ exports.edit = function(el, options) {
 /**
  * Creates a new [[EditSession]], and returns the associated [[Document]].
  * @param {import('./document').Document | String} text {:textParam}
- * @param {import("../ace-internal").Ace.SyntaxMode} [mode] {:modeParam}
+ * @param {import("../ace-internal").Ace.SyntaxMode | string} [mode] {:modeParam}
  * @returns {EditSession}
  **/
 exports.createEditSession = function(text, mode) {


### PR DESCRIPTION
## Summary
- Allow `ace.createEditSession` to accept string mode IDs in the generated public TypeScript declaration.
- Add package type coverage for passing a string mode to `createEditSession`.

Fixes #5946

## Testing
- `bash tool/test-npm-package.sh`
- `npm run typecheck`
- `node_modules/.bin/tsc --noImplicitAny --strict --noUnusedLocals --noImplicitReturns --noUnusedParameters --noImplicitThis ace.d.ts`
- `npx eslint src/ace.js`
- `npm run update-types`
- `git diff --check`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[Open kitchen-sink @ f03a1a4cdd1d6350c2674b263bf78d4fa3dd2604](https://raw.githack.com/cyphercodes/ace/f03a1a4cdd1d6350c2674b263bf78d4fa3dd2604/kitchen-sink.html)