### PR TITLE
Add Velt collaboration SDK to Related Projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@ console.log(addResult);
                             <h2>Related Projects</h2>
                             <ul class="content-list">
                                 <li><a href="https://github.com/convergencelabs/ace-collab-ext">Ace collaboration extension</a></li>
+                                <li><a href="https://docs.velt.dev/async-collaboration/comments/setup/ace">Velt collaboration SDK for Ace (comments, presence, cursors)</a></li>
                                 <li><a href="https://github.com/rksm/paredit.js">Paredit extension for ace</a></li>
                                 <li><a href="https://github.com/cadorn/ace-extjs">Ace wrapper for ExtJS</a></li>
                                 <li><a href="https://github.com/daveho/AceGWT">Ace wrapper for GWT</a></li>


### PR DESCRIPTION
Adds Velt to the Related Projects list on the homepage, next to the existing Ace collaboration extension.

Velt is a collaboration SDK with a dedicated Ace integration — threaded comments anchored to code, presence, and live cursors:

- Integration docs: https://docs.velt.dev/async-collaboration/comments/setup/ace
- Demo source: https://github.com/velt-js/sample-apps/tree/main/apps/react/comments/text-editors/ace/ace-comments-demo

Matches the existing list format; happy to shorten the label if preferred.

[Open kitchen-sink @ 5083890b04549ebfad7beff4fc5960418390a0a3](https://raw.githack.com/yoen-velt/ace/5083890b04549ebfad7beff4fc5960418390a0a3/kitchen-sink.html)