### PR TITLE
fix: support a leading lookbehind in rules with token arrays

### DIFF
--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -203,6 +203,36 @@ class Tokenizer {
             if (lastCapture.end != null && /^\)*$/.test(src.substr(lastCapture.end)))
                 src = src.substring(0, lastCapture.start) + src.substr(lastCapture.end);
         }
+
+        // The splitter only sees the matched text, so a lookbehind at the start
+        // has no preceding text to check. It was already checked by the full
+        // regexp, so remove it, like the trailing lookahead above.
+        var leadingLookbehind;
+        while ((leadingLookbehind = /^(?:\((?:\?:)?)*\(\?<[=!]/.exec(src))) {
+            var start = leadingLookbehind[0].length - 4;
+            var end = -1;
+            var depth = 0;
+            var inClass = false;
+            var re = /\\.|[\[\]()]/g;
+            re.lastIndex = start;
+            var m;
+            while ((m = re.exec(src))) {
+                var ch = m[0];
+                if (ch.length > 1) continue;
+                if (inClass) {
+                    inClass = ch != "]";
+                } else if (ch == "[") {
+                    inClass = true;
+                } else if (ch == "(") {
+                    depth++;
+                } else if (ch == ")" && --depth == 0) {
+                    end = m.index + 1;
+                    break;
+                }
+            }
+            if (end == -1) break;
+            src = src.substring(0, start) + src.substr(end);
+        }
         
         // this is needed for regexps that can match in multiple ways
         if (src.charAt(0) != "^") src = "^" + src;

--- a/src/tokenizer_test.js
+++ b/src/tokenizer_test.js
@@ -20,6 +20,71 @@ module.exports = {
         assert.equal(re.source, "^[(?=)](\\?=t)$");
     },
 
+    "test: createSplitterRegexp removes leading lookbehind" : function() {
+        var t = new Tokenizer({});
+        var re = t.createSplitterRegexp("(?<=\\s)(a)(b)");
+        assert.equal(re.source, "^(a)(b)$");
+        var re = t.createSplitterRegexp("((?<=\\s)a)(b)");
+        assert.equal(re.source, "^(a)(b)$");
+        var re = t.createSplitterRegexp("(?<![x)(])(a)(b)");
+        assert.equal(re.source, "^(a)(b)$");
+        var re = t.createSplitterRegexp("(?:(?<=(x|\\)))a)(b)");
+        assert.equal(re.source, "^(?:a)(b)$");
+        var re = t.createSplitterRegexp("(?<=\\s)(?<!x)(a)(b)(?=c)");
+        assert.equal(re.source, "^(a)(b)$");
+        // a lookbehind after the start has context inside the match
+        var re = t.createSplitterRegexp("(a)(?<=a)(b)");
+        assert.equal(re.source, "^(a)(?<=a)(b)$");
+        // character classes and named groups are not lookbehinds
+        var re = t.createSplitterRegexp("[(?<=)](a)");
+        assert.equal(re.source, "^[(?<=)](a)$");
+        var re = t.createSplitterRegexp("(?<name>a)(b)");
+        assert.equal(re.source, "^(?<name>a)(b)$");
+    },
+
+    "test: token array with a leading lookbehind" : function() {
+        var t = new Tokenizer({
+            start: [{
+                token: ["option", "lbrk", "content", "rbrk"],
+                regex: "(?<=\\s)(\\:[a-zA-Z][a-zA-Z0-9_-]+)([<({]+)([^>)}]+)([>)}]+)"
+            }, {
+                defaultToken: "text"
+            }]
+        });
+        var line = "=document vvv :one-option<first> :second-option<<<<<second thing>>>>>";
+        var tokens = t.getLineTokens(line, "start").tokens;
+        assert.deepEqual(tokens, [
+            {type: "text", value: "=document vvv "},
+            {type: "option", value: ":one-option"},
+            {type: "lbrk", value: "<"},
+            {type: "content", value: "first"},
+            {type: "rbrk", value: ">"},
+            {type: "text", value: " "},
+            {type: "option", value: ":second-option"},
+            {type: "lbrk", value: "<<<<<"},
+            {type: "content", value: "second thing"},
+            {type: "rbrk", value: ">>>>>"}
+        ]);
+
+        // a token function uses the same splitter
+        var t = new Tokenizer({
+            start: [{
+                token: function(option, value) {
+                    return ["option", "value"];
+                },
+                regex: "(?<=\\s)(\\:\\w+)(=\\w+)"
+            }, {
+                defaultToken: "text"
+            }]
+        });
+        var tokens = t.getLineTokens("x :key=value", "start").tokens;
+        assert.deepEqual(tokens, [
+            {type: "text", value: "x "},
+            {type: "option", value: ":key"},
+            {type: "value", value: "=value"}
+        ]);
+    },
+
     "test: removeCapturingGroups" : function() {
         var t = new Tokenizer({});
         var re = t.removeCapturingGroups("(ax(by))[()]");


### PR DESCRIPTION
*Issue #, if available:* Fixes #6001

*Description of changes:*

When a rule has more than one capturing group, the tokenizer splits the matched text with a second regexp built by `createSplitterRegexp`. That regexp runs on the matched text alone. A lookbehind at the start of the rule regexp has no text before it to check, so the split failed:

- With a token array, `$arrayTokens` got `null` and returned the whole match as a single `text` token. This is the behavior in #6001.
- With a token function, `$applyToken` threw `Cannot read properties of null (reading 'slice')`.

The full rule regexp has already checked the lookbehind against the line, so the splitter can drop it. `createSplitterRegexp` already does the same for a trailing lookahead. The new code removes `(?<=...)` and `(?<!...)` groups when nothing but `(` or `(?:` comes before them. That covers both forms from the issue, with the lookbehind inside or outside the first group. Escapes, character classes, and nested groups inside the lookbehind are skipped when finding its closing paren. A lookbehind later in the regexp is kept, because the text it checks is part of the match. Named groups such as `(?<name>...)` are left alone.

Tests in `src/tokenizer_test.js`:

- `createSplitterRegexp removes leading lookbehind` covers regexp sources for the cases above, plus a combined leading lookbehind and trailing lookahead.
- `token array with a leading lookbehind` uses the rule regexp and the sample line from #6001, and a token function with a leading lookbehind.

## Verification

| | `npx mocha src/tokenizer_test.js` | `npm test` |
|---|---|---|
| Before the `src/tokenizer.js` change | 3 passing, 2 failing (the new tests) | 1485 passing, 3 pending, 2 failing |
| After | 5 passing | 1487 passing, 3 pending, 2 failing |

The 2 failures in `npm test` are the same with and without this change: `test: multiselect` in `mouse_handler_test.js` and ``test vim_<C-c>copy`` in `vim_test.js`. I ran on macOS with Node, and they look environment related.

`npx eslint src/tokenizer.js src/tokenizer_test.js` and `npm run typecheck` pass. I did not test in the mode creator page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Open kitchen-sink @ 3c1176684909a26f2a48cd0d00a4412a48148845](https://raw.githack.com/lbesecker195/ace/3c1176684909a26f2a48cd0d00a4412a48148845/kitchen-sink.html)