### PR TITLE
fix: avoid repeated document reads during search highlighting

### DIFF
--- a/src/search_highlight.js
+++ b/src/search_highlight.js
@@ -39,10 +39,12 @@ class SearchHighlight {
         var renderedMarkerRanges = {};
         var _search = session.$editor && session.$editor.$search;
         var mtSearch = _search && _search.$isMultilineSearch(session.$editor.getLastSearchOptions());
+        var docLen = session.getValue().length;
+        var cacheInvalid = docLen != this.docLen;
 
         for (var i = start; i <= end; i++) {
             var ranges = this.cache[i];
-            if (ranges == null || session.getValue().length != this.docLen) {
+            if (ranges == null || cacheInvalid) {
                 if (mtSearch) {
                     ranges = [];
                     var match = _search.$multiLineForward(session, this.regExp, i, end);
@@ -78,7 +80,7 @@ class SearchHighlight {
                     html, rangeToAddMarkerTo, this.clazz, config);
             }
         }
-        this.docLen = session.getValue().length;
+        this.docLen = docLen;
     }
 }
 


### PR DESCRIPTION
*fixes Issue #5993*


Search highlighting became slow in large, folded documents because `session.getValue()` was called for every row being processed (which can be a lot if folded at high level). `session.getValue()` rebuilds the full document string causing a lot of repeated work. This was introduced in https://github.com/ajaxorg/ace/commit/06d51b9164dc9dc39fbd6df26b7132f4b9580a4c

*Description of changes:*
- Read the document value once per highlight update.
- Reuse its length when checking whether the highlight cache is stale.

[Open kitchen-sink @ 2af47ee796d23e1ad7cfc224a7e0cb512bfa8865](https://raw.githack.com/pageldev/ace/2af47ee796d23e1ad7cfc224a7e0cb512bfa8865/kitchen-sink.html)