### PR TITLE
fix(autocomplete): compare whole completions when removing duplicates

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -1061,12 +1061,13 @@ class FilteredList {
                 || (a.caption || a.value).localeCompare(b.caption || b.value);
         });
 
-        // make unique
-        var prev = null;
+        // make unique: completions are the same only when they read the same in the popup
+        // and insert the same text, and duplicates need not be next to each other
+        var seen = new Set();
         matches = matches.filter(function(item){
-            var caption = item.snippet || item.caption || item.value;
-            if (caption === prev) return false;
-            prev = caption;
+            var key = (item.caption || item.value || item.snippet) + "\0" + (item.snippet || item.value);
+            if (seen.has(key)) return false;
+            seen.add(key);
             return true;
         });
 

--- a/src/autocomplete_test.js
+++ b/src/autocomplete_test.js
@@ -925,6 +925,49 @@ module.exports = {
         assert.equal(completer.popup.isOpen, true);
         assert.equal(completer.popup.data.length, 1);
     },
+    "test: duplicate completions are removed regardless of their position": function() {
+        editor = initEditor("");
+
+        editor.completers = [
+            {
+                getCompletions: function (editor, session, pos, prefix, callback) {
+                    var completions = [
+                        {
+                            value: "foo",
+                            meta: "higher",
+                            score: 5
+                        }, {
+                            value: "bar",
+                            score: 3
+                        }, {
+                            value: "foo",
+                            meta: "lower",
+                            score: 1
+                        }, {
+                            caption: "snippet a",
+                            snippet: "shared body"
+                        }, {
+                            caption: "snippet b",
+                            snippet: "shared body"
+                        }
+                    ];
+                    callback(null, completions);
+                }
+            }
+        ];
+
+        editor.execCommand('startAutocomplete');
+        var data = editor.completer.popup.data;
+
+        // sorting by score keeps the two identical completions apart, while the two snippets
+        // read differently in the popup and are therefore not duplicates of each other
+        assert.jsonEquals(data.map(function(item) {
+            return item.caption || item.value;
+        }), ["foo", "bar", "snippet a", "snippet b"]);
+
+        // of a set of duplicates the first one after sorting survives, which is the highest scored
+        assert.equal(data[0].meta, "higher");
+    },
 
     "test: should add inline preview content to aria-describedby": function() {
         editor = initEditor("fun");


### PR DESCRIPTION
## Problem

`FilteredList.setFilter` removes duplicates by comparing each completion with the one immediately before it. That is only correct while equal completions stay adjacent, and they do not: the list is sorted by score first, so a duplicate scoring differently from its twin ends up separated by another completion and both reach the popup.

Two completers offering the same word with different scores is enough:

```js
[{value: "foo", score: 5}, {value: "bar", score: 3}, {value: "foo", score: 1}]
// popup shows: foo, bar, foo
```

The comparison is too coarse in the other direction as well. The key is `snippet || caption || value`, so snippets are compared by their body alone, and two snippets expanding to the same text collapse into one however differently they are captioned. Ace's own html mode ships fourteen `doc` snippets that expand to only eight distinct bodies — three of them are dropped from the popup today, and the survivor of each pair is whichever sorts first alphabetically.

## Change

Compare what a completion reads as in the popup together with what it inserts, and track every completion kept rather than only the previous one.

| | before | after |
| --- | --- | --- |
| same value, separated by a different score | both shown | merged |
| same value, adjacent | merged | merged |
| distinct captions, same snippet body | merged | both shown |
| html mode, `doc` prefix | 11 of 14 shown | 14 of 14 shown |

Completions that look the same in the popup and insert the same text are still merged, which is what keeps the keyword and text completers from offering the same word twice. Of a set of duplicates the first one after sorting survives, which is the highest scored — the same one that survived before.

The `Set` replaces a single variable in a function that already sorts the same array immediately above, so the added cost is not measurable against what `setFilter` does per keystroke.

## Test

`test: duplicate completions are removed regardless of their position` covers both directions at once, and asserts the surviving duplicate is the higher scored one. Against the current code it fails with:

```
'["foo","bar","foo","snippet a"]' == '["foo","bar","snippet a","snippet b"]'
```

— `foo` twice, and `snippet b` missing.


[Open kitchen-sink @ 2a773af408f8dfa2c8f61df011b845662b2c4e02](https://raw.githack.com/boogie/ace/2a773af408f8dfa2c8f61df011b845662b2c4e02/kitchen-sink.html)