### PR TITLE
fix(autocomplete): apply the replacement range of matches given to the popup

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -546,7 +546,12 @@ class Autocomplete {
             this.base = this.editor.session.doc.createAnchor(pos.row, pos.column);
             this.base.$insertRight = true;
             this.completions = new FilteredList(options.matches);
-            this.getCompletionProvider().completions = this.completions;
+            // the range of a completion is applied relative to the cursor, the same reference
+            // point the regular path uses, which is not the start of a non-empty selection
+            this.getCompletionProvider({
+                prefix: "",
+                pos: this.editor.getCursorPosition()
+            }).completions = this.completions;
             return this.openPopup(this.editor, "", keepPopupPosition);
         }
 
@@ -885,7 +890,7 @@ class CompletionProvider {
 
             var replaceBefore = this.completions.filterText.length;
             var replaceAfter = 0;
-            if (data.range && data.range.start.row === data.range.end.row) {
+            if (this.initialPosition && data.range && data.range.start.row === data.range.end.row) {
                 replaceBefore -= this.initialPosition.prefix.length;
                 replaceBefore += this.initialPosition.pos.column - data.range.start.column;
                 replaceAfter += data.range.end.column - this.initialPosition.pos.column;

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -1447,6 +1447,30 @@ module.exports = {
 
         assert.equal(editor.getValue(), "example value<b2-b2>");
     },
+    "test: replacement range of matches passed to execCommand is applied": function() {
+        editor = initEditor("abcdefGHI");
+
+        // the cursor sits inside the range, so text is replaced on both sides of it
+        editor.moveCursorTo(0, 3);
+        editor.execCommand('startAutocomplete', {
+            matches: [
+                { value: 'xyz', range: new Range(0, 0, 0, 6) }
+            ]
+        });
+        user.type("\n");
+        assert.equal(editor.getValue(), "xyzGHI");
+
+        // a selection must not widen the replacement beyond the range
+        editor.setValue("abcdefGHI", -1);
+        editor.selection.setRange(new Range(0, 1, 0, 4));
+        editor.execCommand('startAutocomplete', {
+            matches: [
+                { value: 'xyz', range: new Range(0, 0, 0, 6) }
+            ]
+        });
+        user.type("\n");
+        assert.equal(editor.getValue(), "xyzGHI");
+    },
     "test: should close popup if backspacing until input is fully deleted": function() {
         editor = initEditor("");
 


### PR DESCRIPTION
## Problem

Inserting a completion that carries a `range` throws when the popup was opened with a prepared list of matches:

```js
var editor = ace.edit(el, {enableBasicAutocompletion: true, value: "abcdefGHI"});
editor.moveCursorTo(0, 3);
editor.execCommand("startAutocomplete", {
    matches: [{value: "xyz", range: new Range(0, 0, 0, 6)}]
});
// press Enter
```

```
TypeError: Cannot read properties of undefined (reading 'prefix')
    at CompletionProvider.insertMatch (src/autocomplete.js:889)
```

The `options.matches` branch of `updateCompletions` builds the `CompletionProvider` without an initial position, and `insertMatch` reads `this.initialPosition.prefix` when converting a completion's `range` into the span to replace. The completion never makes it into the document.

`range` is part of the completion API and is what language server integrations use to honour a `textEdit`, so this path is reachable for anyone feeding Ace prepared matches.

## Change

Give the provider the position the popup was opened at.

The position is taken from the cursor rather than from the start of the selection. Ranges are applied as offsets around that reference point, and the regular completion path uses the cursor, so anchoring on the start of a non-empty selection would widen the replacement by the length of the selection. With the fix both paths agree:

| | before | after |
| --- | --- | --- |
| matches path, collapsed cursor | throws | replaces the range |
| matches path, non-empty selection | throws | replaces the range |
| regular path, collapsed cursor | replaces the range | unchanged |
| regular path, non-empty selection | replaces the range | unchanged |

The range handling is also guarded on the initial position, since `CompletionProvider` is exported and can be constructed directly.

Out of scope, unchanged by this PR: ranges spanning more than one row are still ignored by the surrounding condition, on this path as on any other.

## Test

`test: replacement range of matches passed to execCommand is applied` covers a range that extends on both sides of the cursor, and a non-empty selection that must not widen the replacement. Without the change the first case throws; anchoring on the selection start instead of the cursor fails the second with `'xyz' == 'xyzGHI'`.


[Open kitchen-sink @ a3e40f4ae27a7f0d62c253a4a0be8a2430a12be1](https://raw.githack.com/boogie/ace/a3e40f4ae27a7f0d62c253a4a0be8a2430a12be1/kitchen-sink.html)