### PR TITLE
Improve folding logic for tags-based modes

### DIFF
--- a/src/mode/folding/html_test.js
+++ b/src/mode/folding/html_test.js
@@ -8,7 +8,7 @@ module.exports = {
 
     "test: fold mixed html and javascript": function() {
         var session = new EditSession([
-            '<script type="text/javascript"> ',
+            '<script type="text/javascript">',
             'function() foo {',
             '    var bar = 1;',
             '}',

--- a/src/mode/folding/xml.js
+++ b/src/mode/folding/xml.js
@@ -121,8 +121,11 @@ function is(token, type) {
         }
         var tags = session.getMatchingTags({row: row, column: 0});
         if (tags) {
+            var startRow = tags.openTag.start.row;
             return new Range(
-                tags.openTag.end.row, tags.openTag.end.column, tags.closeTag.start.row, tags.closeTag.start.column);
+                startRow, session.getLine(startRow).length, tags.closeTag.start.row,
+                tags.closeTag.start.column
+            );
         }
     };
 

--- a/src/mode/folding/xml_test.js
+++ b/src/mode/folding/xml_test.js
@@ -21,8 +21,8 @@ module.exports = {
         assert.equal(session.getFoldWidget(1), "");
         assert.equal(session.getFoldWidget(2), "end");
         
-        assert.range(session.getFoldWidgetRange(0), 0, 8, 2, 19);
-        assert.range(session.getFoldWidgetRange(2), 0, 8, 2, 19);
+        assert.range(session.getFoldWidgetRange(0), 0, 7, 2, 19);
+        assert.range(session.getFoldWidgetRange(2), 0, 7, 2, 19);
     },
     
     "test: fold should skip self closing elements": function() {
@@ -64,8 +64,8 @@ module.exports = {
         assert.equal(session.getFoldWidget(4), "end");
         
         assert.range(session.getFoldWidgetRange(0), 0, 8, 4, 0);
-        assert.range(session.getFoldWidgetRange(1), 1, 9, 3, 19);
-        assert.range(session.getFoldWidgetRange(3), 1, 9, 3, 19);
+        assert.range(session.getFoldWidgetRange(1), 1, 8, 3, 19);
+        assert.range(session.getFoldWidgetRange(3), 1, 8, 3, 19);
         assert.range(session.getFoldWidgetRange(4), 0, 8, 4, 0);
     },
     "test: fold should handle multi-line comments inside nested elements correctly": function () {
@@ -95,7 +95,30 @@ module.exports = {
         assert.range(session.getFoldWidgetRange(0), 0, 15, 10, 0);
         assert.range(session.getFoldWidgetRange(2), 2, 13, 5, 4);
         assert.equal(session.getFoldWidgetRange(8), "");
+    },
+
+    "test: fold multi-line opening tag from logical line end": function () {
+        var session = new EditSession([
+            '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"', '  version="1.0">',
+            '  <xsl:template match="/">', '  </xsl:template>', '</xsl:stylesheet>'
+        ]);
+
+        session.setMode(new XmlMode());
+        session.setFoldStyle("markbeginend");
+
+        var startColumn = session.getLine(0).length;
+
+        assert.range(session.getFoldWidgetRange(0), 0, startColumn, 4, 0);
+        assert.range(session.getFoldWidgetRange(4), 0, startColumn, 4, 0);
+
+        // The same opening widget must fold and unfold.
+        session.$toggleFoldWidget(0, {});
+        assert.ok(session.getFoldLine(0));
+
+        session.$toggleFoldWidget(0, {});
+        assert.equal(session.getFoldLine(0), undefined);
     }
+
 
 };
 


### PR DESCRIPTION
*Issue #, if available:* #5985

*Description of changes:*
Now it uses open tag start row to determine starting column on `getFoldWidgetRange`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts



[Open kitchen-sink @ e7339299b7732054fd41fb694e02dcb669736d5d](https://raw.githack.com/mkslanc/ace/e7339299b7732054fd41fb694e02dcb669736d5d/kitchen-sink.html)