### PR TITLE
ci: pin issue/PR triage actions to full commit SHAs

### DIFF
--- a/.github/workflows/issue-reprioritization.yml
+++ b/.github/workflows/issue-reprioritization.yml
@@ -9,14 +9,14 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: kaizencc/issue-reprioritization-manager@main
+      - uses: kaizencc/issue-reprioritization-manager@22649736f385c446eb14f947ab8230a194f3664c # main
         id: reprioritization-manager
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           original-label: p2
           new-label: p1
           reprioritization-threshold: 5
-      - uses: kaizencc/pr-triage-manager@main
+      - uses: kaizencc/pr-triage-manager@3a2558737a4d072feaaa4c1768b92f51abfde53b # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           on-pulls: ${{ steps.reprioritization-manager.outputs.linked-pulls }}


### PR DESCRIPTION
## What
Pin `kaizencc/issue-reprioritization-manager` and `kaizencc/pr-triage-manager` in `issue-reprioritization.yml` from `@main` to the commits they resolve to.

## Why
Both are third-party (personal-account) actions handed `GITHUB_TOKEN` with `issues: write`, referenced by the moving `@main` branch — so the code that runs with the token can change without any change here. Pinning to full SHAs closes that; behaviour unchanged.

I used AI assistance to identify this and draft the change; I verified it against the live workflow myself.

[Open kitchen-sink @ 66f61bce4b6551a7911a8c25e9d728db29f9c089](https://raw.githack.com/kobihikri/ace/66f61bce4b6551a7911a8c25e9d728db29f9c089/kitchen-sink.html)