### PR TITLE
Fix crash restoring a session serialized without undo history

### DIFF
--- a/src/edit_session.js
+++ b/src/edit_session.js
@@ -337,10 +337,14 @@ class EditSession {
         if (typeof session == "string")
             session = JSON.parse(session);
         const undoManager = new UndoManager();
-        undoManager.$undoStack = session.history.$undoStack;
-        undoManager.$redoStack = session.history.$redoStack;
-        undoManager.mark = session.history.mark;
-        undoManager.$rev = session.history.rev;
+        // history may be empty, e.g. serialized from a session that used
+        // the default no-op undo manager
+        if (session.history) {
+            undoManager.$undoStack = session.history.$undoStack || [];
+            undoManager.$redoStack = session.history.$redoStack || [];
+            undoManager.mark = session.history.mark || 0;
+            undoManager.$rev = session.history.rev || 0;
+        }
 
         const editSession = new EditSession(session.value);
         session.folds.forEach(function(fold) {

--- a/src/edit_session_test.js
+++ b/src/edit_session_test.js
@@ -1242,6 +1242,16 @@ module.exports = {
         assert.equal(session.getValue(), "Hello world! test1 test2");
     },
 
+    "test: JSON deserialization of session without undo history": function() {
+        // sessions using the default no-op undo manager serialize
+        // history as {}; editing after restore should not throw
+        var session = new EditSession(["Hello world!"]);
+        session = EditSession.fromJSON(JSON.stringify(session));
+
+        session.insert({row: 0, column: 0}, "x");
+        assert.equal(session.getValue(), "xHello world!");
+    },
+
     "test: operation handling : when session it not attached to an editor": async function(done) {
         const session = new EditSession("Hello world!");
         const beforeEndOperationSpy = [];

--- a/src/undomanager.js
+++ b/src/undomanager.js
@@ -303,8 +303,9 @@ class UndoManager {
      */
     fromJSON(json) {
         this.reset();
-        this.$undoStack = json.$undoStack;
-        this.$redoStack = json.$redoStack;
+        if (!json) return;
+        this.$undoStack = json.$undoStack || [];
+        this.$redoStack = json.$redoStack || [];
     }
 
 


### PR DESCRIPTION
## Problem

Restoring a session with `EditSession.fromJSON()` crashes on the first subsequent edit when the serialized session was using the default no-op undo manager:

```
Uncaught TypeError: Cannot set properties of undefined (setting 'length')
    at UndoManager.add (undomanager.js:45:58)
    at EditSession.onChange (edit_session.js:303:31)
```

`EditSession.toJSON()` serializes the undo manager under `history`; a session that never had a real `UndoManager` attached serializes it as `{}`. On restore, `fromJSON` then does:

```js
undoManager.$undoStack = session.history.$undoStack; // undefined
undoManager.$redoStack = session.history.$redoStack; // undefined
```

clobbering the arrays the `UndoManager` constructor just created, so the first `UndoManager.add()` throws at `this.$redoStack.length = 0`.

## Repro

```js
var session = new EditSession("hello");            // default no-op undo manager
var restored = EditSession.fromJSON(JSON.stringify(session.toJSON()));
restored.insert({row: 0, column: 0}, "x");          // TypeError
```

This is hit in practice by the kitchen-sink demo, which persists the session to `localStorage` on unload and restores it via `fromJSON` on the next load — after which every keystroke/paste throws. Regression from the `history` serialization changes in #5920.

## Fix

- `EditSession.fromJSON`: tolerate a missing/empty `history` object and default `$undoStack`/`$redoStack` to `[]`, `mark`/`rev` to `0`.
- `UndoManager.fromJSON`: guard against `null`/partial input the same way.
- Regression test: round-trip a session without undo history and edit it.

Round-tripping a session **with** real history is unaffected (covered by the existing `JSON serialization preserves undo/redo history` test).


[Open kitchen-sink @ ae482be47cbf147e7a550f1efc3487e0928f847a](https://raw.githack.com/xyos/ace/ae482be47cbf147e7a550f1efc3487e0928f847a/kitchen-sink.html)